### PR TITLE
Move stuff from AttackableUnit to ObjAiBase

### DIFF
--- a/GameServerLib/Logic/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/Logic/GameObjects/AttackableUnits/AI/Champion.cs
@@ -352,11 +352,6 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             return hash;
         }
 
-        public override bool isInDistress()
-        {
-            return DistressCause != null;
-        }
-
         public short getSkillPoints()
         {
             return _skillPoints;

--- a/GameServerLib/Logic/GameObjects/AttackableUnits/AI/Minion.cs
+++ b/GameServerLib/Logic/GameObjects/AttackableUnits/AI/Minion.cs
@@ -127,11 +127,6 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             base.onCollision(collider);
         }
 
-        public override bool isInDistress()
-        {
-            return DistressCause != null;
-        }
-
         // AI tasks
         protected bool scanForTargets()
         {

--- a/GameServerLib/Logic/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/Logic/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -1,6 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using LeagueSandbox.GameServer.Logic.API;
+using LeagueSandbox.GameServer.Logic.Content;
 using LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits;
+using LeagueSandbox.GameServer.Logic.Items;
 using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
 
 namespace LeagueSandbox.GameServer.Logic.GameObjects
@@ -12,22 +17,71 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
         private object BuffsLock { get; }
         private Dictionary<string, Buff> Buffs { get; }
         
+        private List<UnitCrowdControl> crowdControlList = new List<UnitCrowdControl>();
+        protected ItemManager _itemManager = Program.ResolveDependency<ItemManager>();
+        protected CSharpScriptEngine _scriptEngine = Program.ResolveDependency<CSharpScriptEngine>();
+
+
+        /// <summary>
+        /// Unit we want to attack as soon as in range
+        /// </summary>
+        public AttackableUnit TargetUnit { get; set; }
+        public AttackableUnit AutoAttackTarget { get; set; }
+        public CharData CharData { get; protected set; }
+        public SpellData AASpellData { get; protected set; }
+        private bool _isNextAutoCrit;
+        public float AutoAttackDelay { get; set; }
+        public float AutoAttackProjectileSpeed { get; set; }
+        private float _autoAttackCurrentCooldown;
+        private float _autoAttackCurrentDelay;
+        public bool IsAttacking { protected get; set; }
+        protected internal bool _hasMadeInitialAttack;
+        private bool _nextAttackFlag;
+        private uint _autoAttackProjId;
+        public MoveOrder MoveOrder { get; set; }
+        public bool IsCastingSpell { get; set; }
+        public bool IsMelee { get; set; }
+        private Random random = new Random();
+
         public ObjAIBase(string model, Stats stats, int collisionRadius = 40,
             float x = 0, float y = 0, int visionRadius = 0, uint netId = 0) :
             base(model, stats, collisionRadius, x, y, visionRadius, netId)
         {
-            if(!string.IsNullOrEmpty(model))
+            CharData = _game.Config.ContentManager.GetCharData(Model);
+            Stats.LoadStats(CharData);
+
+            if (CharData.PathfindingCollisionRadius > 0)
+            {
+                CollisionRadius = CharData.PathfindingCollisionRadius;
+            }
+            else if (collisionRadius > 0)
+            {
+                CollisionRadius = collisionRadius;
+            }
+            else
+            {
+                CollisionRadius = 40;
+            }
+            Stats.CurrentMana = stats.ManaPoints.Total;
+            Stats.CurrentHealth = stats.HealthPoints.Total;
+            if (!string.IsNullOrEmpty(model))
             {
                 AASpellData = _game.Config.ContentManager.GetSpellData(model + "BasicAttack");
                 AutoAttackDelay = AASpellData.CastFrame / 30.0f;
                 AutoAttackProjectileSpeed = AASpellData.MissileSpeed;
+                IsMelee = CharData.IsMelee;
+            } 
+            else
+            {
+                AutoAttackDelay = 0;
+                AutoAttackProjectileSpeed = 500;
+                IsMelee = true;
             }
             
             AppliedBuffs = new Buff[256];
             BuffGameScriptControllers = new List<BuffGameScriptController>();
             BuffsLock = new object();
             Buffs = new Dictionary<string, Buff>();
-
         }
         
         public BuffGameScriptController AddBuffGameScript(string buffNamespace, string buffClass, Spell ownerSpell, float removeAfter = -1f, bool isUnique = false)
@@ -98,7 +152,22 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
                 return null;
             }
         }
-        
+
+        public void AddStatModifier(ChampionStatModifier statModifier)
+        {
+            Stats.AddModifier(statModifier);
+        }
+
+        public void UpdateStatModifier(ChampionStatModifier statModifier)
+        {
+            Stats.UpdateModifier(statModifier);
+        }
+
+        public void RemoveStatModifier(ChampionStatModifier statModifier)
+        {
+            Stats.RemoveModifier(statModifier);
+        }
+
         public void AddBuff(Buff b)
         {
             lock (BuffsLock)
@@ -140,6 +209,137 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             AppliedBuffs[slot] = null;
         }
 
