### PR TITLE
Fix Vision

### DIFF
--- a/GameServerCore/Content/INavGrid.cs
+++ b/GameServerCore/Content/INavGrid.cs
@@ -30,6 +30,8 @@ namespace GameServerCore.Content
         bool IsWalkable(Vector2 coords);
         bool IsWalkable(float x, float y);
         List<Vector2> GetPath(Vector2 start, Vector2 end);
+        bool IsSeeThrough(Vector2 coords);
+        bool IsSeeThrough(float x, float y);
         Vector2 GetSize();
         bool IsAnythingBetween(IGameObject a, IGameObject b);
         Vector2 GetClosestTerrainExit(Vector2 location);

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -35,8 +35,9 @@ namespace GameServerCore.Packets.Interfaces
         void NotifyDebugPacket(int userId, byte[] data);
         void NotifyEditBuff(IBuff b, int stacks);
         void NotifyEmotions(Emotions type, uint netId);
-        void NotifyEnterVision(IGameObject o, TeamId team);
-        void NotifyEnterVision(int userId, IChampion champion);
+        void NotifyEnterLocalVisibilityClient(IAttackableUnit unit, int userId = 0);
+        void NotifyEnterLocalVisibilityClient(int userId, uint netId);
+        void NotifyEnterVisibilityClient(IAttackableUnit o, TeamId team, int userId = 0);
         void NotifyFaceDirection(IAttackableUnit u, Vector2 direction, bool isInstant = true, float turnTime = 0.0833F);
         void NotifyFogUpdate2(IAttackableUnit u, uint newFogId);
         void NotifyGameEnd(Vector3 cameraPosition, INexus nexus, List<Pair<uint, ClientInfo>> players);
@@ -81,9 +82,6 @@ namespace GameServerCore.Packets.Interfaces
         void NotifyResumeGame(IAttackableUnit unpauser, bool showWindow);
         void NotifySetAnimation(IAttackableUnit u, List<string> animationPairs);
         void NotifySetCooldown(IChampion c, byte slotId, float currentCd, float totalCd);
-        void NotifySetHealth(IAttackableUnit u);
-        void NotifySetHealth(int userId, IAttackableUnit unit);
-        void NotifySetHealth(int userId, uint netId);
         void NotifySetTarget(IAttackableUnit attacker, IAttackableUnit target);
         void NotifySetTeam(IAttackableUnit unit, TeamId team);
         void NotifyShowProjectile(IProjectile p);

--- a/GameServerLib/Content/NavGrid.cs
+++ b/GameServerLib/Content/NavGrid.cs
@@ -432,22 +432,42 @@ namespace LeagueSandbox.GameServer.Content
             return cell != null && !cell.HasFlag(this, NavigationGridCellFlags.NOT_PASSABLE);
         }
 
-        public bool IsWalkable(float x, float y)
+        public bool IsSeeThrough(Vector2 coords)
         {
-            return IsWalkable(new Vector2(x, y));
+            var vector = TranslateToNavGrid(new Vector<float> { X = coords.X, Y = coords.Y });
+            var cell = GetCell((short)vector.X, (short)vector.Y);
+
+            return cell != null && cell.HasFlag(this, NavigationGridCellFlags.SEE_THROUGH);
         }
 
         public bool IsBrush(Vector2 coords)
         {
             var vector = TranslateToNavGrid(new Vector<float> { X = coords.X, Y = coords.Y });
             var cell = GetCell((short)vector.X, (short)vector.Y);
+
             return cell != null && cell.HasFlag(this, NavigationGridCellFlags.HAS_GRASS);
+        }
+
+        public bool IsWalkable(float x, float y)
+        {
+            return IsWalkable(new Vector2(x, y));
+        }
+
+        public bool IsSeeThrough(float x, float y)
+        {
+            return IsSeeThrough(new Vector2(x, y));
+        }
+
+        public bool IsBrush(float x, float y)
+        {
+            return IsBrush(new Vector2(x, y));
         }
 
         public bool HasGlobalVision(Vector2 coords)
         {
             var vector = TranslateToNavGrid(new Vector<float> { X = coords.X, Y = coords.Y });
             var cell = GetCell((short)vector.X, (short)vector.Y);
+
             return cell != null && cell.HasFlag(this, NavigationGridCellFlags.HAS_GLOBAL_VISION);
         }
 
