### PR TITLE
Resolve #728 -- Smite show jungle items on shop

### DIFF
--- a/PacketDefinitions420/PacketDefinitions/S2C/SynchVersionResponse.cs
+++ b/PacketDefinitions420/PacketDefinitions/S2C/SynchVersionResponse.cs
@@ -22,6 +22,7 @@ namespace PacketDefinitions420.PacketDefinitions.S2C
                 Write((short)0x1E); // unk
                 WriteStringHash(summonerSpells[0]);
                 WriteStringHash(summonerSpells[1]);
+                // TODO: maybe smite flag here to test with 0xFFFFFFFF
                 Write((byte)0); // bot boolean
                 Write((int)p.Team); // Probably a short
                 Fill(0, 64); // name is no longer here

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -276,8 +276,21 @@ namespace PacketDefinitions420
 
         public void NotifyAvatarInfo(int userId, ClientInfo client)
         {
-            var info = new PacketDefinitions.S2C.AvatarInfo(client);
-            _packetHandlerManager.SendPacket(userId, info, Channel.CHL_S2C);
+            var avatar = new AvatarInfo_Server();
+            avatar.SenderNetID = client.Champion.NetId;
+            var skills = new uint[2] { HashFunctions.HashString(client.SummonerSkills[0]), HashFunctions.HashString(client.SummonerSkills[1]) };
+            Console.WriteLine("Hashes: " + skills[0] + " | " + skills[1]);
+
+            avatar.SummonerIDs[0] = skills[0];
+            avatar.SummonerIDs[1] = skills[1];
+            for (int i = 0; i < client.Champion.RuneList.Runes.Count; ++i)
+            {
+                int runeValue = 0;
+                client.Champion.RuneList.Runes.TryGetValue(i, out runeValue);
+                avatar.ItemIDs[i] =(uint) runeValue;
+            }
+            // TODO: add talents
+            _packetHandlerManager.SendPacket(userId, avatar.GetBytes(), Channel.CHL_S2C);
         }
 
         public void NotifyBuyItem(int userId, IChampion champion, IItem itemInstance)

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -278,8 +278,7 @@ namespace PacketDefinitions420
         {
             var avatar = new AvatarInfo_Server();
             avatar.SenderNetID = client.Champion.NetId;
-            var skills = new uint[2] { HashFunctions.HashString(client.SummonerSkills[0]), HashFunctions.HashString(client.SummonerSkills[1]) };
-            Console.WriteLine("Hashes: " + skills[0] + " | " + skills[1]);
+            var skills = new uint[] { HashFunctions.HashString(client.SummonerSkills[0]), HashFunctions.HashString(client.SummonerSkills[1]) };
 
             avatar.SummonerIDs[0] = skills[0];
             avatar.SummonerIDs[1] = skills[1];


### PR DESCRIPTION
This PR fixes the problem of jungle acknowledgement by using the proper AvatarInfo packet from LeaguePackets.

Champion needs to have jungle item set defined (in client, if I recall correctly).