### PR TITLE
Resolve #818 -- AddProjectile function expanded

### DIFF
--- a/GameServerCore/Domain/ISpell.cs
+++ b/GameServerCore/Domain/ISpell.cs
@@ -31,6 +31,7 @@ namespace GameServerCore.Domain
         void ApplyEffects(IAttackableUnit u, IProjectile p);
         void LevelUp();
         void AddProjectile(string nameMissile, float toX, float toY, bool isServerOnly = false);
+        void AddProjectileCoords(string nameMissile, float fromX, float fromY, float toX, float toY, bool isServerOnly = false);
         void AddProjectileTarget(string nameMissile, ITarget target, bool isServerOnly = false);
         void AddLaser(string effectName, float toX, float toY, bool affectAsCastIsOver = true);
         void AddCone(string effectName, float toX, float toY, float angleDeg, bool affectAsCastIsOver = true);

--- a/GameServerCore/Domain/ISpell.cs
+++ b/GameServerCore/Domain/ISpell.cs
@@ -30,8 +30,7 @@ namespace GameServerCore.Domain
         void Deactivate();
         void ApplyEffects(IAttackableUnit u, IProjectile p);
         void LevelUp();
-        void AddProjectile(string nameMissile, float toX, float toY, bool isServerOnly = false);
-        void AddProjectileCoords(string nameMissile, float fromX, float fromY, float toX, float toY, bool isServerOnly = false);
+        void AddProjectile(string nameMissile, float fromX, float fromY, float toX, float toY, bool isServerOnly = false);
         void AddProjectileTarget(string nameMissile, ITarget target, bool isServerOnly = false);
         void AddLaser(string effectName, float toX, float toY, bool affectAsCastIsOver = true);
         void AddCone(string effectName, float toX, float toY, float angleDeg, bool affectAsCastIsOver = true);

--- a/GameServerLib/GameObjects/Spells/Spell.cs
+++ b/GameServerLib/GameObjects/Spells/Spell.cs
@@ -218,29 +218,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             _spellGameScript.ApplyEffects(Owner, u, this, p);
         }
 
-        public void AddProjectile(string nameMissile, float toX, float toY, bool isServerOnly = false)
-        {
-            var p = new Projectile(
-                _game,
-                Owner.X,
-                Owner.Y,
-                (int)SpellData.LineWidth,
-                Owner,
-                new Target(toX, toY),
-                this,
-                SpellData.MissileSpeed,
-                nameMissile,
-                SpellData.Flags,
-                FutureProjNetId
-            );
-            _game.ObjectManager.AddObject(p);
-            if (!isServerOnly)
-            {
-                _game.PacketNotifier.NotifyProjectileSpawn(p);
-            }
-        }
-
-        public void AddProjectileCoords(string nameMissile, float fromX, float fromY, float toX, float toY, bool isServerOnly = false)
+        public void AddProjectile(string nameMissile, float fromX, float fromY, float toX, float toY, bool isServerOnly = false)
         {
             var p = new Projectile(
                 _game,

--- a/GameServerLib/GameObjects/Spells/Spell.cs
+++ b/GameServerLib/GameObjects/Spells/Spell.cs
@@ -240,6 +240,28 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             }
         }
 
+        public void AddProjectileCoords(string nameMissile, float fromX, float fromY, float toX, float toY, bool isServerOnly = false)
+        {
+            var p = new Projectile(
+                _game,
+                fromX,
+                fromY,
+                (int)SpellData.LineWidth,
+                Owner,
+                new Target(toX, toY),
+                this,
+                SpellData.MissileSpeed,
+                nameMissile,
+                SpellData.Flags,
+                FutureProjNetId
+            );
+            _game.ObjectManager.AddObject(p);
+            if (!isServerOnly)
+            {
+                _game.PacketNotifier.NotifyProjectileSpawn(p);
+            }
+        }
+
         public void AddProjectileTarget(string nameMissile, ITarget target, bool isServerOnly = false)
         {
             var p = new Projectile(


### PR DESCRIPTION
Fixes #818. Has x and y as spawn parameters for cases where projectile is spawned by client-side spell or when projectile should spawn at casted position rather than owner position.