### PR TITLE
Cheats can now be toggled from GameInfo.json

### DIFF
--- a/GameServer/Bindings.cs
+++ b/GameServer/Bindings.cs
@@ -23,7 +23,7 @@ namespace LeagueSandbox.GameServer
             Bind<Game>().To<Game>().InSingletonScope();
 
             Bind<ItemManager>().To<ItemManager>().InSingletonScope();
-            Bind<ChatboxManager>().To<ChatboxManager>().InSingletonScope();
+            Bind<ChatCommandManager>().To<ChatCommandManager>().InSingletonScope();
             Bind<PlayerManager>().To<PlayerManager>().InSingletonScope();
             Bind<NetworkIdManager>().To<NetworkIdManager>().InSingletonScope();
 

--- a/GameServer/GameServer.csproj
+++ b/GameServer/GameServer.csproj
@@ -77,7 +77,7 @@
     <Compile Include="Extensions.cs" />
     <Compile Include="Logic\API\ApiFunctionManager.cs" />
     <Compile Include="Logic\Blowfish.cs" />
-    <Compile Include="Logic\Chatbox\ChatboxManager.cs" />
+    <Compile Include="Logic\Chatbox\ChatCommandManager.cs" />
     <Compile Include="Logic\Chatbox\ChatCommand.cs" />
     <Compile Include="Logic\Chatbox\Commands\KillCommand.cs" />
     <Compile Include="Logic\Chatbox\Commands\ChangeTeamCommand.cs" />

--- a/GameServer/Logic/Chatbox/ChatCommand.cs
+++ b/GameServer/Logic/Chatbox/ChatCommand.cs
@@ -4,14 +4,14 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox
 {
     public abstract class ChatCommand
     {
-        internal ChatboxManager _owner;
+        internal ChatCommandManager _owner;
 
         public string Command { get; set; }
         public string Syntax { get; set; }
         public bool IsHidden { get; set; }
         public bool IsDisabled { get; set; }
 
-        public ChatCommand(string command, string syntax, ChatboxManager owner)
+        public ChatCommand(string command, string syntax, ChatCommandManager owner)
         {
             Command = command;
             Syntax = syntax;
@@ -22,7 +22,7 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox
 
         public void ShowSyntax()
         {
-            _owner.SendDebugMsgFormatted(ChatboxManager.DebugMsgType.SYNTAX, _owner.CommandStarterCharacter + Syntax);
+            _owner.SendDebugMsgFormatted(ChatCommandManager.DebugMsgType.SYNTAX, _owner.CommandStarterCharacter + Syntax);
         }
     }
 }

--- a/GameServer/Logic/Chatbox/ChatCommandManager.cs
+++ b/GameServer/Logic/Chatbox/ChatCommandManager.cs
@@ -8,11 +8,11 @@ using System.Threading.Tasks;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox
 {
-    public class ChatboxManager
+    public class ChatCommandManager
     {
-        public string CommandStarterCharacter= ".";
+        public string CommandStarterCharacter = ".";
 
-        private SortedDictionary<string, ChatCommand> _chatCommandsDictionary = new SortedDictionary<string, ChatCommand>()
+        private SortedDictionary<string, ChatCommand> _chatCommandsDictionary = new SortedDictionary<string, ChatCommand>
         {
             /*
             {".gold",  new GoldCommand(".gold", ".gold goldAmount")},
@@ -34,12 +34,19 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox
             {".xp",  new XpCommand(".xp", ".xp xp")}*/
         };
 
-        public enum DebugMsgType { ERROR, INFO, SYNTAX, SYNTAXERROR, NORMAL };
+        public enum DebugMsgType
+        {
+            ERROR,
+            INFO,
+            SYNTAX,
+            SYNTAXERROR,
+            NORMAL
+        }
 
         // TODO: Refactor this method or maybe the packet notifier?
         public void SendDebugMsgFormatted(DebugMsgType type, string message = "")
         {
-            Game _game = Program.ResolveDependency<Game>();
+            var _game = Program.ResolveDependency<Game>();
             var formattedText = new StringBuilder();
             int fontSize = 20; // Big fonts seem to make the chatbox buggy
                                // This may need to be removed.
@@ -71,17 +78,26 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox
             }
         }
 
-        public ChatboxManager()
+        public ChatCommandManager()
         {
+            AddCommand(new HelpCommand("help", "", this));
+        }
+
+        public void LoadCommands()
+        {
+            var _game = Program.ResolveDependency<Game>();
+            if (!_game.Config.ChatCheatsEnabled)
+            {
+                return;
+            }
+
             AddCommand(new AdCommand("ad", "ad bonusAd", this));
             AddCommand(new ApCommand("ap", "ap bonusAp", this));
-            AddCommand(new ChCommand("ch", "ch championName", this));
             AddCommand(new ChangeTeamCommand("changeteam", "changeteam teamNumber", this));
+            AddCommand(new ChCommand("ch", "ch championName", this));
             AddCommand(new CoordsCommand("coords", "", this));
-            AddCommand(new HelpCommand("help", "", this));
             AddCommand(new GoldCommand("gold", "gold goldAmount", this));
             AddCommand(new HealthCommand("health", "health maxHealth", this));
-            AddCommand(new HelpCommand("help", "", this));
             AddCommand(new InhibCommand("inhib", "", this));
             AddCommand(new JunglespawnCommand("junglespawn", "", this));
             AddCommand(new KillCommand("kill", "kill minions", this));
@@ -108,11 +124,9 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox
             {
                 return false;
             }
-            else
-            {
-                _chatCommandsDictionary.Add(command.Command, command);
-                return true;
-            }
+
+            _chatCommandsDictionary.Add(command.Command, command);
+            return true;
         }
 
         public bool RemoveCommand(ChatCommand command)
@@ -122,10 +136,8 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox
                 _chatCommandsDictionary.Remove(command.Command);
                 return true;
             }
-            else
-            {
-                return false;
-            }
+
+            return false;
         }
 
         public bool RemoveCommand(string commandString)
