### PR TITLE
Resolve #416  -- Fix leveling up spells fast error

### DIFF
--- a/GameServerLib/Logic/GameObjects/Spell.cs
+++ b/GameServerLib/Logic/GameObjects/Spell.cs
@@ -791,9 +791,13 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
 
         public virtual void levelUp()
         {
-            if (Level <= 5)
+            try
             {
                 ++Level;
+            }
+            catch
+            {
+                _logger.LogCoreWarning("Something went wrong while trying to level up");
             }
             if (Slot < 4)
             {


### PR DESCRIPTION
I was tired of seeing this bug everytime i was testing something fast. Fix leveling up spells fast error. Nothing cant escape from a Catch

Refs #416