+        public void ApplyCrowdControl(UnitCrowdControl cc)
+        {
+            if (cc.IsTypeOf(CrowdControlType.Stun) || cc.IsTypeOf(CrowdControlType.Root))
+            {
+                this.StopMovement();
+            }
+            crowdControlList.Add(cc);
+        }
+        public void RemoveCrowdControl(UnitCrowdControl cc)
+        {
+            crowdControlList.Remove(cc);
+        }
+        public void ClearAllCrowdControl()
+        {
+            crowdControlList.Clear();
+        }
+        public bool HasCrowdControl(CrowdControlType ccType)
+        {
+            return crowdControlList.FirstOrDefault((cc) => cc.IsTypeOf(ccType)) != null;
+        }
+
+        public void StopMovement()
+        {
+            this.SetWaypoints(new List<Vector2> { this.GetPosition(), this.GetPosition() });
+        }
+
+        public virtual void refreshWaypoints()
+        {
+            if (TargetUnit == null || (GetDistanceTo(TargetUnit) <= Stats.Range.Total && Waypoints.Count == 1))
+                return;
+
+            if (GetDistanceTo(TargetUnit) <= Stats.Range.Total - 2.0f)
+            {
+                SetWaypoints(new List<Vector2> { new Vector2(X, Y) });
+            }
+            else
+            {
+                var t = new Target(Waypoints[Waypoints.Count - 1]);
+                if (t.GetDistanceTo(TargetUnit) >= 25.0f)
+                {
+                    SetWaypoints(new List<Vector2> { new Vector2(X, Y), new Vector2(TargetUnit.X, TargetUnit.Y) });
+                }
+            }
+        }
+
+        public ClassifyUnit ClassifyTarget(AttackableUnit target)
+        {
+            var ai = target as ObjAIBase;
+            if (ai != null)
+            {
+                if (ai.TargetUnit != null && ai.TargetUnit.isInDistress()) // If an ally is in distress, target this unit. (Priority 1~5)
+                {
+                    if (target is Champion && ai.TargetUnit is Champion) // If it's a champion attacking an allied champion
+                    {
+                        return ClassifyUnit.ChampionAttackingChampion;
+                    }
+
+                    if (target is Minion && ai.TargetUnit is Champion) // If it's a minion attacking an allied champion.
+                    {
+                        return ClassifyUnit.MinionAttackingChampion;
+                    }
+
+                    if (target is Minion && ai.TargetUnit is Minion) // Minion attacking minion
+                    {
+                        return ClassifyUnit.MinionAttackingMinion;
+                    }
+
+                    if (target is BaseTurret && ai.TargetUnit is Minion) // Turret attacking minion
+                    {
+                        return ClassifyUnit.TurretAttackingMinion;
+                    }
+
+                    if (target is Champion && ai.TargetUnit is Minion) // Champion attacking minion
+                    {
+                        return ClassifyUnit.ChampionAttackingMinion;
+                    }
+                }
+            }
+            
+
+            var p = target as Placeable;
+            if (p != null)
+            {
+                return ClassifyUnit.Placeable;
+            }
+
+            var m = target as Minion;
+            if (m != null)
+            {
+                switch (m.getType())
+                {
+                    case MinionSpawnType.MINION_TYPE_MELEE:
+                        return ClassifyUnit.MeleeMinion;
+                    case MinionSpawnType.MINION_TYPE_CASTER:
+                        return ClassifyUnit.CasterMinion;
+                    case MinionSpawnType.MINION_TYPE_CANNON:
+                    case MinionSpawnType.MINION_TYPE_SUPER:
+                        return ClassifyUnit.SuperOrCannonMinion;
+                }
+            }
+
+            if (target is BaseTurret)
+            {
+                return ClassifyUnit.Turret;
+            }
+
+            if (target is Champion)
+            {
+                return ClassifyUnit.Champion;
+            }
+
+            if (target is Inhibitor && !target.IsDead)
+            {
+                return ClassifyUnit.Inhibitor;
+            }
+
+            if (target is Nexus)
+            {
+                return ClassifyUnit.Nexus;
+            }
+
+            return ClassifyUnit.Default;
+        }
+
+
+        public void SetTargetUnit(AttackableUnit target)
+        {
+            TargetUnit = target;
+            refreshWaypoints();
+        }
+
         private byte GetBuffSlot(Buff buffToLookFor = null)
         {
             for (byte i = 1; i < AppliedBuffs.Length; i++) // Find the first open slot or the slot corresponding to buff
@@ -152,10 +352,192 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             throw new Exception("No slot found with requested value"); // If no open slot or no corresponding slot
         }
 
