### PR TITLE
Resolve #392 -- Mac client crashing GameServer

### DIFF
--- a/GameServerLib/Logic/Packets/Packets.cs
+++ b/GameServerLib/Logic/Packets/Packets.cs
@@ -363,7 +363,10 @@ namespace LeagueSandbox.GameServer.Logic.Packets
             userId = reader.ReadInt64();
             trash = reader.ReadUInt32();
             checkId = reader.ReadUInt64();
-            trash2 = reader.ReadUInt32();
+            if (reader.BaseStream.Position != reader.BaseStream.Length)
+            {
+                trash2 = reader.ReadUInt32();
+            }
             reader.Close();
         }
 


### PR DESCRIPTION
Removed int check that the mac client doesn't send.

Refs #392