@@ -135,10 +147,8 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox
                 _chatCommandsDictionary.Remove(commandString);
                 return true;
             }
-            else
-            {
-                return false;
-            }
+
+            return false;
         }
 
         public List<ChatCommand> GetCommands()
@@ -157,10 +167,8 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox
             {
                 return _chatCommandsDictionary[commandString];
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
     }
 }

--- a/GameServer/Logic/Chatbox/Commands/AdCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/AdCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class AdCommand : ChatCommand
     {
-        public AdCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public AdCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/ApCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/ApCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class ApCommand : ChatCommand
     {
-        public ApCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public ApCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/ChCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/ChCommand.cs
@@ -2,14 +2,14 @@
 using LeagueSandbox.GameServer.Core.Logic;
 using LeagueSandbox.GameServer.Logic.GameObjects;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class ChCommand : ChatCommand
     {
 
-        public ChCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public ChCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/ChangeTeamCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/ChangeTeamCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class ChangeTeamCommand : ChatCommand
     {
-        public ChangeTeamCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public ChangeTeamCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/CoordsCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/CoordsCommand.cs
@@ -1,13 +1,13 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Core.Logic;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class CoordsCommand : ChatCommand
     {
-        public CoordsCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public CoordsCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/GoldCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/GoldCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class GoldCommand : ChatCommand
     {
-        public GoldCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public GoldCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/HealthCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/HealthCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class HealthCommand : ChatCommand
     {
-        public HealthCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public HealthCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/HelpCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/HelpCommand.cs
@@ -1,29 +1,38 @@
 ﻿using ENet;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using LeagueSandbox.GameServer.Core.Logic;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     public class HelpCommand : ChatCommand
     {
-        public HelpCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public HelpCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {
-            ChatboxManager _chatboxManager = Program.ResolveDependency<ChatboxManager>();
+            var _game = Program.ResolveDependency<Game>();
+            if (!_game.Config.ChatCheatsEnabled)
+            {
+                _owner.SendDebugMsgFormatted(DebugMsgType.INFO, "Chat commands are disabled in this game.");
+                return;
+            }
 
-            string commands = "";
-            int count = 0;
+            var _chatboxManager = Program.ResolveDependency<ChatCommandManager>();
+
+            var commands = "";
+            var count = 0;
             foreach (var command in _owner.GetCommandsStrings())
             {
-                count += 1;
+                count++;
                 commands = commands
                            + "<font color =\"#E175FF\"><b>"
                            + _chatboxManager.CommandStarterCharacter + command
                            + "</b><font color =\"#FFB145\">, ";
             }
+
             _owner.SendDebugMsgFormatted(DebugMsgType.INFO, "List of available commands: ");
             _owner.SendDebugMsgFormatted(DebugMsgType.INFO, commands);
-            _owner.SendDebugMsgFormatted(DebugMsgType.INFO, "There are " + count.ToString() + " commands");
+            _owner.SendDebugMsgFormatted(DebugMsgType.INFO, "There are " + count + " commands");
 
             _owner.AddCommand(new NewCommand("newcommand", "", _owner));
         }

--- a/GameServer/Logic/Chatbox/Commands/InhibCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/InhibCommand.cs
@@ -8,7 +8,7 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class InhibCommand : ChatCommand
     {
-        public InhibCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public InhibCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/JunglespawnCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/JunglespawnCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Core.Logic;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class JunglespawnCommand : ChatCommand
     {
-        public JunglespawnCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public JunglespawnCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/KillCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/KillCommand.cs
@@ -2,13 +2,13 @@
 using LeagueSandbox.GameServer.Core.Logic;
 using LeagueSandbox.GameServer.Logic.GameObjects;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class KillCommand : ChatCommand
     {
-        public KillCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public KillCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/LevelCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/LevelCommand.cs
@@ -1,13 +1,13 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Core.Logic;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class LevelCommand : ChatCommand
     {
-        public LevelCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public LevelCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/ManaCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/ManaCommand.cs
@@ -1,13 +1,13 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Core.Logic;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class ManaCommand : ChatCommand
     {
-        public ManaCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public ManaCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/MobsCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/MobsCommand.cs
@@ -6,13 +6,13 @@ using LeagueSandbox.GameServer.Logic.GameObjects;
 using LeagueSandbox.GameServer.Logic.Packets;
 using LeagueSandbox.GameServer.Logic.Players;
 using System.Linq;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class MobsCommand : ChatCommand
     {
-        public MobsCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public MobsCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/ModelCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/ModelCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class ModelCommand : ChatCommand
     {
-        public ModelCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public ModelCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/NewCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/NewCommand.cs
@@ -1,11 +1,11 @@
 ﻿using ENet;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class NewCommand : ChatCommand
     {
-        public NewCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public NewCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/PacketCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/PacketCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using ENet;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 using LeagueSandbox.GameServer.Core.Logic.PacketHandlers;
 using LeagueSandbox.GameServer.Core.Logic;
 using LeagueSandbox.GameServer.Logic.Players;
@@ -9,7 +9,7 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class PacketCommand : ChatCommand
     {
-        public PacketCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public PacketCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/RainbowCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/RainbowCommand.cs
@@ -12,10 +12,10 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class RainbowCommand : ChatCommand
     {
-        public RainbowCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public RainbowCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         private static Champion me;
-        private static ChatboxManager owner;
+        private static ChatCommandManager owner;
         private static bool run = false;
         private static float a = 0.5f;
         private static float speed = 0.25f;

--- a/GameServer/Logic/Chatbox/Commands/ReloadLuaCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/ReloadLuaCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     public class ReloadLuaCommand : ChatCommand
     {
-        public ReloadLuaCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public ReloadLuaCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/SetCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/SetCommand.cs
@@ -1,11 +1,11 @@
 ﻿using ENet;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class SetCommand : ChatCommand
     {
-        public SetCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public SetCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/SizeCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/SizeCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class SizeCommand : ChatCommand
     {
-        public SizeCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public SizeCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/SkillpointsCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/SkillpointsCommand.cs
@@ -8,7 +8,7 @@ namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class SkillpointsCommand : ChatCommand
     {
-        public SkillpointsCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public SkillpointsCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/SpawnCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/SpawnCommand.cs
@@ -6,13 +6,13 @@ using LeagueSandbox.GameServer.Logic.Players;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class SpawnCommand : ChatCommand
     {
-        public SpawnCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public SpawnCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/SpawnStateCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/SpawnStateCommand.cs
@@ -1,16 +1,16 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Core.Logic;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class SpawnStateCommand : ChatCommand
     {
-        public SpawnStateCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public SpawnStateCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {
-            Game _game = Program.ResolveDependency<Game>();
+            var _game = Program.ResolveDependency<Game>();
 
             var split = arguments.ToLower().Split(' ');
 

--- a/GameServer/Logic/Chatbox/Commands/SpeedCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/SpeedCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class SpeedCommand : ChatCommand
     {
-        public SpeedCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public SpeedCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/TpCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/TpCommand.cs
@@ -1,13 +1,13 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Core.Logic;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class TpCommand : ChatCommand
     {
-        public TpCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public TpCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Chatbox/Commands/XpCommand.cs
+++ b/GameServer/Logic/Chatbox/Commands/XpCommand.cs
@@ -1,12 +1,12 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Players;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 
 namespace LeagueSandbox.GameServer.Logic.Chatbox.Commands
 {
     class XpCommand : ChatCommand
     {
-        public XpCommand(string command, string syntax, ChatboxManager owner) : base(command, syntax, owner) { }
+        public XpCommand(string command, string syntax, ChatCommandManager owner) : base(command, syntax, owner) { }
 
         public override void Execute(Peer peer, bool hasReceivedArguments, string arguments = "")
         {

--- a/GameServer/Logic/Config.cs
+++ b/GameServer/Logic/Config.cs
@@ -14,8 +14,10 @@ namespace LeagueSandbox.GameServer.Logic
         public ContentManager ContentManager { get; private set; }
         public const string VERSION = "Version 4.20.0.315 [PUBLIC]";
 
-        public bool CooldownsDisabled { get; protected set; }
-        public bool ManaCostsDisabled { get; protected set; }
+        public bool CooldownsEnabled { get; private set; }
+        public bool ManaCostsEnabled { get; private set; }
+        public bool ChatCheatsEnabled { get; private set; }
+        public bool MinionSpawnsEnabled { get; private set; }
 
         public Config(string path)
         {
@@ -37,10 +39,16 @@ namespace LeagueSandbox.GameServer.Logic
                 Players.Add($"player{playerNum}", playerConfig);
             }
 
-            //Read cost/cd info
-            var spellInfo = data.SelectToken("spellInfo");
-            CooldownsDisabled = (bool)spellInfo.SelectToken("NO_COOLDOWN");
-            ManaCostsDisabled = (bool)spellInfo.SelectToken("NO_MANACOST");
+            // Read cost/cd info
+            var gameInfo = data.SelectToken("gameInfo");
+            CooldownsEnabled = (bool)gameInfo.SelectToken("COOLDOWNS_ENABLED");
+            ManaCostsEnabled = (bool)gameInfo.SelectToken("MANACOSTS_ENABLED");
+
+            // Read if chat commands are enabled
+            ChatCheatsEnabled = (bool)gameInfo.SelectToken("CHEATS_ENABLED");
+
+            // Read if minion spawns are enabled
+            MinionSpawnsEnabled = (bool)gameInfo.SelectToken("MINION_SPAWNS_ENABLED");
 
             // Read the game configuration
             var game = data.SelectToken("game");

--- a/GameServer/Logic/Game.cs
+++ b/GameServer/Logic/Game.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using LeagueSandbox.GameServer.Logic.API;
 using LeagueSandbox.GameServer.Logic.Content;
 using LeagueSandbox.GameServer.Logic.Chatbox;
+using LeagueSandbox.GameServer.Logic.Chatbox.Commands;
 using LeagueSandbox.GameServer.Logic.Players;
 
 namespace LeagueSandbox.GameServer.Core.Logic
@@ -36,19 +37,19 @@ namespace LeagueSandbox.GameServer.Core.Logic
         // Object managers
         private ItemManager _itemManager;
         // Other managers
-        private ChatboxManager _chatboxManager;
+        private ChatCommandManager _chatCommandManager;
         private PlayerManager _playerManager;
         private NetworkIdManager _networkIdManager;
 
         public Game(
             ItemManager itemManager,
-            ChatboxManager chatboxManager,
+            ChatCommandManager chatCommandManager,
             NetworkIdManager networkIdManager,
             PlayerManager playerManager,
             Logger logger
         ) {
             _itemManager = itemManager;
-            _chatboxManager = chatboxManager;
+            _chatCommandManager = chatCommandManager;
             _networkIdManager = networkIdManager;
             _playerManager = playerManager;
             _logger = logger;
@@ -66,6 +67,8 @@ namespace LeagueSandbox.GameServer.Core.Logic
             }
 
             Config = new Config(configPath);
+
+            _chatCommandManager.LoadCommands();
 
             _server = new Host();
             _server.Create(address, 32, 32, 0, 0);
@@ -108,6 +111,7 @@ namespace LeagueSandbox.GameServer.Core.Logic
             if (!dic.ContainsKey(mapName))
             {
                 Map = new SummonersRift(this);
+                return;
             }
 
             Map = (Map)Activator.CreateInstance(dic[mapName], this);

--- a/GameServer/Logic/GameObjects/Projectile.cs
+++ b/GameServer/Logic/GameObjects/Projectile.cs
@@ -56,7 +56,7 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
         public override void onCollision(GameObject collider)
         {
             base.onCollision(collider);
-            if (Target != null && Target.IsSimpleTarget)
+            if (Target != null && Target.IsSimpleTarget && !isToRemove())
             {
                 CheckFlagsForUnit(collider as Unit);
             }

--- a/GameServer/Logic/GameObjects/Spell.cs
+++ b/GameServer/Logic/GameObjects/Spell.cs
@@ -118,8 +118,8 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             CastTime = 0.0f;
             ProjectileSpeed = 2000.0f;
             _currentCastTime = 0.0f;
-            NoCooldown = _game.Config.CooldownsDisabled;
-            NoManacost = _game.Config.ManaCostsDisabled;
+            NoCooldown = !_game.Config.CooldownsEnabled;
+            NoManacost = !_game.Config.ManaCostsEnabled;
 
             _scriptEngine = new LuaScriptEngine();
             LoadLua(_scriptEngine);

--- a/GameServer/Logic/GameObjects/Unit.cs
+++ b/GameServer/Logic/GameObjects/Unit.cs
@@ -344,10 +344,6 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             {
                 if (collider == null)
                 {
-                    if (!IsDashing)
-                    {
-                        setPosition(_game.Map.AIMesh.getClosestTerrainExit(new Vector2(X, Y)));
-                    }
                     _scriptEngine.Execute("onCollideWithTerrain()");
                 }
                 else

--- a/GameServer/Logic/Maps/Map.cs
+++ b/GameServer/Logic/Maps/Map.cs
@@ -60,19 +60,20 @@ namespace LeagueSandbox.GameServer.Logic.Maps
             _game = game;
             HasFirstBloodHappened = false;
             IsKillGoldRewardReductionActive = true;
-            _spawnEnabled = false;
+            _spawnEnabled = _game.Config.MinionSpawnsEnabled;
             _hasFountainHeal = hasFountainHeal;
             _collisionHandler = new CollisionHandler(this);
-            _fountains = new Dictionary<TeamId, Fountain>();
-            _fountains.Add(TeamId.TEAM_BLUE, new Fountain(TeamId.TEAM_BLUE, 11, 250, 1000));
-            _fountains.Add(TeamId.TEAM_PURPLE, new Fountain(TeamId.TEAM_PURPLE, 13950, 14200, 1000));
+            _fountains = new Dictionary<TeamId, Fountain>
+            {
+                { TeamId.TEAM_BLUE, new Fountain(TeamId.TEAM_BLUE, 11, 250, 1000) },
+                { TeamId.TEAM_PURPLE, new Fountain(TeamId.TEAM_PURPLE, 13950, 14200, 1000) }
+            };
             Id = id;
 
             _teamsIterator = Enum.GetValues(typeof(TeamId)).Cast<TeamId>().ToList();
 
             foreach (var team in _teamsIterator)
                 _visionUnits.Add(team, new Dictionary<uint, Unit>());
-
         }
 
         public virtual void Update(long diff)

--- a/GameServer/Logic/Maps/SummonersRift.cs
+++ b/GameServer/Logic/Maps/SummonersRift.cs
@@ -145,7 +145,7 @@ namespace LeagueSandbox.GameServer.Logic.Maps
         private Logger _logger = Program.ResolveDependency<Logger>();
         private int _cannonMinionCount;
 
-        public SummonersRift(Game game) : base(game, 15 * 1000, 30 * 1000, 90 * 1000, true, 1)
+        public SummonersRift(Game game) : base(game, 90 * 1000, 30 * 1000, 90 * 1000, true, 1)
         {
             var path = System.IO.Path.Combine(
                 Program.ExecutingDirectory,

--- a/GameServer/Logic/Packets/PacketHandlers/Handlers/HandleAutoAttackOption.cs
+++ b/GameServer/Logic/Packets/PacketHandlers/Handlers/HandleAutoAttackOption.cs
@@ -6,7 +6,7 @@ namespace LeagueSandbox.GameServer.Core.Logic.PacketHandlers.Packets
 {
     class HandleAutoAttackOption : IPacketHandler
     {
-        private ChatboxManager _chatboxManager = Program.ResolveDependency<ChatboxManager>();
+        private ChatCommandManager _chatCommandManager = Program.ResolveDependency<ChatCommandManager>();
 
         public bool HandlePacket(Peer peer, byte[] data)
         {
@@ -17,8 +17,8 @@ namespace LeagueSandbox.GameServer.Core.Logic.PacketHandlers.Packets
                 state = "Activated";
             }
 
-            _chatboxManager.SendDebugMsgFormatted(
-                GameServer.Logic.Chatbox.ChatboxManager.DebugMsgType.NORMAL,
+            _chatCommandManager.SendDebugMsgFormatted(
+                GameServer.Logic.Chatbox.ChatCommandManager.DebugMsgType.NORMAL,
                 "Auto attack: " + state
             );
             return true;

--- a/GameServer/Logic/Packets/PacketHandlers/Handlers/HandleBlueTipClicked.cs
+++ b/GameServer/Logic/Packets/PacketHandlers/Handlers/HandleBlueTipClicked.cs
@@ -8,7 +8,7 @@ namespace LeagueSandbox.GameServer.Core.Logic.PacketHandlers.Packets
     class HandleBlueTipClicked : IPacketHandler
     {
         private Game _game = Program.ResolveDependency<Game>();
-        private ChatboxManager _chatboxManager = Program.ResolveDependency<ChatboxManager>();
+        private ChatCommandManager _chatCommandManager = Program.ResolveDependency<ChatCommandManager>();
         private PlayerManager _playerManager = Program.ResolveDependency<PlayerManager>();
 
         public bool HandlePacket(Peer peer, byte[] data)
@@ -23,8 +23,8 @@ namespace LeagueSandbox.GameServer.Core.Logic.PacketHandlers.Packets
             );
             _game.PacketHandlerManager.sendPacket(peer, removeBlueTip, Channel.CHL_S2C);
 
-            _chatboxManager.SendDebugMsgFormatted(
-                ChatboxManager.DebugMsgType.NORMAL,
+            _chatCommandManager.SendDebugMsgFormatted(
+                ChatCommandManager.DebugMsgType.NORMAL,
                 string.Format("Clicked blue tip with netid: {0}", blueTipClicked.netid)
             );
             return true;

--- a/GameServer/Logic/Packets/PacketHandlers/Handlers/HandleChatBoxMessage.cs
+++ b/GameServer/Logic/Packets/PacketHandlers/Handlers/HandleChatBoxMessage.cs
@@ -1,7 +1,7 @@
 ﻿using ENet;
 using LeagueSandbox.GameServer.Logic.Packets;
 using LeagueSandbox.GameServer.Logic.Chatbox;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 using LeagueSandbox.GameServer.Logic.Players;
 
 namespace LeagueSandbox.GameServer.Core.Logic.PacketHandlers.Packets
@@ -9,7 +9,7 @@ namespace LeagueSandbox.GameServer.Core.Logic.PacketHandlers.Packets
     class HandleChatBoxMessage : IPacketHandler
     {
         private Game _game = Program.ResolveDependency<Game>();
-        private ChatboxManager _chatboxManager = Program.ResolveDependency<ChatboxManager>();
+        private ChatCommandManager _chatCommandManager = Program.ResolveDependency<ChatCommandManager>();
         private PlayerManager _playerManager = Program.ResolveDependency<PlayerManager>();
 
         public bool HandlePacket(Peer peer, byte[] data)
@@ -36,13 +36,13 @@ namespace LeagueSandbox.GameServer.Core.Logic.PacketHandlers.Packets
 
             #region Commands
             // Execute commands
-            var CommandStarterCharacter = _chatboxManager.CommandStarterCharacter;
+            var CommandStarterCharacter = _chatCommandManager.CommandStarterCharacter;
             if (message.msg.StartsWith(CommandStarterCharacter))
             {
                 message.msg = message.msg.Remove(0, 1);
                 split = message.msg.ToLower().Split(' ');
 
-                ChatCommand command = _chatboxManager.GetCommand(split[0]);
+                ChatCommand command = _chatCommandManager.GetCommand(split[0]);
                 if (command != null)
                 {
                     command.Execute(peer, true, message.msg);
@@ -50,8 +50,8 @@ namespace LeagueSandbox.GameServer.Core.Logic.PacketHandlers.Packets
                 }
                 else
                 {
-                    _chatboxManager.SendDebugMsgFormatted(DebugMsgType.ERROR, "<font color =\"#E175FF\"><b>" + _chatboxManager.CommandStarterCharacter + split[0] + "</b><font color =\"#AFBF00\"> is not a valid command.");
-                    _chatboxManager.SendDebugMsgFormatted(DebugMsgType.INFO, "Type <font color =\"#E175FF\"><b>" + _chatboxManager.CommandStarterCharacter + "help</b><font color =\"#AFBF00\"> for a list of available commands");
+                    _chatCommandManager.SendDebugMsgFormatted(DebugMsgType.ERROR, "<font color =\"#E175FF\"><b>" + _chatCommandManager.CommandStarterCharacter + split[0] + "</b><font color =\"#AFBF00\"> is not a valid command.");
+                    _chatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "Type <font color =\"#E175FF\"><b>" + _chatCommandManager.CommandStarterCharacter + "help</b><font color =\"#AFBF00\"> for a list of available commands");
                     return true;
                 }
             }

--- a/GameServer/Logic/Packets/PacketHandlers/Handlers/HandleQuestClicked.cs
+++ b/GameServer/Logic/Packets/PacketHandlers/Handlers/HandleQuestClicked.cs
@@ -6,14 +6,14 @@ namespace LeagueSandbox.GameServer.Core.Logic.PacketHandlers.Packets
 {
     class HandleQuestClicked : IPacketHandler
     {
-        private ChatboxManager _chatboxManager = Program.ResolveDependency<ChatboxManager>();
+        private ChatCommandManager _chatCommandManager = Program.ResolveDependency<ChatCommandManager>();
 
         public bool HandlePacket(Peer peer, byte[] data)
         {
             var questClicked = new QuestClicked(data);
 
-            _chatboxManager.SendDebugMsgFormatted(
-                GameServer.Logic.Chatbox.ChatboxManager.DebugMsgType.NORMAL,
+            _chatCommandManager.SendDebugMsgFormatted(
+                GameServer.Logic.Chatbox.ChatCommandManager.DebugMsgType.NORMAL,
                 string.Format("Clicked quest with netid: {0}", questClicked.netid.ToString())
             );
             return true;

--- a/GameServer/Logic/Packets/PacketNotifier.cs
+++ b/GameServer/Logic/Packets/PacketNotifier.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using LeagueSandbox.GameServer.Core.Logic;
+﻿using LeagueSandbox.GameServer.Core.Logic;
 using LeagueSandbox.GameServer.Core.Logic.PacketHandlers;
 using LeagueSandbox.GameServer.Logic.Content;
 using LeagueSandbox.GameServer.Logic.Enet;

--- a/GameServer/Settings/GameInfo.json.template
+++ b/GameServer/Settings/GameInfo.json.template
@@ -49,10 +49,10 @@
         "map": 1,
         "gameMode": "LeagueSandbox-Default"
     },
-    "spellInfo": {
-        // True = sandbox mode
-        // False = normal game
-        "NO_MANACOST": true,
-        "NO_COOLDOWN": true
+    "gameInfo": {
+        "MANACOSTS_ENABLED": false,
+        "COOLDOWNS_ENABLED": false,
+        "CHEATS_ENABLED": true,
+        "MINION_SPAWNS_ENABLED": false
     }
 }

--- a/GameServerTests/Logic/Chatbox/ChatboxManagerTests.cs
+++ b/GameServerTests/Logic/Chatbox/ChatboxManagerTests.cs
@@ -5,20 +5,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static LeagueSandbox.GameServer.Logic.Chatbox.ChatboxManager;
+using static LeagueSandbox.GameServer.Logic.Chatbox.ChatCommandManager;
 using LeagueSandbox.GameServer.Logic.Chatbox.Commands;
 using LeagueSandbox.GameServer.Core.Logic;
 using LeagueSandbox.GameServer.Logic.Content;
 
 namespace GameServerTests
 {
-    [TestClass()]
+    [TestClass]
     public class ChatboxManagerTests
     {
-        [TestMethod()]
+        [TestMethod]
         public void AddCommandTest()
         {
-            var chatboxManager = new ChatboxManager();
+            var chatboxManager = new ChatCommandManager();
 
             var command = new HelpCommand("ChatboxManagerTestsTestCommand", "", chatboxManager);
             var result = chatboxManager.AddCommand(command);
@@ -27,10 +27,10 @@ namespace GameServerTests
             Assert.AreEqual(false, result);
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void RemoveCommandTest()
         {
-            var chatboxManager = new ChatboxManager();
+            var chatboxManager = new ChatCommandManager();
 
             var command = new HelpCommand("ChatboxManagerTestsTestCommand", "", chatboxManager);
             var result = chatboxManager.AddCommand(command);


### PR DESCRIPTION
- Cheats can be toggled from GameInfo.json (default: enabled)
- Minion spawns can be toggled from GameInfo.json (default: enabled)
- Fixed a bug where that projectiles that despawn on on-hit can affect more than one unit on the same point.
- Reverted "if inside terrain, teleport to closest exit" because of the pathfinding bugs, which put you inside terrain many times and cause you to stop.