### PR TITLE
Starting Gold is now tied to the Map.

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -58,7 +58,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             Inventory = InventoryManager.CreateInventory();
             Shop = Shop.CreateShop(this, game);
 
-            Stats.Gold = 475.0f;
+            Stats.Gold = _game.Map.MapGameScript.StartingGold;
             Stats.GoldPerSecond.BaseValue = _game.Map.MapGameScript.GoldPerSecond;
             Stats.IsGeneratingGold = false;
 

--- a/GameServerLib/Maps/SummonersRift.cs
+++ b/GameServerLib/Maps/SummonersRift.cs
@@ -177,6 +177,7 @@ namespace LeagueSandbox.GameServer.Maps
         };
 
         public float GoldPerSecond { get; set; } = 1.9f;
+        public float StartingGold { get; set; } = 475.0f;
         public bool HasFirstBloodHappened { get; set; } = false;
         public bool IsKillGoldRewardReductionActive { get; set; } = true;
         public int BluePillId { get; set; } = 2001;

--- a/GameServerLib/Scripting/CSharp/MapGameScript.cs
+++ b/GameServerLib/Scripting/CSharp/MapGameScript.cs
@@ -12,6 +12,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
     {
         List<int> ExpToLevelUp { get; set; }
         float GoldPerSecond { get; set; }
+        float StartingGold { get; set; }
         bool HasFirstBloodHappened { get; set; }
         bool IsKillGoldRewardReductionActive { get; set; }
         int BluePillId { get; set; }


### PR DESCRIPTION
Starting Gold is now taken from the currently selected map, rather than always being set to 475 regardless of what Map is chosen.

Solves #727.