### PR TITLE
Fix #255 -- Make Appveyor run tests only once

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,11 @@ build:
   project: GameServer.sln
   verbosity: minimal
 
-after_test:
+test_script:
   - .\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\MSTest.exe" -targetargs:"/noresults /noisolation /testcontainer:"".\GameServerAppTests\bin\Debug\GameServerAppTests.dll" -filter:"+[GameServerApp]*  -[GameServerApp]GameServerApp.Properties.*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:.\GameServerApp_coverage.xml
   - .\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\MSTest.exe" -targetargs:"/noresults /noisolation /testcontainer:"".\GameServerLibTests\bin\Debug\GameServerLibTests.dll" -filter:"+[GameServerLib]*  -[GameServerLib]GameServerLib.Properties.*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:.\GameServerLib_coverage.xml
+
+after_test:
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
   - pip install codecov
   - codecov -f "GameServerApp_coverage.xml"


### PR DESCRIPTION
Currently tests are being run once by Travis' defeault config, and once when generating code coverage report
Change this so both are done on the same run

Refs #255