+        /// <summary>
+        /// This is called by the AA projectile when it hits its target
+        /// </summary>
+        public virtual void AutoAttackHit(AttackableUnit target)
+        {
+            if (HasCrowdControl(CrowdControlType.Blind))
+            {
+                target.TakeDamage(this, 0, DamageType.DAMAGE_TYPE_PHYSICAL,
+                                             DamageSource.DAMAGE_SOURCE_ATTACK,
+                                             DamageText.DAMAGE_TEXT_MISS);
+                return;
+            }
+
+            var damage = Stats.AttackDamage.Total;
+            if (_isNextAutoCrit)
+            {
+                damage *= Stats.getCritDamagePct();
+            }
+
+            var onAutoAttack = _scriptEngine.GetStaticMethod<Action<AttackableUnit, AttackableUnit>>(Model, "Passive", "OnAutoAttack");
+            onAutoAttack?.Invoke(this, target);
+
+            target.TakeDamage(this, damage, DamageType.DAMAGE_TYPE_PHYSICAL,
+                DamageSource.DAMAGE_SOURCE_ATTACK,
+                _isNextAutoCrit);
+        }
+
+
+        public void UpdateAutoAttackTarget(float diff)
+        {
+            if (HasCrowdControl(CrowdControlType.Disarm) || HasCrowdControl(CrowdControlType.Stun))
+            {
+                return;
+            }
+            if (IsDead)
+            {
+                if (TargetUnit != null)
+                {
+                    SetTargetUnit(null);
+                    AutoAttackTarget = null;
+                    IsAttacking = false;
+                    _game.PacketNotifier.NotifySetTarget(this, null);
+                    _hasMadeInitialAttack = false;
+                }
+                return;
+            }
+
+            if (TargetUnit != null)
+            {
+                if (TargetUnit.IsDead || !_game.ObjectManager.TeamHasVisionOn(Team, TargetUnit))
+                {
+                    SetTargetUnit(null);
+                    IsAttacking = false;
+                    _game.PacketNotifier.NotifySetTarget(this, null);
+                    _hasMadeInitialAttack = false;
+
+                }
+                else if (IsAttacking && AutoAttackTarget != null)
+                {
+                    _autoAttackCurrentDelay += diff / 1000.0f;
+                    if (_autoAttackCurrentDelay >= AutoAttackDelay / Stats.AttackSpeedMultiplier.Total)
+                    {
+                        if (!IsMelee)
+                        {
+                            var p = new Projectile(
+                                X,
+                                Y,
+                                5,
+                                this,
+                                AutoAttackTarget,
+                                null,
+                                AutoAttackProjectileSpeed,
+                                "",
+                                0,
+                                _autoAttackProjId
+                            );
+                            _game.ObjectManager.AddObject(p);
+                            _game.PacketNotifier.NotifyShowProjectile(p);
+                        }
+                        else
+                        {
+                            AutoAttackHit(AutoAttackTarget);
+                        }
+                        _autoAttackCurrentCooldown = 1.0f / (Stats.GetTotalAttackSpeed());
+                        IsAttacking = false;
+                    }
+
+                }
+                else if (GetDistanceTo(TargetUnit) <= Stats.Range.Total)
+                {
+                    refreshWaypoints();
+                    _isNextAutoCrit = random.Next(0, 100) < Stats.CriticalChance.Total * 100;
+                    if (_autoAttackCurrentCooldown <= 0)
+                    {
+                        IsAttacking = true;
+                        _autoAttackCurrentDelay = 0;
+                        _autoAttackProjId = _networkIdManager.GetNewNetID();
+                        AutoAttackTarget = TargetUnit;
+
+                        if (!_hasMadeInitialAttack)
+                        {
+                            _hasMadeInitialAttack = true;
+                            _game.PacketNotifier.NotifyBeginAutoAttack(
+                                this,
+                                TargetUnit,
+                                _autoAttackProjId,
+                                _isNextAutoCrit
+                            );
+                        }
+                        else
+                        {
+                            _nextAttackFlag = !_nextAttackFlag; // The first auto attack frame has occurred
+                            _game.PacketNotifier.NotifyNextAutoAttack(
+                                this,
+                                TargetUnit,
+                                _autoAttackProjId,
+                                _isNextAutoCrit,
+                                _nextAttackFlag
+                                );
+                        }
+
+                        var attackType = IsMelee ? AttackType.ATTACK_TYPE_MELEE : AttackType.ATTACK_TYPE_TARGETED;
+                        _game.PacketNotifier.NotifyOnAttack(this, TargetUnit, attackType);
+                    }
+
+                }
+                else
+                {
+                    refreshWaypoints();
+                }
+
+            }
+            else if (IsAttacking)
+            {
+                if (AutoAttackTarget == null
+                    || AutoAttackTarget.IsDead
+                    || !_game.ObjectManager.TeamHasVisionOn(Team, AutoAttackTarget)
+                )
+                {
+                    IsAttacking = false;
+                    _hasMadeInitialAttack = false;
+                    AutoAttackTarget = null;
+                }
+            }
+
+            if (_autoAttackCurrentCooldown > 0)
+            {
+                _autoAttackCurrentCooldown -= diff / 1000.0f;
+            }
+        }
+
+
         public override void update(float diff)
         {
+            foreach (UnitCrowdControl cc in crowdControlList)
+            {
+                cc.Update(diff);
+            }
+            crowdControlList.RemoveAll((cc) => cc.IsDead());
+
+            var onUpdate = _scriptEngine.GetStaticMethod<Action<AttackableUnit, double>>(Model, "Passive", "OnUpdate");
+            onUpdate?.Invoke(this, diff);
             BuffGameScriptControllers.RemoveAll((b) => b.NeedsRemoved());
             base.update(diff);
+            UpdateAutoAttackTarget(diff);
+        }
+        public override void die(AttackableUnit killer)
+        {
+            var onDie = _scriptEngine.GetStaticMethod<Action<AttackableUnit, AttackableUnit>>(Model, "Passive", "OnDie");
+            onDie?.Invoke(this, killer);
+            base.die(killer);
+        }
+
+        public override void onCollision(GameObject collider)
+        {
+            base.onCollision(collider);
+            if (collider == null)
+            {
+                var onCollideWithTerrain = _scriptEngine.GetStaticMethod<Action<AttackableUnit>>(Model, "Passive", "onCollideWithTerrain");
+                onCollideWithTerrain?.Invoke(this);
+            }
+            else
+            {
+                var onCollide = _scriptEngine.GetStaticMethod<Action<AttackableUnit, AttackableUnit>>(Model, "Passive", "onCollide");
+                onCollide?.Invoke(this, collider as AttackableUnit);
+            }
         }
     }
 }