@@ -478,7 +498,7 @@ namespace LeagueSandbox.GameServer.Content
             return IsAnythingBetween(new Vector2(origin.X, origin.Y), new Vector2(destination.X, destination.Y));
         }
 
-        public float CastRaySqr(Vector2 origin, Vector2 destination, bool inverseRay = false)
+        public float CastRaySqr(Vector2 origin, Vector2 destination, bool checkWalkable = false)
         {
             var x1 = origin.X;
             var y1 = origin.Y;
@@ -490,34 +510,32 @@ namespace LeagueSandbox.GameServer.Content
                 return 0.0f;
             }
 
-            var b = x2 - x1;
-            var h = y2 - y1;
-            var l = Math.Abs(b);
-            if (Math.Abs(h) > l)
+            var distx = x2 - x1;
+            var disty = y2 - y1;
+            var greatestdist = Math.Abs(distx);
+            if (Math.Abs(disty) > greatestdist)
             {
-                l = Math.Abs(h);
+                greatestdist = Math.Abs(disty);
             }
 
-            var il = (int)l;
-            var dx = b / l;
-            var dy = h / l;
+            var il = (int)greatestdist;
+            var dx = distx / greatestdist;
+            var dy = disty / greatestdist;
             int i;
-            for (i = 0; i <= il; i++)
+            for (i = 0; i < il; i++)
             {
-                if (IsWalkable(x1, y1) == inverseRay)
+                if (IsWalkable(x1, y1) == checkWalkable || IsSeeThrough(x1, y1) == checkWalkable || (IsBrush(origin) && IsBrush(x1, y1)) == checkWalkable)
                 {
                     break;
                 }
 
-                // Inverse = report on walkable
-                // Normal = report on terrain
-                // so break when isWalkable == true and inverse == true
-                // Break when isWalkable == false and inverse == false
+                // if checkWalkable == true, stop incrementing when (x1, x2) is a see-able position
+                // if checkWalkable == false, stop incrementing when (x1, x2) is a non-see-able position
                 x1 += dx;
                 y1 += dy;
             }
 
-            if (i == il)
+            if (i == il || (x1 == origin.X && y1 == origin.Y))
             {
                 return (new Vector2(x2, y2) - origin).SqrLength();
             }
@@ -542,7 +560,7 @@ namespace LeagueSandbox.GameServer.Content
 
         public bool IsAnythingBetween(IGameObject a, IGameObject b)
         {
-            return CastRaySqr(a.GetPosition(), b.GetPosition()) <= (b.GetPosition() - a.GetPosition()).SqrLength();
+            return CastRaySqr(a.GetPosition(), b.GetPosition()) < (b.GetPosition() - a.GetPosition()).SqrLength();
         }
 
         public Vector2 GetClosestTerrainExit(Vector2 location)

