### PR TITLE
Implemented EventOnChampionMove in ApiEventManager.cs and Champion.cs

### DIFF
--- a/GameServerLib/API/ApiEventManager.cs
+++ b/GameServerLib/API/ApiEventManager.cs
@@ -68,11 +68,13 @@ namespace LeagueSandbox.GameServer.API
         {
             OnChampionDamageTaken.RemoveListener(owner);
             OnUpdate.RemoveListener(owner);
+            OnChampionMove.RemoveListener(owner);
         }
 
         public static EventOnUpdate OnUpdate = new EventOnUpdate();
         public static EventOnChampionDamageTaken OnChampionDamageTaken = new EventOnChampionDamageTaken();
         public static EventOnUnitDamageTaken OnUnitDamageTaken = new EventOnUnitDamageTaken();
+        public static EventOnChampionMove OnChampionMove = new EventOnChampionMove();
         public static EventOnHitUnit OnHitUnit = new EventOnHitUnit();
     }
 
@@ -124,6 +126,37 @@ namespace LeagueSandbox.GameServer.API
     }
 
     public class EventOnChampionDamageTaken
+    {
+        private readonly List<Tuple<object, IChampion, Action>> _listeners = new List<Tuple<object, IChampion, Action>>();
+        public void AddListener(object owner, IChampion champion, Action callback)
+        {
+            var listenerTuple = new Tuple<object, IChampion, Action>(owner, champion, callback);
+            _listeners.Add(listenerTuple);
+        }
+
+        public void RemoveListener(object owner, IChampion champion)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner && listener.Item2 == champion);
+        }
+
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner);
+        }
+
+        public void Publish(IChampion champion)
+        {
+            _listeners.ForEach(listener =>
+            {
+                if (listener.Item2 == champion)
+                {
+                    listener.Item3();
+                }
+            });
+        }
+    }
+
+    public class EventOnChampionMove
     {
         private readonly List<Tuple<object, IChampion, Action>> _listeners = new List<Tuple<object, IChampion, Action>>();
         public void AddListener(object owner, IChampion champion, Action callback)

--- a/GameServerLib/API/ApiEventManager.cs
+++ b/GameServerLib/API/ApiEventManager.cs
@@ -76,6 +76,8 @@ namespace LeagueSandbox.GameServer.API
         public static EventOnUnitDamageTaken OnUnitDamageTaken = new EventOnUnitDamageTaken();
         public static EventOnChampionMove OnChampionMove = new EventOnChampionMove();
         public static EventOnHitUnit OnHitUnit = new EventOnHitUnit();
+        public static EventOnUnitCrowdControlled OnUnitCrowdControlled = new EventOnUnitCrowdControlled();
+        public static EventOnChampionCrowdControlled OnChampionCrowdControlled = new EventOnChampionCrowdControlled();
     }
 
     public class EventOnUpdate
@@ -216,6 +218,64 @@ namespace LeagueSandbox.GameServer.API
         public void AddListener(IChampion owner, Action<IAttackableUnit, bool> onAutoAttack)
         {
             throw new NotImplementedException();
+        }
+    }
+
+    public class EventOnUnitCrowdControlled
+    {
+        private readonly List<Tuple<object, IAttackableUnit, Action>> _listeners = new List<Tuple<object, IAttackableUnit, Action>>();
+        public void AddListener(object owner, IAttackableUnit unit, Action callback)
+        {
+            var listenerTuple = new Tuple<object, IAttackableUnit, Action>(owner, unit, callback);
+            _listeners.Add(listenerTuple);
+        }
+
+        public void RemoveListener(object owner, IAttackableUnit unit)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner && listener.Item2 == unit);
+        }
+
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner);
+        }
+
+        public void Publish(IAttackableUnit unit)
+        {
+            _listeners.ForEach(listener => listener.Item3());
+            if (unit is IChampion champion)
+                ApiEventManager.OnChampionCrowdControlled.Publish(champion);
+        }
+    }
+
+    public class EventOnChampionCrowdControlled
+    {
+        private readonly List<Tuple<object, IChampion, Action>> _listeners = new List<Tuple<object, IChampion, Action>>();
+        public void AddListener(object owner, IChampion champion, Action callback)
+        {
+            var listenerTuple = new Tuple<object, IChampion, Action>(owner, champion, callback);
+            _listeners.Add(listenerTuple);
+        }
+
+        public void RemoveListener(object owner, IChampion champion)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner && listener.Item2 == champion);
+        }
+
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner);
+        }
+
+        public void Publish(IChampion champion)
+        {
+            _listeners.ForEach(listener =>
+            {
+                if (listener.Item2 == champion)
+                {
+                    listener.Item3();
+                }
+            });
         }
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -167,6 +167,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public void UpdateMoveOrder(MoveOrder order)
         {
             MoveOrder = order;
+
+            ApiEventManager.OnChampionDamageTaken.Publish(this);
         }
 
         public bool CanCast()

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -168,7 +168,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             MoveOrder = order;
 
-            ApiEventManager.OnChampionDamageTaken.Publish(this);
+            ApiEventManager.OnChampionMove.Publish(this);
         }
 
         public bool CanCast()

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -234,6 +234,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 StopMovement();
             }
 
+            ApiEventManager.OnUnitCrowdControlled.Publish(TargetUnit);
+
             _crowdControlList.Add(cc);
         }
 


### PR DESCRIPTION
Implemented EventOnChampionMove in ApiEventManager called by Champion.UpdateMoveOrder. This allows for channels like Recall to be cancelled on user movement.