### PR TITLE
HP Update for Paused AI

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AI/LaneMinion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/LaneMinion.cs
@@ -81,6 +81,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             {
                 if (IsDashing || _aiPaused)
                 {
+                    Replication.Update();
                     return;
                 }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
@@ -93,6 +93,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             {
                 if (IsDashing || _aiPaused)
                 {
+                    Replication.Update();
                     return;
                 }
                 if (ScanForTargets()) // returns true if we have a target


### PR DESCRIPTION
Paused Minions and LaneMinions did not update their HP if their AI was paused and they got hit. This fixes the issue #810