--- a/GameServerLib/Content/NavGrid.cs
+++ b/GameServerLib/Content/NavGrid.cs
@@ -524,7 +524,8 @@ namespace LeagueSandbox.GameServer.Content
             int i;
             for (i = 0; i < il; i++)
             {
-                if (IsWalkable(x1, y1) == checkWalkable || IsSeeThrough(x1, y1) == checkWalkable || (IsBrush(origin) && IsBrush(x1, y1)) == checkWalkable)
+                //TODO: Implement bush logic (preferably near here)
+                if (IsWalkable(x1, y1) == checkWalkable && IsSeeThrough(x1, y1) == checkWalkable)
                 {
                     break;
                 }
@@ -555,7 +556,7 @@ namespace LeagueSandbox.GameServer.Content
 
         public bool IsAnythingBetween(Vector2 a, Vector2 b)
         {
-            return CastRaySqr(a, b) <= (b - a).SqrLength();
+            return CastRaySqr(a, b) < (b - a).SqrLength();
         }
 
         public bool IsAnythingBetween(IGameObject a, IGameObject b)

--- a/GameServerLib/Content/NavGrid.cs
+++ b/GameServerLib/Content/NavGrid.cs
@@ -525,6 +525,7 @@ namespace LeagueSandbox.GameServer.Content
             for (i = 0; i < il; i++)
             {
                 //TODO: Implement bush logic (preferably near here)
+                //TODO: Implement methods for NavGrids without SEE_THROUGH flags
                 if (IsWalkable(x1, y1) == checkWalkable && IsSeeThrough(x1, y1) == checkWalkable)
                 {
                     break;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -610,7 +610,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 //Find optimal position...
                 foreach (var point in targetCircle.Points.OrderBy(x => GetDistanceTo(X, Y)))
                 {
-                    if (!_game.Map.NavGrid.IsWalkable(point))
+                    if (!_game.Map.NavGrid.IsWalkable(point) && !_game.Map.NavGrid.IsSeeThrough(point))
                         continue;
                     var positionUsed = false;
                     foreach (var circlePoly in usedPositions)

--- a/GameServerLib/Maps/SummonersRift.cs
+++ b/GameServerLib/Maps/SummonersRift.cs
@@ -215,6 +215,7 @@ namespace LeagueSandbox.GameServer.Maps
             _game.Map.AnnouncerEvents.Add(new Announce(_game, _firstSpawnTime, Announces.MINIONS_HAVE_SPAWNED, false)); // Minions have spawned (90 * 1000)
             _game.Map.AnnouncerEvents.Add(new Announce(_game, _firstSpawnTime, Announces.MINIONS_HAVE_SPAWNED2, false)); // Minions have spawned [2] (90 * 1000)
 
+            // TODO: Generate & use exact positions from content files
             _game.ObjectManager.AddObject(new LaneTurret(_game, "Turret_T1_R_03_A", 10097.62f, 808.73f, TeamId.TEAM_BLUE,
                 TurretType.OUTER_TURRET, GetTurretItems(TurretType.OUTER_TURRET)));
             _game.ObjectManager.AddObject(new LaneTurret(_game, "Turret_T1_R_02_A", 6512.53f, 1262.62f, TeamId.TEAM_BLUE,

--- a/GameServerLib/Maps/SummonersRift.cs
+++ b/GameServerLib/Maps/SummonersRift.cs
@@ -273,15 +273,14 @@ namespace LeagueSandbox.GameServer.Maps
             var collisionRadius = 0;
             var sightRange = 1700;
 
-            _game.ObjectManager.AddObject(new Inhibitor(_game, "OrderInhibitor", TeamId.TEAM_BLUE, collisionRadius, 835, 3400, sightRange, 0xffd23c3e)); //top
-            _game.ObjectManager.AddObject(new Inhibitor(_game, "OrderInhibitor", TeamId.TEAM_BLUE, collisionRadius, 2785, 3000, sightRange, 0xff4a20f1)); //mid
-            _game.ObjectManager.AddObject(new Inhibitor(_game, "OrderInhibitor", TeamId.TEAM_BLUE, collisionRadius, 3044, 1070, sightRange, 0xff9303e1)); //bot
-            _game.ObjectManager.AddObject(new Inhibitor(_game, "ChaosInhibitor", TeamId.TEAM_PURPLE, collisionRadius, 10960, 13450, sightRange, 0xff6793d0)); //top
-            _game.ObjectManager.AddObject(new Inhibitor(_game, "ChaosInhibitor", TeamId.TEAM_PURPLE, collisionRadius, 11240, 11490, sightRange, 0xffff8f1f)); //mid
-            _game.ObjectManager.AddObject(new Inhibitor(_game, "ChaosInhibitor", TeamId.TEAM_PURPLE, collisionRadius, 13200, 11200, sightRange, 0xff26ac0f)); //bot
-
+            _game.ObjectManager.AddObject(new Inhibitor(_game, "OrderInhibitor", TeamId.TEAM_BLUE, collisionRadius, 853.368f, 3345.1645f, sightRange, 0xffd23c3e)); //top exact
+            _game.ObjectManager.AddObject(new Inhibitor(_game, "OrderInhibitor", TeamId.TEAM_BLUE, collisionRadius, 2785, 3000, sightRange, 0xff4a20f1)); //mid exact
+            _game.ObjectManager.AddObject(new Inhibitor(_game, "OrderInhibitor", TeamId.TEAM_BLUE, collisionRadius, 3044, 1070, sightRange, 0xff9303e1)); //bot exact
+            _game.ObjectManager.AddObject(new Inhibitor(_game, "ChaosInhibitor", TeamId.TEAM_PURPLE, collisionRadius, 10962.21f, 13422.915f, sightRange, 0xff6793d0)); //top exact          
+            _game.ObjectManager.AddObject(new Inhibitor(_game, "ChaosInhibitor", TeamId.TEAM_PURPLE, collisionRadius, 11225.62402f, 11425.87012f, sightRange, 0xffff8f1f)); //mid exact            
+            _game.ObjectManager.AddObject(new Inhibitor(_game, "ChaosInhibitor", TeamId.TEAM_PURPLE, collisionRadius, 13200, 11200, sightRange, 0xff26ac0f)); //bot exact
             _game.ObjectManager.AddObject(new Nexus(_game, "OrderNexus", TeamId.TEAM_BLUE, collisionRadius, 1170, 1470, sightRange, 0xfff97db5));
-            _game.ObjectManager.AddObject(new Nexus(_game, "ChaosNexus", TeamId.TEAM_PURPLE, collisionRadius, 12800, 13100, sightRange, 0xfff02c0f));
+            _game.ObjectManager.AddObject(new Nexus(_game, "ChaosNexus", TeamId.TEAM_PURPLE, collisionRadius, 12804.69f, 13041.465f, sightRange, 0xfff02c0f));
         }
 
         public void Update(float diff)

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -85,7 +85,7 @@ namespace LeagueSandbox.GameServer
                     if (!u.IsVisibleByTeam(team) && TeamHasVisionOn(team, u))
                     {
                         u.SetVisibleByTeam(team, true);
-                        _game.PacketNotifier.NotifyEnterVision(u, team);
+                        _game.PacketNotifier.NotifyEnterVisibilityClient(u, team);
                         // TODO: send this in one place only
                         _game.PacketNotifier.NotifyUpdatedStats(u, false);
                     }

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -118,16 +118,17 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 
             // TODO shop map specific?
             // Level props are just models, we need button-object minions to allow the client to interact with it
+            // TODO: Generate shop NetId to avoid hard-coding
             if (peerInfo != null && peerInfo.Team == TeamId.TEAM_BLUE)
             {
                 // Shop (blue team)
-                 _game.PacketNotifier.NotifyStaticObjectSpawn(userId, 0xff10c6db);
+                _game.PacketNotifier.NotifyStaticObjectSpawn(userId, 0xff10c6db);
                 _game.PacketNotifier.NotifyEnterLocalVisibilityClient(userId, 0xff10c6db);
             }
             else if (peerInfo != null && peerInfo.Team == TeamId.TEAM_PURPLE)
             {
                 // Shop (purple team)
-                 _game.PacketNotifier.NotifyStaticObjectSpawn(userId, 0xffa6170e);
+                _game.PacketNotifier.NotifyStaticObjectSpawn(userId, 0xffa6170e);
                 _game.PacketNotifier.NotifyEnterLocalVisibilityClient(userId, 0xffa6170e);
             }
 

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -74,7 +74,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                      _game.PacketNotifier.NotifyFogUpdate2(turret, _networkIdManager.GetNewNetId());
 
                     // To suppress game HP-related errors for enemy turrets out of vision
-                     _game.PacketNotifier.NotifySetHealth(userId, turret);
+                    _game.PacketNotifier.NotifyEnterLocalVisibilityClient(turret, userId);
 
                     foreach (var item in turret.Inventory)
                     {
@@ -94,14 +94,14 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 {
                     if (champion.IsVisibleByTeam(peerInfo.Champion.Team))
                     {
-                         _game.PacketNotifier.NotifyEnterVision(userId, champion);
+                        _game.PacketNotifier.NotifyEnterVisibilityClient(champion, champion.Team, userId);
                     }
                 }
                 else if (kv.Value is IInhibitor || kv.Value is INexus)
                 {
                     var inhibtor = (IAttackableUnit)kv.Value;
                      _game.PacketNotifier.NotifyStaticObjectSpawn(userId, inhibtor.NetId);
-                     _game.PacketNotifier.NotifySetHealth(userId, inhibtor.NetId);
+                    _game.PacketNotifier.NotifyEnterLocalVisibilityClient(userId, inhibtor.NetId);
                 }
                 else if (kv.Value is IProjectile projectile)
                 {
@@ -122,13 +122,13 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             {
                 // Shop (blue team)
                  _game.PacketNotifier.NotifyStaticObjectSpawn(userId, 0xff10c6db);
-                 _game.PacketNotifier.NotifySetHealth(userId, 0xff10c6db);
+                _game.PacketNotifier.NotifyEnterLocalVisibilityClient(userId, 0xff10c6db);
             }
             else if (peerInfo != null && peerInfo.Team == TeamId.TEAM_PURPLE)
             {
                 // Shop (purple team)
                  _game.PacketNotifier.NotifyStaticObjectSpawn(userId, 0xffa6170e);
-                 _game.PacketNotifier.NotifySetHealth(userId, 0xffa6170e);
+                _game.PacketNotifier.NotifyEnterLocalVisibilityClient(userId, 0xffa6170e);
             }
 
              _game.PacketNotifier.NotifySpawnEnd(userId);

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -51,7 +51,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                          _game.PacketNotifier.NotifyDebugMessage(userId, msg);
                     }
 
-                    _game.PacketNotifier.NotifySetHealth(player.Item2.Champion);
+                    _game.PacketNotifier.NotifyEnterLocalVisibilityClient(player.Item2.Champion);
                     // TODO: send this in one place only
                     _game.PacketNotifier.NotifyUpdatedStats(player.Item2.Champion, false);
                     _game.PacketNotifier.NotifyBlueTip((int) player.Item2.PlayerId, "Welcome to League Sandbox!",

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -721,7 +721,6 @@ namespace PacketDefinitions420
             }
         }
 
-        // TODO: Fix IsAnythingBetween randomly losing vision often, which ends up spamming this as well
         public void NotifyEnterVisibilityClient(IAttackableUnit u, TeamId team, int userId = 0)
         {
             var enterVis = new OnEnterVisiblityClient(); // TYPO >:(
@@ -741,12 +740,14 @@ namespace PacketDefinitions420
             enterVis.LookAtPosition = new Vector3(1, 0, 0);
             if (u is IObjAiBase)
             {
-                _ = ((IObjAiBase)u).GetBuffs().ToList(); // buffList left for when someone decides to finish this
+                //TODO: Use a non-empty buff list here
                 var emptyBuffCountList = new List<KeyValuePair<byte, int>>();
-                enterVis.BuffCount = emptyBuffCountList; //TODO: Use a non-empty buff count list
+                enterVis.BuffCount = emptyBuffCountList;
             }
             enterVis.UnknownIsHero = false;
-            var md = new MovementDataStop //TODO: Use MovementDataNormal instead, because currently we desync if the unit is moving
+            //TODO: Use MovementDataNormal instead, because currently we desync if the unit is moving
+            // TODO: Save unit waypoints in unit class so they can be used here for MovementDataNormal
+            var md = new MovementDataStop
             {
                 Position = u.GetPosition(),
                 Forward = new Vector2(0, 1),
@@ -758,6 +759,7 @@ namespace PacketDefinitions420
             {
                 case IMinion m:
                     {
+                        // TODO: This implementation will probably need a refactor later
                         charStackData.SkinID = 0;
                         charStackDataList.Add(charStackData);
                         enterVis.CharacterDataStack = charStackDataList;


### PR DESCRIPTION
Fixes the issue where units would teleport to different corners of the map after re-entering vision.
Replaced NotifyEnterVision with LeaguePackets' NotifyEnterVisibilityClient. 
Replaced NotifySetHealth with LeaguePackets' NotifyEnterLocalVisibilityClient.

Fixed sometimes losing vision of a unit when a raycast stops where it started.

Fixed not being able to see through the NavGridFlag 0x40 (SEE_THROUGH, or TransparentWall), this consequently fixes not being able to attack units that are behind a see through part of the NavGrid, such as Inhibitors and Nexus'.
**NOTE: This is only applicable if the NavGrid has the flag.**
In the case were it does not, unless you decide to edit the NavGrid, use the fix suggested by #845.

When merging, close #580 and #843.