### PR TITLE
Added ApiFunctionManager.CancelDash(Unit unit) and fixed a loading bug

### DIFF
--- a/GameServerLib/Logic/API/ApiFunctionManager.cs
+++ b/GameServerLib/Logic/API/ApiFunctionManager.cs
@@ -154,7 +154,7 @@ namespace LeagueSandbox.GameServer.Logic.API
 
         public static void CancelDash(Unit unit) {
             // Allow the user to move the champion
-            unit.IsDashing = false;
+            unit.SetDashingState(false);
 
             // Reset the default run animation
             var animList = new List<string> {"RUN", ""};

--- a/GameServerLib/Logic/API/ApiFunctionManager.cs
+++ b/GameServerLib/Logic/API/ApiFunctionManager.cs
@@ -152,6 +152,15 @@ namespace LeagueSandbox.GameServer.Logic.API
             champion.Model = model;
         }
 
+        public static void CancelDash(Unit unit) {
+            // Allow the user to move the champion
+            unit.IsDashing = false;
+
+            // Reset the default run animation
+            var animList = new List<string> {"RUN", ""};
+            _game.PacketNotifier.NotifySetAnimation(unit, animList);
+        }
+
         public static void DashToUnit(Unit unit,
                                   Target target,
                                   float dashSpeed,

--- a/GameServerLib/Logic/GameObjects/GameObject.cs
+++ b/GameServerLib/Logic/GameObjects/GameObject.cs
@@ -43,7 +43,7 @@ namespace LeagueSandbox.GameServer.Logic
         public float CollisionRadius { get; set; }
         protected Vector2 _direction;
         public float VisionRadius { get; protected set; }
-        public bool IsDashing { get; protected set; }
+        public bool IsDashing { get; internal set; }
         public override bool IsSimpleTarget { get { return false; } }
         protected float _dashSpeed;
         private Dictionary<TeamId, bool> _visibleByTeam;

--- a/GameServerLib/Logic/GameObjects/GameObject.cs
+++ b/GameServerLib/Logic/GameObjects/GameObject.cs
@@ -43,7 +43,7 @@ namespace LeagueSandbox.GameServer.Logic
         public float CollisionRadius { get; set; }
         protected Vector2 _direction;
         public float VisionRadius { get; protected set; }
-        public bool IsDashing { get; internal set; }
+        public bool IsDashing { get; protected set; }
         public override bool IsSimpleTarget { get { return false; } }
         protected float _dashSpeed;
         private Dictionary<TeamId, bool> _visibleByTeam;
@@ -277,6 +277,10 @@ namespace LeagueSandbox.GameServer.Logic
             _dashSpeed = dashSpeed;
             Target = t;
             Waypoints.Clear();
+        }
+
+        public void SetDashingState(bool state) {
+            IsDashing = state;
         }
     }
 }

--- a/GameServerLib/Logic/Scripting/CSharp/CSharpScriptEngine.cs
+++ b/GameServerLib/Logic/Scripting/CSharp/CSharpScriptEngine.cs
@@ -109,8 +109,8 @@ namespace LeagueSandbox.GameServer.Logic.Scripting.CSharp
             return default(T);
         }
 
-        public T CreateObject<T>(string scriptNamespace, string scriptClass)
-        {
+        public T CreateObject<T>(string scriptNamespace, string scriptClass) {
+            scriptClass = scriptClass.Replace(" ", "_");
             _logger.LogCoreInfo("Loading game script for: " + scriptNamespace + ", " + scriptClass);
             if (_scriptAssembly == null)
             {


### PR DESCRIPTION
Used to fix a bug where the champion can't move after flashing while dashing ([see PR #44 in default package](https://github.com/LeagueSandbox/LeagueSandbox-Default/pull/44))

Fixed loading of spells with a space in their name (use an underscore instead)