--- a/GameServerLib/Logic/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/Logic/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -2,12 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using LeagueSandbox.GameServer.Core.Logic;
 using LeagueSandbox.GameServer.Logic.API;
 using LeagueSandbox.GameServer.Logic.Content;
 using LeagueSandbox.GameServer.Logic.Items;
-using LeagueSandbox.GameServer.Logic.Players;
-using LeagueSandbox.GameServer.Logic.Scripting.CSharp;
 
 namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits
 {
@@ -15,39 +12,11 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits
     {
         internal const float DETECT_RANGE = 475.0f;
         internal const int EXP_RANGE = 1400;
-        internal const long UPDATE_TIME = 500;
 
         protected Stats Stats { get; }
-        public InventoryManager Inventory { get; protected set; }
-        protected ItemManager _itemManager = Program.ResolveDependency<ItemManager>();
-        protected PlayerManager _playerManager = Program.ResolveDependency<PlayerManager>();
-
-        private Random random = new Random();
-
-        public CharData CharData { get; protected set; }
-        public SpellData AASpellData { get; protected set; }
-        public float AutoAttackDelay { get; set; }
-        public float AutoAttackProjectileSpeed { get; set; }
-        private float _autoAttackCurrentCooldown;
-        private float _autoAttackCurrentDelay;
-        public bool IsAttacking { protected get; set; }
-        public bool IsModelUpdated { get; set; }
-        public bool IsMelee { get; set; }
-        protected internal bool _hasMadeInitialAttack;
-        private bool _nextAttackFlag;
-        public AttackableUnit DistressCause { get; protected set; }
         private float _statUpdateTimer;
-        private uint _autoAttackProjId;
-        public MoveOrder MoveOrder { get; set; }
-
-        /// <summary>
-        /// Unit we want to attack as soon as in range
-        /// </summary>
-        public AttackableUnit TargetUnit { get; set; }
-        public AttackableUnit AutoAttackTarget { get; set; }
-
+        public bool IsModelUpdated { get; set; }
         public bool IsDead { get; protected set; }
-
         private string _model;
         public string Model
         {
@@ -58,18 +27,9 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits
                 IsModelUpdated = true;
             }
         }
-
-        private bool _isNextAutoCrit;
-        protected CSharpScriptEngine _scriptEngine = Program.ResolveDependency<CSharpScriptEngine>();
         protected Logger _logger = Program.ResolveDependency<Logger>();
-
+        public InventoryManager Inventory { get; protected set; }
         public int KillDeathCounter { get; protected set; }
-
-        private float _timerUpdate;
-
-        public bool IsCastingSpell { get; set; }
-
-        private List<UnitCrowdControl> crowdControlList = new List<UnitCrowdControl>();
 
         public AttackableUnit(
             string model,
@@ -84,27 +44,8 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits
         {
             Stats = stats;
             Model = model;
-            CharData = _game.Config.ContentManager.GetCharData(Model);
-            Stats.LoadStats(CharData);
-            AutoAttackDelay = 0;
-            AutoAttackProjectileSpeed = 500;
-            IsMelee = CharData.IsMelee;
-            Stats.CurrentMana = stats.ManaPoints.Total;
-            Stats.CurrentHealth = stats.HealthPoints.Total;
+            CollisionRadius = 40;
             Stats.AttackSpeedMultiplier.BaseValue = 1.0f;
-
-            if (CharData.PathfindingCollisionRadius > 0)
-            {
-                CollisionRadius = CharData.PathfindingCollisionRadius;
-            }
-            else if (collisionRadius > 0)
-            {
-                CollisionRadius = collisionRadius;
-            }
-            else
-            {
-                CollisionRadius = 40;
-            }
         }
 
         public override void OnAdded()
@@ -124,195 +65,15 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits
             return Stats;
         }
 
-        public void ApplyCrowdControl(UnitCrowdControl cc)
-        {
-            if (cc.IsTypeOf(CrowdControlType.Stun) || cc.IsTypeOf(CrowdControlType.Root))
-            {
-                this.StopMovement();
-            }
-            crowdControlList.Add(cc);
-        }
-        public void RemoveCrowdControl(UnitCrowdControl cc)
-        {
-            crowdControlList.Remove(cc);
-        }
-        public void ClearAllCrowdControl()
-        {
-            crowdControlList.Clear();
-        }
-        public bool HasCrowdControl(CrowdControlType ccType)
-        {
-            return crowdControlList.FirstOrDefault((cc)=>cc.IsTypeOf(ccType)) != null;
-        }
-        public void AddStatModifier(ChampionStatModifier statModifier)
-        {
-            Stats.AddModifier(statModifier);
-        }
-
-        public void UpdateStatModifier(ChampionStatModifier statModifier)
-        {
-            Stats.UpdateModifier(statModifier);
-        }
-
-        public void RemoveStatModifier(ChampionStatModifier statModifier)
-        {
-            Stats.RemoveModifier(statModifier);
-        }
-        
-        public void StopMovement()
-        {
-            this.SetWaypoints(new List<Vector2> { this.GetPosition(), this.GetPosition() });
-        }
-
         public override void update(float diff)
         {
-            _timerUpdate += diff;
-            if (_timerUpdate >= UPDATE_TIME)
-            {
-                _timerUpdate = 0;
-            }
-
-            foreach(UnitCrowdControl cc in crowdControlList)
-            {
-                cc.Update(diff);
-            }
-            crowdControlList.RemoveAll((cc)=>cc.IsDead());
-
-            var onUpdate = _scriptEngine.GetStaticMethod<Action<AttackableUnit, double>>(Model, "Passive", "OnUpdate");
-            onUpdate?.Invoke(this, diff);
-
-            UpdateAutoAttackTarget(diff);
-
             base.update(diff);
 
             _statUpdateTimer += diff;
-            if (_statUpdateTimer >= 500)
+            while (_statUpdateTimer >= 500)
             { // update Stats (hpregen, manaregen) every 0.5 seconds
                 Stats.update(_statUpdateTimer);
-                _statUpdateTimer = 0;
-            }
-        }
-
-        public void UpdateAutoAttackTarget(float diff)
-        {
-            if (HasCrowdControl(CrowdControlType.Disarm) || HasCrowdControl(CrowdControlType.Stun))
-            {
-                return;
-            }
-            if (IsDead)
-            {
-                if (TargetUnit != null)
-                {
-                    SetTargetUnit(null);
-                    AutoAttackTarget = null;
-                    IsAttacking = false;
-                    _game.PacketNotifier.NotifySetTarget(this, null);
-                    _hasMadeInitialAttack = false;
-                }
-                return;
-            }
-
-            if (TargetUnit != null)
-            {
-                if (TargetUnit.IsDead || !_game.ObjectManager.TeamHasVisionOn(Team, TargetUnit))
-                {
-                    SetTargetUnit(null);
-                    IsAttacking = false;
-                    _game.PacketNotifier.NotifySetTarget(this, null);
-                    _hasMadeInitialAttack = false;
-
-                }
-                else if (IsAttacking && AutoAttackTarget != null)
-                {
-                    _autoAttackCurrentDelay += diff / 1000.0f;
-                    if (_autoAttackCurrentDelay >= AutoAttackDelay / Stats.AttackSpeedMultiplier.Total)
-                    {
-                        if (!IsMelee)
-                        {
-                            var p = new Projectile(
-                                X,
-                                Y,
-                                5,
-                                this,
-                                AutoAttackTarget,
-                                null,
-                                AutoAttackProjectileSpeed,
-                                "",
-                                0,
-                                _autoAttackProjId
-                            );
-                            _game.ObjectManager.AddObject(p);
-                            _game.PacketNotifier.NotifyShowProjectile(p);
-                        }
-                        else
-                        {
-                            AutoAttackHit(AutoAttackTarget);
-                        }
-                        _autoAttackCurrentCooldown = 1.0f / (Stats.GetTotalAttackSpeed());
-                        IsAttacking = false;
-                    }
-
-                }
-                else if (GetDistanceTo(TargetUnit) <= Stats.Range.Total)
-                {
-                    refreshWaypoints();
-                    _isNextAutoCrit = random.Next(0, 100) < Stats.CriticalChance.Total * 100;
-                    if (_autoAttackCurrentCooldown <= 0)
-                    {
-                        IsAttacking = true;
-                        _autoAttackCurrentDelay = 0;
-                        _autoAttackProjId = _networkIdManager.GetNewNetID();
-                        AutoAttackTarget = TargetUnit;
-
-                        if (!_hasMadeInitialAttack)
-                        {
-                            _hasMadeInitialAttack = true;
-                            _game.PacketNotifier.NotifyBeginAutoAttack(
-                                this,
-                                TargetUnit,
-                                _autoAttackProjId,
-                                _isNextAutoCrit
-                            );
-                        }
-                        else
-                        {
-                            _nextAttackFlag = !_nextAttackFlag; // The first auto attack frame has occurred
-                            _game.PacketNotifier.NotifyNextAutoAttack(
-                                this,
-                                TargetUnit,
-                                _autoAttackProjId,
-                                _isNextAutoCrit,
-                                _nextAttackFlag
-                                );
-                        }
-
-                        var attackType = IsMelee ? AttackType.ATTACK_TYPE_MELEE : AttackType.ATTACK_TYPE_TARGETED;
-                        _game.PacketNotifier.NotifyOnAttack(this, TargetUnit, attackType);
-                    }
-
-                }
-                else
-                {
-                    refreshWaypoints();
-                }
-
-            }
-            else if (IsAttacking)
-            {
-                if (AutoAttackTarget == null
-                    || AutoAttackTarget.IsDead
-                    || !_game.ObjectManager.TeamHasVisionOn(Team, AutoAttackTarget)
-                )
-                {
-                    IsAttacking = false;
-                    _hasMadeInitialAttack = false;
-                    AutoAttackTarget = null;
-                }
-            }
-
-            if (_autoAttackCurrentCooldown > 0)
-            {
-                _autoAttackCurrentCooldown -= diff / 1000.0f;
+                _statUpdateTimer -= 500;
             }
         }
 
@@ -321,56 +82,12 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits
             return Stats.MoveSpeed.Total;
         }
 
