### PR TITLE
Minor Fixes.

### DIFF
--- a/GameServerLib/Logic/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/Logic/GameObjects/AttackableUnits/AI/Champion.cs
@@ -63,6 +63,12 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits.AI
 
             Spells[4] = new Spell(this, clientInfo.SummonerSkills[0], 4);
             Spells[5] = new Spell(this, clientInfo.SummonerSkills[1], 5);
+
+            for(short i = 0; i < 7 ; i++)
+            {
+                Spells[(byte)(i + 6)] = new Spell(this, "BaseSpell", (byte)(i + 6));
+            }
+
             Spells[13] = new Spell(this, "Recall", 13);
 
             for (short i = 0; i<CharData.Passives.Length; i++)
@@ -86,6 +92,7 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits.AI
             Spells[4].LevelUp();
             Spells[5].LevelUp();
             Replication = new ReplicationHero(this);
+            Stats.SetSpellEnabled(13, true);
         }
 
         private string GetPlayerIndex()

--- a/GameServerLib/Logic/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/Logic/GameObjects/AttackableUnits/AI/Champion.cs
@@ -53,7 +53,7 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits.AI
 
             //TODO: automaticaly rise spell levels with CharData.SpellLevelsUp
 
-            for (short i = 0; i<CharData.SpellNames.Length;i++)
+            for (short i = 0; i<CharData.SpellNames.Length; i++)
             {
                 if (!string.IsNullOrEmpty(CharData.SpellNames[i]))
                 {
@@ -64,9 +64,9 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.AttackableUnits.AI
             Spells[4] = new Spell(this, clientInfo.SummonerSkills[0], 4);
             Spells[5] = new Spell(this, clientInfo.SummonerSkills[1], 5);
 
-            for(short i = 0; i < 7 ; i++)
+            for (byte i = 6; i < 13; i++)
             {
-                Spells[(byte)(i + 6)] = new Spell(this, "BaseSpell", (byte)(i + 6));
+                Spells[i] = new Spell(this, "BaseSpell", i);
             }
 
             Spells[13] = new Spell(this, "Recall", 13);

--- a/GameServerLib/Logic/GameObjects/Missiles/Projectile.cs
+++ b/GameServerLib/Logic/GameObjects/Missiles/Projectile.cs
@@ -174,7 +174,7 @@ namespace LeagueSandbox.GameServer.Logic.GameObjects.Missiles
                     }
                     else
                     { // auto attack
-                        var ai = u as ObjAiBase;
+                        var ai = Owner as ObjAiBase;
                         if (ai != null)
                         {
                             ai.AutoAttackHit(u);


### PR DESCRIPTION
Re-Enabled Recall, used 'BaseSpell' to fill the spell slots for items (which prevents the game from crashing when someone attempts to use an item active), and fixed an issue with basic attack projectiles that caused them to use the target's data when the attack projectile hits.