### PR TITLE
Spell and Champion Level and Spell set changes

### DIFF
--- a/GameServerCore/Domain/GameObjects/IChampion.cs
+++ b/GameServerCore/Domain/GameObjects/IChampion.cs
@@ -25,9 +25,9 @@ namespace GameServerCore.Domain.GameObjects
         void Respawn();
 
         // spells
-        void SetSpell(string name, byte slot, bool enabled = false);
         void SwapSpells(byte slot1, byte slot2);
         void RemoveSpell(byte slot);
+        ISpell SetSpell(string name, byte slot, bool enabled = false);
         ISpell GetSpell(byte slot);
         ISpell LevelUpSpell(byte slot);
 

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -30,6 +30,9 @@ namespace GameServerCore.Domain.GameObjects
         void RemoveBuffSlot(IBuff b);
         byte GetNewBuffSlot(IBuff b);
         void AddBuff(IBuff b);
+        void ChangeAutoAttackSpellData(ISpellData newAutoAttackSpellData);
+        void ChangeAutoAttackSpellData(string newAutoAttackSpellDataName);
+        void ResetAutoAttackSpellData();
         void ApplyCrowdControl(ICrowdControl cc);
         void RemoveCrowdControl(ICrowdControl cc);
         void SetDashingState(bool state);

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -30,9 +30,6 @@ namespace GameServerCore.Domain.GameObjects
         void RemoveBuffSlot(IBuff b);
         byte GetNewBuffSlot(IBuff b);
         void AddBuff(IBuff b);
-        void ChangeAutoAttackSpellData(ISpellData newAutoAttackSpellData);
-        void ChangeAutoAttackSpellData(string newAutoAttackSpellDataName);
-        void ResetAutoAttackSpellData();
         void ApplyCrowdControl(ICrowdControl cc);
         void RemoveCrowdControl(ICrowdControl cc);
         void SetDashingState(bool state);

--- a/GameServerCore/Domain/ISpell.cs
+++ b/GameServerCore/Domain/ISpell.cs
@@ -30,6 +30,7 @@ namespace GameServerCore.Domain
         void Deactivate();
         void ApplyEffects(IAttackableUnit u, IProjectile p);
         void LevelUp();
+        void SetLevel(byte toLevel);
         void AddProjectile(string nameMissile, float fromX, float fromY, float toX, float toY, bool isServerOnly = false);
         void AddProjectileTarget(string nameMissile, ITarget target, bool isServerOnly = false);
         void AddLaser(string effectName, float toX, float toY, bool affectAsCastIsOver = true);

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -548,10 +548,19 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             Skin = skinNo;
         }
 
-        public void SetSpell(string name, byte slot, bool enabled)
+        public ISpell SetSpell(string name, byte slot, bool enabled)
         {
-            Spells[slot] = new Spell(_game, this, name, slot);
+            ISpell newSpell = new Spell(_game, this, name, slot);
+
+            if (Spells[slot] != null)
+            {
+                newSpell.SetLevel(Spells[slot].Level);
+            }
+
+            Spells[slot] = newSpell;
             Stats.SetSpellEnabled(slot, enabled);
+
+            return newSpell;
         }
 
         public void SwapSpells(byte slot1, byte slot2)

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -36,7 +36,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public IAttackableUnit TargetUnit { get; set; }
         public IAttackableUnit AutoAttackTarget { get; set; }
         public CharData CharData { get; }
-        public ISpellData AaSpellData { get; private set; }
+        public ISpellData AaSpellData { get; }
         private bool _isNextAutoCrit;
         public float AutoAttackDelay { get; set; }
         public float AutoAttackProjectileSpeed { get; set; }
@@ -251,21 +251,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public bool HasCrowdControl(CrowdControlType ccType)
         {
             return _crowdControlList.FirstOrDefault(cc => cc.IsTypeOf(ccType)) != null;
-        }
-
-        public void ChangeAutoAttackSpellData(ISpellData newAutoAttackSpellData)
-        {
-            AaSpellData = newAutoAttackSpellData;
-        }
-
-        public void ChangeAutoAttackSpellData(string newAutoAttackSpellDataName)
-        {
-            AaSpellData = _game.Config.ContentManager.GetSpellData(newAutoAttackSpellDataName);
-        }
-
-        public void ResetAutoAttackSpellData()
-        {
-            AaSpellData = _game.Config.ContentManager.GetSpellData(Model + "BasicAttack");
         }
 
         public void StopMovement()

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -36,7 +36,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public IAttackableUnit TargetUnit { get; set; }
         public IAttackableUnit AutoAttackTarget { get; set; }
         public CharData CharData { get; }
-        public ISpellData AaSpellData { get; }
+        public ISpellData AaSpellData { get; private set; }
         private bool _isNextAutoCrit;
         public float AutoAttackDelay { get; set; }
         public float AutoAttackProjectileSpeed { get; set; }
@@ -77,6 +77,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             Stats.CurrentMana = stats.ManaPoints.Total;
             Stats.CurrentHealth = stats.HealthPoints.Total;
+
             if (!string.IsNullOrEmpty(model))
             {
                 AaSpellData = _game.Config.ContentManager.GetSpellData(model + "BasicAttack");
@@ -250,6 +251,21 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public bool HasCrowdControl(CrowdControlType ccType)
         {
             return _crowdControlList.FirstOrDefault(cc => cc.IsTypeOf(ccType)) != null;
+        }
+
+        public void ChangeAutoAttackSpellData(ISpellData newAutoAttackSpellData)
+        {
+            AaSpellData = newAutoAttackSpellData;
+        }
+
+        public void ChangeAutoAttackSpellData(string newAutoAttackSpellDataName)
+        {
+            AaSpellData = _game.Config.ContentManager.GetSpellData(newAutoAttackSpellDataName);
+        }
+
+        public void ResetAutoAttackSpellData()
+        {
+            AaSpellData = _game.Config.ContentManager.GetSpellData(Model + "BasicAttack");
         }
 
         public void StopMovement()

--- a/GameServerLib/GameObjects/Spells/Spell.cs
+++ b/GameServerLib/GameObjects/Spells/Spell.cs
@@ -347,6 +347,19 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             }
         }
 
+        public void SetLevel(byte toLevel)
+        {
+            if (toLevel <= 5)
+            {
+                Level = toLevel;
+            }
+
+            if (Slot < 4)
+            {
+                Owner.Stats.ManaCost[Slot] = SpellData.ManaCost[Level];
+            }
+        }
+
         public void SetCooldown(float newCd)
         {
             if (newCd <= 0)


### PR DESCRIPTION
Added a Spell.SetLevel function for easier level setting and changed Champion.SetSpell to automatically change it's level to the level of the spell that used to be in the given slot if it existed. It also now returns the Spell that's set so it's not needed to GetSpell after if you want to change the recently set spell.