### PR TITLE
Change Champion.Spell to private.

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -20,7 +20,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public float RespawnTimer { get; private set; }
         public float ChampionGoldFromMinions { get; set; }
         public RuneCollection RuneList { get; set; }
-        public Dictionary<short, Spell> Spells { get; private set; } = new Dictionary<short, Spell>();
+        private Dictionary<short, Spell> Spells { get; set; }
         public ChampionStats ChampStats { get; private set; } = new ChampionStats();
 
         public byte SkillPoints { get; set; }
@@ -54,6 +54,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             _playerId = playerId;
             _playerTeamSpecialId = playerTeamSpecialId;
             RuneList = runeList;
+
+            Spells = new Dictionary<short, Spell>();
 
             Inventory = InventoryManager.CreateInventory();
             Shop = Shop.CreateShop(this, game);
@@ -228,6 +230,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             l.Add(new Vector2(this.X, this.Y));
             this.SetWaypoints(l);
             _game.PacketNotifier.NotifyMovement(this);
+        }
+
+        public Spell GetSpellBySlot(byte slot)
+        {
+            return Spells[slot];
         }
 
         public Spell GetSpellByName(string name)

--- a/GameServerLib/GameObjects/Spells/Spell.cs
+++ b/GameServerLib/GameObjects/Spells/Spell.cs
@@ -347,7 +347,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
 
         public void SetCooldown(byte slot, float newCd)
         {
-            var targetSpell = Owner.Spells[slot];
+            var targetSpell = Owner.GetSpellBySlot(slot);
 
             if (newCd <= 0)
             {
@@ -365,7 +365,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
 
         public void LowerCooldown(byte slot, float lowerValue)
         {
-            SetCooldown(slot, Owner.Spells[slot].CurrentCooldown - lowerValue);
+            SetCooldown(slot, Owner.GetSpellBySlot(slot).CurrentCooldown - lowerValue);
         }
     }
 }


### PR DESCRIPTION
All calls to get a spell will be made with Champion.GetSpellBySlot() or Champion.GetSpellByName() for proper encapsulation.
Closes #543