### PR TITLE
Resolve #516 - Fix copy commands

### DIFF
--- a/GameServer.sln
+++ b/GameServer.sln
@@ -3,13 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26020.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameServerLib", "GameServerLib\GameServerLib.csproj", "{CB004023-B938-4EC6-B036-29EE2F55CFA4}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameServerLibTests", "GameServerLibTests\GameServerLibTests.csproj", "{56E885A9-FC37-4ABB-B9CC-822DAC13CC67}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameServerApp", "GameServerApp\GameServerApp.csproj", "{9CE7FFAA-C3AE-4688-930E-3C71A0CC2F7E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameServerAppTests", "GameServerAppTests\GameServerAppTests.csproj", "{77FE4FF5-3B1C-42A5-B56F-4CAD91013410}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameServerLib", "GameServerLib\GameServerLib.csproj", "{CB004023-B938-4EC6-B036-29EE2F55CFA4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameServerLibTests", "GameServerLibTests\GameServerLibTests.csproj", "{56E885A9-FC37-4ABB-B9CC-822DAC13CC67}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeagueSandbox-Default", "GameServerApp\Content\Data\LeagueSandbox-Default\LeagueSandbox-Default.csproj", "{9C11EF83-17F6-446B-95D4-F60568A9F486}"
 EndProject

--- a/GameServerApp/GameServerApp.csproj
+++ b/GameServerApp/GameServerApp.csproj
@@ -63,11 +63,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <_ContentSourceDirectory>$(SolutionDir)GameServerApp\Content</_ContentSourceDirectory>
+    <_ContentSourceDirectory>$(SolutionDir)GameServerApp\Content\.</_ContentSourceDirectory>
     <_ContentTargetDirectory>$(TargetDir)Content\</_ContentTargetDirectory>
-    <_SettingsSourceDirectory>$(SolutionDir)GameServerApp\Settings</_SettingsSourceDirectory>
+    <_SettingsSourceDirectory>$(SolutionDir)GameServerApp\Settings\.</_SettingsSourceDirectory>
     <_SettingsTargetDirectory>$(TargetDir)Settings\</_SettingsTargetDirectory>
-    <_LibSourceDirectory>$(SolutionDir)lib</_LibSourceDirectory>
+    <_LibSourceDirectory>$(SolutionDir)lib\.</_LibSourceDirectory>
     <_LibTargetDirectory>$(TargetDir)</_LibTargetDirectory>
     <_ENetSharpLeagueSourceDirectory>$(SolutionDir)packages\ENetSharpLeague.1.2.1-beta\lib\native\.</_ENetSharpLeagueSourceDirectory>
     <_ENetSharpLeagueTargetDirectory>$(TargetDir)</_ENetSharpLeagueTargetDirectory>


### PR DESCRIPTION
Copy commands on unix were recreating source directory name in target directory.
Example:
``cp Src/Foo Dest/Foo`` would copy to ``Dest/Foo/Foo``
Refs: #516