### PR TITLE
Fix #269 -- Fix game client connection issue

### DIFF
--- a/GameServerApp/GameServerApp.csproj
+++ b/GameServerApp/GameServerApp.csproj
@@ -74,7 +74,7 @@
     <_LibTargetDirectory>$(TargetDir)</_LibTargetDirectory>
     <_NLuaSourceDirectory>$(SolutionDir)packages\NLua.1.3.2.1\lib\native\.</_NLuaSourceDirectory>
     <_NLuaTargetDirectory>$(TargetDir)</_NLuaTargetDirectory>
-    <_ENetSharpLeagueSourceDirectory>$(SolutionDir)packages\ENetSharpLeague.1.0.2\lib\native\.</_ENetSharpLeagueSourceDirectory>
+    <_ENetSharpLeagueSourceDirectory>$(SolutionDir)packages\ENetSharpLeague.1.1.0\lib\native\.</_ENetSharpLeagueSourceDirectory>
     <_ENetSharpLeagueTargetDirectory>$(TargetDir)</_ENetSharpLeagueTargetDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' != 'Unix'">

--- a/GameServerLib/GameServerLib.csproj
+++ b/GameServerLib/GameServerLib.csproj
@@ -38,8 +38,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ENetCS, Version=1.3.1.0, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\packages\ENetSharpLeague.1.0.2\lib\net461\ENetCS.dll</HintPath>
+    <Reference Include="ENetCS, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ENetSharpLeague.1.1.0\lib\net461\ENetCS.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="KeraLua, Version=1.3.2.0, Culture=neutral, PublicKeyToken=04d04586786c6f34, processorArchitecture=MSIL">

--- a/GameServerLib/packages.config
+++ b/GameServerLib/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net461" />
-  <package id="ENetSharpLeague" version="1.0.2" targetFramework="net461" />
+  <package id="ENetSharpLeague" version="1.1.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net461" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net461" />
   <package id="NLua" version="1.3.2.1" targetFramework="net46" />

--- a/GameServerLibTests/GameServerLibTests.csproj
+++ b/GameServerLibTests/GameServerLibTests.csproj
@@ -104,7 +104,7 @@
     <_LibTargetDirectory>$(TargetDir)</_LibTargetDirectory>
     <_NLuaSourceDirectory>$(SolutionDir)packages\NLua.1.3.2.1\lib\native\.</_NLuaSourceDirectory>
     <_NLuaTargetDirectory>$(TargetDir)</_NLuaTargetDirectory>
-    <_ENetSharpLeagueSourceDirectory>$(SolutionDir)packages\ENetSharpLeague.1.0.2\lib\native\.</_ENetSharpLeagueSourceDirectory>
+    <_ENetSharpLeagueSourceDirectory>$(SolutionDir)packages\ENetSharpLeague.1.1.0\lib\native\.</_ENetSharpLeagueSourceDirectory>
     <_ENetSharpLeagueTargetDirectory>$(TargetDir)</_ENetSharpLeagueTargetDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' != 'Unix'">


### PR DESCRIPTION
The game client is incapable of forming a connection with the server
due to ENet version mismatch

Fix this by updating ENetSharpLeague version from 1.0.2 to 1.1.0

Refs #269