### PR TITLE
Spells can now be disabled now

### DIFF
--- a/GameServerLib/Logic/GameObjects/Stats.cs
+++ b/GameServerLib/Logic/GameObjects/Stats.cs
@@ -640,7 +640,7 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             if (enabled)
                 mask |= (short)(1 << id);
             else
-                mask |= (short)(~(1 << id));
+                mask &= (short)(~(1 << id));
             _spellsEnabled = mask;
             appendStat(_updatedStats, MasterMask.MM_One, FieldMask.FM1_Spells_Enabled, _spellsEnabled);
         }


### PR DESCRIPTION
Resolve #274 -- Spells can't be disabled

Spells can't be disabled because of a code porting failure
Fix this issue

Refs #274 