-        public override void onCollision(GameObject collider)
-        {
-            base.onCollision(collider);
-            if (collider == null)
-            {
-                var onCollideWithTerrain = _scriptEngine.GetStaticMethod<Action<AttackableUnit>>(Model, "Passive", "onCollideWithTerrain");
-                onCollideWithTerrain?.Invoke(this);
-            }
-            else
-            {
-                var onCollide = _scriptEngine.GetStaticMethod<Action<AttackableUnit, AttackableUnit>>(Model, "Passive", "onCollide");
-                onCollide?.Invoke(this, collider as AttackableUnit);
-            }
-        }
-
-        /// <summary>
-        /// This is called by the AA projectile when it hits its target
-        /// </summary>
-        public virtual void AutoAttackHit(AttackableUnit target)
-        {
-            if (HasCrowdControl(CrowdControlType.Blind)) {
-                target.TakeDamage(this, 0, DamageType.DAMAGE_TYPE_PHYSICAL,
-                                             DamageSource.DAMAGE_SOURCE_ATTACK,
-                                             DamageText.DAMAGE_TEXT_MISS);
-                return;
-            }
-
-            var damage = Stats.AttackDamage.Total;
-            if (_isNextAutoCrit)
-            {
-                damage *= Stats.getCritDamagePct();
-            }
-
-            var onAutoAttack = _scriptEngine.GetStaticMethod<Action<AttackableUnit, AttackableUnit>>(Model, "Passive", "OnAutoAttack");
-            onAutoAttack?.Invoke(this, target);
-
-            target.TakeDamage(this, damage, DamageType.DAMAGE_TYPE_PHYSICAL,
-                DamageSource.DAMAGE_SOURCE_ATTACK,
-                _isNextAutoCrit);
-        }
-        
         public virtual void die(AttackableUnit killer)
         {
             setToRemove();
             _game.ObjectManager.StopTargeting(this);
 
             _game.PacketNotifier.NotifyNpcDie(this, killer);
-
-            var onDie = _scriptEngine.GetStaticMethod<Action<AttackableUnit, AttackableUnit>>(Model, "Passive", "OnDie");
-            onDie?.Invoke(this, killer);
 
             var exp = _game.Map.MapGameScript.GetExperienceFor(this);
             var champs = _game.ObjectManager.GetChampionsInRange(this, EXP_RANGE, true);
@@ -472,27 +189,6 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits
             //Damage dealing. (based on leagueoflegends' wikia)
             damage = defense >= 0 ? (100 / (100 + defense)) * damage : (2 - (100 / (100 - defense))) * damage;
 
-            if (HasCrowdControl(CrowdControlType.Invulnerable))
-            {
-                bool attackerIsFountainTurret;
-                var checkLaneTurret = attacker as LaneTurret;
-
-                if (checkLaneTurret != null)
-                {
-                    attackerIsFountainTurret = checkLaneTurret.Type == TurretType.FountainTurret;
-                }
-                else
-                {
-                    attackerIsFountainTurret = false;
-                }
-
-                if (attackerIsFountainTurret == false)
-                {
-                    damage = 0;
-                    damageText = DamageText.DAMAGE_TEXT_INVULNERABLE;
-                }
-            }
-
             ApiEventManager.OnUnitDamageTaken.Publish(this);
 
             GetStats().CurrentHealth = Math.Max(0.0f, GetStats().CurrentHealth - damage);
@@ -524,118 +220,6 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits
             }
 
             TakeDamage(attacker, damage, type, source, text);
