### PR TITLE
Fix Minion Movment

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
@@ -146,6 +146,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 return true;
             }
 
+            _game.PacketNotifier.NotifyStopAutoAttack(this);
+            IsAttacking = false;
+
             return false;
         }
 


### PR DESCRIPTION
Stops Minions from moving awkward after losing all targets.