### PR TITLE
Fix Auto Attacks

### DIFF
--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -11,7 +11,7 @@ namespace GameServerCore.Domain.GameObjects
         bool IsDashing { get; }
         bool HasMadeInitialAttack { get; set; }
 
-        float AutoAttackDelay { get; set;  }
+        float AutoAttackCastTime { get; set; }
         float AutoAttackProjectileSpeed { get; set;  }
         MoveOrder MoveOrder { get; }
         bool IsCastingSpell { get; set;  }

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -48,6 +48,7 @@ namespace GameServerCore.Packets.Interfaces
         void NotifyHeroSpawn2(int userId, IChampion champion);
         void NotifyInhibitorSpawningSoon(IInhibitor inhibitor);
         void NotifyInhibitorState(IInhibitor inhibitor, IGameObject killer = null, List<IChampion> assists = null);
+        void NotifyInstantStopAttack(IAttackableUnit attacker, bool isSummonerSpell, uint missileNetID = 0);
         void NotifyItemBought(IAttackableUnit u, IItem i);
         void NotifyItemsSwapped(IChampion c, byte fromSlot, byte toSlot);
         // TODO: move handling to PacketDefinitions
@@ -93,7 +94,6 @@ namespace GameServerCore.Packets.Interfaces
         void NotifySpawnStart(int userId);
         void NotifySpellAnimation(IAttackableUnit u, string animation);
         void NotifyStaticObjectSpawn(int userId, uint netId);
-        void NotifyStopAutoAttack(IAttackableUnit attacker);
         void NotifySurrender(IChampion starter, byte flag, byte yesVotes, byte noVotes, byte maxVotes, TeamId team, float timeOut);
         void NotifySynchVersion(int userId, List<Pair<uint, ClientInfo>> players, string version, string gameMode, int mapId);
         void NotifyTeleport(IAttackableUnit u, Vector2 pos);

--- a/GameServerLib/Content/CharData.cs
+++ b/GameServerLib/Content/CharData.cs
@@ -35,6 +35,7 @@ namespace LeagueSandbox.GameServer.Content
         public float BaseStaticHpRegen { get; private set; } = 0.30000001f;
         public float BaseStaticMpRegen { get; private set; } = 0.30000001f;
         public float AttackDelayOffsetPercent { get; private set; }
+        public float AttackDelayCastOffsetPercent { get; private set; }
         public float HpPerLevel { get; private set; } = 10.0f;
         public float MpPerLevel { get; private set; } = 10.0f;
         public float DamagePerLevel { get; private set; } = 10.0f;
@@ -102,6 +103,7 @@ namespace LeagueSandbox.GameServer.Content
             BaseStaticHpRegen = file.GetFloat("Data", "BaseStaticHPRegen", BaseStaticHpRegen);
             BaseStaticMpRegen = file.GetFloat("Data", "BaseStaticMPRegen", BaseStaticMpRegen);
             AttackDelayOffsetPercent = file.GetFloat("Data", "AttackDelayOffsetPercent", AttackDelayOffsetPercent);
+            AttackDelayCastOffsetPercent = file.GetFloat("Data", "AttackDelayCastOffsetPercent", AttackDelayCastOffsetPercent);
             HpPerLevel = file.GetFloat("Data", "HPPerLevel", HpPerLevel);
             MpPerLevel = file.GetFloat("Data", "MPPerLevel", MpPerLevel);
             DamagePerLevel = file.GetFloat("Data", "DamagePerLevel", DamagePerLevel);
@@ -110,7 +112,7 @@ namespace LeagueSandbox.GameServer.Content
             HpRegenPerLevel = file.GetFloat("Data", "HPRegenPerLevel", HpRegenPerLevel);
             MpRegenPerLevel = file.GetFloat("Data", "MPRegenPerLevel", MpRegenPerLevel);
             AttackSpeedPerLevel = file.GetFloat("Data", "AttackSpeedPerLevel", AttackSpeedPerLevel);