-        }
-
-        public void SetTargetUnit(AttackableUnit target)
-        {
-            if (target == null) // If we are unsetting the target (moving around)
-            {
-                if (TargetUnit != null) // and we had a target
-                    TargetUnit.DistressCause = null; // Unset the distress call
-                                                      // TODO: Replace this with a delay?
-
-                IsAttacking = false;
-            }
-            else
-            {
-                target.DistressCause = this; // Otherwise set the distress call
-            }
-
-            TargetUnit = target;
-            refreshWaypoints();
-        }
-
-        public virtual void refreshWaypoints()
-        {
-            if (TargetUnit == null || (GetDistanceTo(TargetUnit) <= Stats.Range.Total && Waypoints.Count == 1))
-                return;
-
-            if (GetDistanceTo(TargetUnit) <= Stats.Range.Total - 2.0f)
-            {
-                SetWaypoints(new List<Vector2> { new Vector2(X, Y) });
-            }
-            else
-            {
-                var t = new Target(Waypoints[Waypoints.Count - 1]);
-                if (t.GetDistanceTo(TargetUnit) >= 25.0f)
-                {
-                    SetWaypoints(new List<Vector2> { new Vector2(X, Y), new Vector2(TargetUnit.X, TargetUnit.Y) });
-                }
-            }
-        }
-
-        public ClassifyUnit ClassifyTarget(AttackableUnit target)
-        {
-            if (target.TargetUnit != null && target.TargetUnit.isInDistress()) // If an ally is in distress, target this unit. (Priority 1~5)
-            {
-                if (target is Champion && target.TargetUnit is Champion) // If it's a champion attacking an allied champion
-                {
-                    return ClassifyUnit.ChampionAttackingChampion;
-                }
-
-                if (target is Minion && target.TargetUnit is Champion) // If it's a minion attacking an allied champion.
-                {
-                    return ClassifyUnit.MinionAttackingChampion;
-                }
-
-                if (target is Minion && target.TargetUnit is Minion) // Minion attacking minion
-                {
-                    return ClassifyUnit.MinionAttackingMinion;
-                }
-
-                if (target is BaseTurret && target.TargetUnit is Minion) // Turret attacking minion
-                {
-                    return ClassifyUnit.TurretAttackingMinion;
-                }
-
-                if (target is Champion && target.TargetUnit is Minion) // Champion attacking minion
-                {
-                    return ClassifyUnit.ChampionAttackingMinion;
-                }
-            }
-
-            var p = target as Placeable;
-            if (p != null)
-            {
-                return ClassifyUnit.Placeable;
-            }
-
-            var m = target as Minion;
-            if (m != null)
-            {
-                switch (m.getType())
-                {
-                    case MinionSpawnType.MINION_TYPE_MELEE:
-                        return ClassifyUnit.MeleeMinion;
-                    case MinionSpawnType.MINION_TYPE_CASTER:
-                        return ClassifyUnit.CasterMinion;
-                    case MinionSpawnType.MINION_TYPE_CANNON:
-                    case MinionSpawnType.MINION_TYPE_SUPER:
-                        return ClassifyUnit.SuperOrCannonMinion;
-                }
-            }
-
-            if (target is BaseTurret)
-            {
-                return ClassifyUnit.Turret;
-            }
-
-            if (target is Champion)
-            {
-                return ClassifyUnit.Champion;
-            }
-
-            if (target is Inhibitor && !target.IsDead)
-            {
-                return ClassifyUnit.Inhibitor;
-            }
-
-            if (target is Nexus)
-            {
-                return ClassifyUnit.Nexus;
-            }
-
-            return ClassifyUnit.Default;
         }
     }
 

