### PR TITLE
Add quiet flag to post build file copy events

### DIFF
--- a/GameServer/GameServer.csproj
+++ b/GameServer/GameServer.csproj
@@ -160,11 +160,11 @@
   <PropertyGroup>
     <PostBuildEvent>rmdir /s /q "$(TargetDir)Content\"
 rmdir /s /q "$(TargetDir)Settings\"
-xcopy /s /y "$(ProjectDir)Content" "$(TargetDir)Content\*"
-xcopy /s /y "$(ProjectDir)Settings" "$(TargetDir)Settings\*"
-xcopy /s /y "$(ProjectDir)LuaLib" "$(TargetDir)LuaLib\*"
-xcopy /s /y "$(SolutionDir)lib" "$(TargetDir)*"
-xcopy /s /y "$(SolutionDir)packages\NLua.1.3.2.1\lib\native\*.*" "$(TargetDir)*"</PostBuildEvent>
+xcopy /s /y /q "$(ProjectDir)Content" "$(TargetDir)Content\*"
+xcopy /s /y /q "$(ProjectDir)Settings" "$(TargetDir)Settings\*"
+xcopy /s /y /q "$(ProjectDir)LuaLib" "$(TargetDir)LuaLib\*"
+xcopy /s /y /q "$(SolutionDir)lib" "$(TargetDir)*"
+xcopy /s /y /q "$(SolutionDir)packages\NLua.1.3.2.1\lib\native\*.*" "$(TargetDir)*"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
This is done to avoid needless 7000 line console spam on Appveyor