-            IsMelee = file.GetString("Data", "IsMelee", IsMelee ? "Yes" : "No").Equals("yes");
+            IsMelee = file.GetString("Data", "IsMelee", IsMelee ? "true" : "false").Equals("true");
             PathfindingCollisionRadius =
                 file.GetFloat("Data", "PathfindingCollisionRadius", PathfindingCollisionRadius);
             GameplayCollisionRadius = file.GetFloat("Data", "GameplayCollisionRadius", GameplayCollisionRadius);

--- a/GameServerLib/GameObjects/AttackableUnits/AI/LaneMinion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/LaneMinion.cs
@@ -135,7 +135,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 return true;
             }
 
-            _game.PacketNotifier.NotifyStopAutoAttack(this);
+            _game.PacketNotifier.NotifyInstantStopAttack(this, false);
             IsAttacking = false;
 
             return false;
@@ -168,7 +168,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             if (IsAttacking && (TargetUnit == null || TargetUnit.IsDead || GetDistanceTo(TargetUnit) > Stats.Range.Total))
             // If target is dead or out of range
             {
-                _game.PacketNotifier.NotifyStopAutoAttack(this);
+                _game.PacketNotifier.NotifyInstantStopAttack(this, false);
                 IsAttacking = false;
             }
         }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
@@ -76,7 +76,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     Stats.MagicResist.BaseValue = 100.0f;
                     Stats.AttackDamage.BaseValue = 170.0f;
 
-                    AutoAttackDelay = 0.165f;
+                    AutoAttackCastTime = 0.165f;
                     AutoAttackProjectileSpeed = 1200.0f;
                     break;
                 case TurretType.OUTER_TURRET:
@@ -91,7 +91,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     Stats.MagicResist.BaseValue = 100.0f;
                     Stats.AttackDamage.BaseValue = 152.0f;
 
-                    AutoAttackDelay = 0.165f;
+                    AutoAttackCastTime = 0.165f;
                     AutoAttackProjectileSpeed = 1200.0f;
                     break;
                 case TurretType.INHIBITOR_TURRET:
@@ -108,7 +108,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     Stats.MagicResist.BaseValue = 100.0f;
                     Stats.AttackDamage.BaseValue = 190.0f;
 
-                    AutoAttackDelay = 0.165f;
+                    AutoAttackCastTime = 0.165f;
                     AutoAttackProjectileSpeed = 1200.0f;
                     break;
                 case TurretType.NEXUS_TURRET:
@@ -124,7 +124,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     Stats.MagicResist.BaseValue = 100.0f;
                     Stats.AttackDamage.BaseValue = 180.0f;
 
-                    AutoAttackDelay = 0.165f;
+                    AutoAttackCastTime = 0.165f;
                     AutoAttackProjectileSpeed = 1200.0f;
                     break;
                 case TurretType.FOUNTAIN_TURRET:
@@ -137,7 +137,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     Stats.AttackDamage.BaseValue = 999.0f;
                     _globalGold = 100.0f;
                     Stats.Range.BaseValue = 1250.0f;
-                    AutoAttackDelay = 1f / 30;
+                    AutoAttackCastTime = 1f / 30;
                     AutoAttackProjectileSpeed = 2000.0f;
                     break;
                 default:
@@ -150,7 +150,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     Stats.Armor.PercentBonus = 0.5f;
                     Stats.MagicResist.PercentBonus = 0.5f;
 
-                    AutoAttackDelay = 0.165f;
+                    AutoAttackCastTime = 0.165f;
                     AutoAttackProjectileSpeed = 1200.0f;
 
                     break;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
@@ -138,7 +138,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 _game.PacketNotifier.NotifySetTarget(this, nextTarget);
                 return true;
             }
-            _game.PacketNotifier.NotifyStopAutoAttack(this);
+            _game.PacketNotifier.NotifyInstantStopAttack(this, false);
             IsAttacking = false;
             return false;
         }
