### PR TITLE
Resolve #758 -- Cannot cast two skills at the same time

### DIFF
--- a/GameServerLib/GameObjects/Spells/Spell.cs
+++ b/GameServerLib/GameObjects/Spells/Spell.cs
@@ -82,7 +82,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
 
             var stats = Owner.Stats;
             if (SpellData.ManaCost[Level] * (1 - stats.SpellCostReduction) >= stats.CurrentMana ||
-                State != SpellState.STATE_READY)
+                State != SpellState.STATE_READY || Owner.IsCastingSpell && Slot != 4 && Slot != 5)
             {
                 return false;
             }


### PR DESCRIPTION
Only summoner spells (slots 4 and 5) can be used while casting a skill

Refs #758