--- a/GameServerLib/Logic/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Inhibitor.cs
+++ b/GameServerLib/Logic/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Inhibitor.cs
@@ -41,7 +41,7 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             var objects = _game.ObjectManager.GetObjects().Values;
             foreach (var obj in objects)
             {
-                var u = obj as AttackableUnit;
+                var u = obj as ObjAIBase;
                 if (u != null && u.TargetUnit == this)
                 {
                     u.SetTargetUnit(null);
@@ -110,10 +110,6 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             base.update(diff);
         }
 
-        public override void refreshWaypoints()
-        {
-
-        }
 
         public override void setToRemove()
         {

--- a/GameServerLib/Logic/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Nexus.cs
+++ b/GameServerLib/Logic/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Nexus.cs
@@ -27,11 +27,6 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
             _game.PacketNotifier.NotifyGameEnd(this);
         }
 
-        public override void refreshWaypoints()
-        {
-
-        }
-
         public override void setToRemove()
         {
 

--- a/GameServerLib/Logic/GameObjects/Missiles/Projectile.cs
+++ b/GameServerLib/Logic/GameObjects/Missiles/Projectile.cs
@@ -152,7 +152,11 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
                     }
                     else
                     { // auto attack
-                        Owner.AutoAttackHit(u);
+                        var ai = u as ObjAIBase;
+                        if (ai != null)
+                        {
+                            ai.AutoAttackHit(u);
+                        }
                         setToRemove();
                     }
                 }