@@ -148,7 +148,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             if (IsAttacking && (TargetUnit == null || TargetUnit.IsDead || GetDistanceTo(TargetUnit) > Stats.Range.Total))
             // If target is dead or out of range
             {
-                _game.PacketNotifier.NotifyStopAutoAttack(this);
+                _game.PacketNotifier.NotifyInstantStopAttack(this, false);
                 IsAttacking = false;
             }
         }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -505,6 +505,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 HasMadeInitialAttack = false;
                 AutoAttackTarget = null;
                 _autoAttackCurrentDelay = 0;
+                _game.PacketNotifier.NotifyInstantStopAttack(this, false);
             }
 
             if (_autoAttackCurrentCooldown > 0)

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -38,7 +38,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public CharData CharData { get; }
         public ISpellData AaSpellData { get; }
         private bool _isNextAutoCrit;
-        public float AutoAttackDelay { get; set; }
+        public float AutoAttackCastTime { get; set; }
         public float AutoAttackProjectileSpeed { get; set; }
         private float _autoAttackCurrentCooldown;
         private float _autoAttackCurrentDelay;
@@ -80,13 +80,14 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             if (!string.IsNullOrEmpty(model))
             {
                 AaSpellData = _game.Config.ContentManager.GetSpellData(model + "BasicAttack");
-                AutoAttackDelay = AaSpellData.CastFrame / 30.0f;
+                float baseAttackCooldown = 1.6f * (1.0f + CharData.AttackDelayOffsetPercent);
+                AutoAttackCastTime = baseAttackCooldown * (0.3f + CharData.AttackDelayCastOffsetPercent);
                 AutoAttackProjectileSpeed = AaSpellData.MissileSpeed;
                 IsMelee = CharData.IsMelee;
             }
             else
             {
-                AutoAttackDelay = 0;
+                AutoAttackCastTime = 0;
                 AutoAttackProjectileSpeed = 500;
                 IsMelee = true;
             }
