### PR TITLE
Resolve #403 -- Add Death Indicator Announcement

### DIFF
--- a/GameServerLib/Logic/GameObjects/Champion.cs
+++ b/GameServerLib/Logic/GameObjects/Champion.cs
@@ -445,6 +445,8 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             RespawnTimer = 5000 + GetStats().Level * 2500;
             _game.Map.StopTargeting(this);
 
+            _game.PacketNotifier.NotifyUnitAnnounceEvent(UnitAnnounces.Death, this, killer);
+
             var cKiller = killer as Champion;
 
             if (cKiller == null && _championHitFlagTimer > 0)

--- a/GameServerLib/Logic/GameObjects/Unit.cs
+++ b/GameServerLib/Logic/GameObjects/Unit.cs
@@ -702,6 +702,7 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
 
     public enum UnitAnnounces : byte
     {
+        Death = 0x04,
         InhibitorDestroyed = 0x1F,
         InhibitorAboutToSpawn = 0x20,
         InhibitorSpawned = 0x21,


### PR DESCRIPTION
Adds an Announcement which shows kill infos on the right and adds and
particle to the dying champion.

Refs #403