--- a/GameServerLib/Logic/GameObjects/Monster.cs
+++ b/GameServerLib/Logic/GameObjects/Monster.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 
 namespace LeagueSandbox.GameServer.Logic.GameObjects
 {
-    public class Monster : AttackableUnit
+    public class Monster : ObjAIBase
     {
         public Vector2 Facing { get; private set; }
         public string Name { get; private set; }

--- a/GameServerLib/Logic/GameObjects/Other/Placeable.cs
+++ b/GameServerLib/Logic/GameObjects/Other/Placeable.cs
@@ -3,13 +3,13 @@ using Newtonsoft.Json.Linq;
 
 namespace LeagueSandbox.GameServer.Logic.GameObjects
 {
-    public class Placeable : AttackableUnit
+    public class Placeable : ObjAIBase
     {
         public string Name { get; private set; }
-        public AttackableUnit Owner { get; private set; } // We'll probably want to change this in the future
+        public ObjAIBase Owner { get; private set; } // We'll probably want to change this in the future
 
         public Placeable(
-            AttackableUnit owner,
+            ObjAIBase owner,
             float x,
             float y,
             string model,
@@ -32,11 +32,6 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects
         {
             base.OnAdded();
             _game.PacketNotifier.NotifySpawn(this);
-        }
-
-        public override bool isInDistress()
-        {
-            return DistressCause != null;
         }
     }
 }

--- a/GameServerLib/Logic/Items/Shop.cs
+++ b/GameServerLib/Logic/Items/Shop.cs
@@ -5,10 +5,10 @@ namespace LeagueSandbox.GameServer.Logic.Items
 {
     public class Shop
     {
-        private AttackableUnit _owner;
+        private Champion _owner;
         private InventoryManager _inventory;
 
-        private Shop(AttackableUnit owner)
+        private Shop(Champion owner)
         {
             _owner = owner;
             _inventory = _owner.Inventory;

--- a/GameServerLib/Logic/ObjectManager.cs
+++ b/GameServerLib/Logic/ObjectManager.cs
@@ -86,11 +86,11 @@ namespace LeagueSandbox.GameServer.Logic
                         _game.PacketNotifier.NotifyLeaveVision(u, team);
                     }
                 }
-
-                if (u is ObjAIBase)
+                
+                var ai = u as ObjAIBase;
+                if (ai != null)
                 {
-                    var uo = u as ObjAIBase;
-                    var tempBuffs = uo.GetBuffs();
+                    var tempBuffs = ai.GetBuffs();
                     foreach (var buff in tempBuffs.Values)
                     {
                         if (buff.NeedsToRemove())
@@ -99,7 +99,7 @@ namespace LeagueSandbox.GameServer.Logic
                             {
                                 _game.PacketNotifier.NotifyRemoveBuff(buff.TargetUnit, buff.Name, buff.Slot);
                             }
-                            uo.RemoveBuff(buff);
+                            ai.RemoveBuff(buff);
                             continue;
                         }
                         buff.Update(diff);
@@ -255,12 +255,15 @@ namespace LeagueSandbox.GameServer.Logic
                     var u = kv.Value as AttackableUnit;
                     if (u == null)
                         continue;
-
-                    if (u.TargetUnit == target)
+                    var ai = u as ObjAIBase;
+                    if (ai != null)
                     {
-                        u.TargetUnit = null;
-                        u.AutoAttackTarget = null;
-                        _game.PacketNotifier.NotifySetTarget(u, null);
+                        if (ai.TargetUnit == target)
+                        {
+                            ai.TargetUnit = null;
+                            ai.AutoAttackTarget = null;
+                            _game.PacketNotifier.NotifySetTarget(u, null);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Stuff that is moved:
-buff add,remove,update ...
-character data loading
-aadata
-everything for autoattacks
-CC
-waypoint refresh, stop movement, movement handling

Removed:
-CC invulnerability (this needs replication changes to work, so until  those land its removed)
-unit distress  (too complex to fix it, can be added latter)

Depends on: https://github.com/LeagueSandbox/LeagueSandbox-Default/pull/55