@@ -425,7 +426,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 else if (IsAttacking && AutoAttackTarget != null)
                 {
                     _autoAttackCurrentDelay += diff / 1000.0f;
-                    if (_autoAttackCurrentDelay >= AutoAttackDelay / Stats.AttackSpeedMultiplier.Total)
+                    if (_autoAttackCurrentDelay >= AutoAttackCastTime / Stats.AttackSpeedMultiplier.Total)
                     {
                         if (!IsMelee)
                         {
@@ -498,17 +499,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 }
 
             }
-            else if (IsAttacking)
+            else
             {
-                if (AutoAttackTarget == null
-                    || AutoAttackTarget.IsDead
-                    || !_game.ObjectManager.TeamHasVisionOn(Team, AutoAttackTarget)
-                )
-                {
-                    IsAttacking = false;
-                    HasMadeInitialAttack = false;
-                    AutoAttackTarget = null;
-                }
+                IsAttacking = false;
+                HasMadeInitialAttack = false;
+                AutoAttackTarget = null;
+                _autoAttackCurrentDelay = 0;
             }
 
             if (_autoAttackCurrentCooldown > 0)

--- a/GameServerLib/Maps/SummonersRift.cs
+++ b/GameServerLib/Maps/SummonersRift.cs
@@ -480,7 +480,7 @@ namespace LeagueSandbox.GameServer.Maps
                     m.Stats.AttackDamage.BaseValue = 12.0f + 1.0f * (int)(_game.GameTime / (180 * 1000));
                     m.Stats.Range.BaseValue = 180.0f;
                     m.Stats.AttackSpeedFlat = 1.250f;
-                    m.AutoAttackDelay = 11.8f / 30.0f;
+                    m.AutoAttackCastTime = 11.8f / 30.0f;
                     m.IsMelee = true;
                     break;
                 case MinionSpawnType.MINION_TYPE_CASTER:
@@ -489,7 +489,7 @@ namespace LeagueSandbox.GameServer.Maps
                     m.Stats.AttackDamage.BaseValue = 23.0f + 1.0f * (int)(_game.GameTime / (90 * 1000));
                     m.Stats.Range.BaseValue = 600.0f;
                     m.Stats.AttackSpeedFlat = 0.670f;
-                    m.AutoAttackDelay = 14.1f / 30.0f;
+                    m.AutoAttackCastTime = 14.1f / 30.0f;
                     m.AutoAttackProjectileSpeed = 650.0f;
                     break;
                 case MinionSpawnType.MINION_TYPE_CANNON:
@@ -498,7 +498,7 @@ namespace LeagueSandbox.GameServer.Maps
                     m.Stats.AttackDamage.BaseValue = 40.0f + 3.0f * (int)(_game.GameTime / (180 * 1000));
                     m.Stats.Range.BaseValue = 450.0f;
                     m.Stats.AttackSpeedFlat = 1.0f;
-                    m.AutoAttackDelay = 9.0f / 30.0f;
+                    m.AutoAttackCastTime = 9.0f / 30.0f;
                     m.AutoAttackProjectileSpeed = 1200.0f;
                     break;
                 case MinionSpawnType.MINION_TYPE_SUPER:
@@ -510,7 +510,7 @@ namespace LeagueSandbox.GameServer.Maps
                     m.Stats.Armor.BaseValue = 30.0f;
                     m.Stats.MagicResist.BaseValue = -30.0f;
                     m.IsMelee = true;
-                    m.AutoAttackDelay = 15.0f / 30.0f;
+                    m.AutoAttackCastTime = 15.0f / 30.0f;
                     break;
             }
         }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -439,7 +439,7 @@ namespace PacketDefinitions420
 
         public void NotifyModifyShield(IAttackableUnit unit, float amount, bool IsPhysical, bool IsMagical, bool StopShieldFade)
         {
-            var mods = new LeaguePackets.Game.ModifyShield();
+            var mods = new ModifyShield();
             mods.SenderNetID = unit.NetId;
             mods.Physical = IsPhysical;
             mods.Magical = IsMagical;
@@ -494,6 +494,19 @@ namespace PacketDefinitions420
         {
             var mp = new UpdateModel(obj.NetId, obj.Model);
             _packetHandlerManager.BroadcastPacket(mp, Channel.CHL_S2C);
+        }
+
+        public void NotifyInstantStopAttack(IAttackableUnit attacker, bool isSummonerSpell, uint missileNetID = 0)
+        {
+            var stopAttack = new NPC_InstantStop_Attack();
+            stopAttack.SenderNetID = attacker.NetId;
+            stopAttack.MissileNetID = missileNetID; //TODO: Fix MissileNetID, currently it only works when it is 0
+            stopAttack.KeepAnimating = false;
+            stopAttack.DestroyMissile = true;
+            stopAttack.OverrideVisibility = true;
+            stopAttack.IsSummonerSpell = isSummonerSpell;
+            stopAttack.ForceDoClient = false;
+            _packetHandlerManager.BroadcastPacket(stopAttack.GetBytes(), Channel.CHL_S2C);
         }
 
         public void NotifyItemBought(IAttackableUnit u, IItem i)
@@ -577,12 +590,6 @@ namespace PacketDefinitions420
         {
             var xp = new AddXp(champion, experience);
             _packetHandlerManager.BroadcastPacket(xp, Channel.CHL_S2C);
-        }
-
-        public void NotifyStopAutoAttack(IAttackableUnit attacker)
-        {
-            var saa = new StopAutoAttack(attacker);
-            _packetHandlerManager.BroadcastPacket(saa, Channel.CHL_S2C);
         }
 
         public void NotifyDebugMessage(string htmlDebugMessage)


### PR DESCRIPTION
Fixes the issue of being able to carry over the time spent auto attacking into the next time you retarget something. Referenced in #472 
Fixes the issue of using missiles for melee auto attacks.
Fixes the issue of players being able to stop turrets from retargeting them by quickly leaving the target range after the turret begins auto attacking.
Fixes the issue of the server not properly communicating auto attack cancels to the client.
NOTE: Missile Net IDs should be fixed in the future, as when using them in LeaguePackets' packets, they do not work properly. Because of this, the missileNetID parameter of NotifyInstantStopAttack defaults to 0.