### PR TITLE
Resolve #278 -- Only complete UpdateStats

### DIFF
--- a/GameServerLib/Logic/GameObjects/GameObjects.cs
+++ b/GameServerLib/Logic/GameObjects/GameObjects.cs
@@ -254,7 +254,7 @@ namespace LeagueSandbox.GameServer.Logic
             _visibleByTeam[team] = visible;
             if (this is Unit)
             {
-                _game.PacketNotifier.NotifyUpdatedStats(this as Unit);
+                _game.PacketNotifier.NotifyUpdatedStats(this as Unit, false);
             }
         }
 

--- a/GameServerLib/Logic/GameObjects/Unit.cs
+++ b/GameServerLib/Logic/GameObjects/Unit.cs
@@ -471,7 +471,7 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             if (regain != 0)
             {
                 stats.CurrentHealth = Math.Min(stats.HealthPoints.Total, stats.CurrentHealth + regain * damage);
-                _game.PacketNotifier.NotifyUpdatedStats(this);
+                _game.PacketNotifier.NotifyUpdatedStats(this, false);
             }
         }
 

--- a/GameServerLib/Logic/Maps/Map.cs
+++ b/GameServerLib/Logic/Maps/Map.cs
@@ -142,7 +142,7 @@ namespace LeagueSandbox.GameServer.Logic.Maps
 
                 if (u.GetStats().GetUpdatedStats().Count > 0)
                 {
-                    _game.PacketNotifier.NotifyUpdatedStats(u);
+                    _game.PacketNotifier.NotifyUpdatedStats(u, false);
                     u.GetStats().ClearUpdatedStats();
                 }
 


### PR DESCRIPTION
"Partial" UpdateStats aren't working and thus breaks the whole GameObject/Unit Stats and sets for example the Movement to 0.