### PR TITLE
#855 - Fixing CSharpScriptEngine script loading

### DIFF
--- a/GameServerLib/Content/Package.cs
+++ b/GameServerLib/Content/Package.cs
@@ -64,7 +64,7 @@ namespace LeagueSandbox.GameServer.Content
         {
             if (!_content.ContainsKey(contentType) || !_content[contentType].ContainsKey(itemName))
             {
-                _logger.Debug($"Package: {PackageName} does not containt file for {itemName}.");
+                _logger.Debug($"Package: {PackageName} does not contain file for {itemName}.");
                 return null;
             }
 

--- a/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
+++ b/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
@@ -115,7 +115,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
 
         public T GetStaticMethod<T>(string scriptNamespace, string scriptClass, string scriptFunction)
         {
-            if (_scriptAssembly == null || _scriptAssembly.Count > 0)
+            if (_scriptAssembly == null || _scriptAssembly.Count <= 0)
             {
                 return default(T);
             }
@@ -142,7 +142,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
 
         public T CreateObject<T>(string scriptNamespace, string scriptClass)
         {
-            if (_scriptAssembly == null || _scriptAssembly.Count > 0)
+            if (_scriptAssembly == null || _scriptAssembly.Count <= 0)
             {
                 return default(T);
             }

--- a/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
+++ b/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
@@ -15,7 +15,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
     public class CSharpScriptEngine
     {
         private readonly ILog _logger;
-        private Assembly _scriptAssembly;
+        private List<Assembly> _scriptAssembly = new List<Assembly>();
 
         public CSharpScriptEngine()
         {
@@ -79,7 +79,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
                     if (result.Success)
                     {
                         ms.Seek(0, SeekOrigin.Begin);
-                        _scriptAssembly = Assembly.Load(ms.ToArray());
+                        _scriptAssembly.Add(Assembly.Load(ms.ToArray()));
                         return errored;
                     }
 
@@ -115,14 +115,26 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
 
         public T GetStaticMethod<T>(string scriptNamespace, string scriptClass, string scriptFunction)
         {
-            if (_scriptAssembly == null) return default(T);
-
-            var classType = _scriptAssembly.GetType(scriptNamespace + "." + scriptClass, false);
-            if (classType != null)
+            if (_scriptAssembly == null || !_scriptAssembly.Any())
             {
+                return default(T);
+            }
+
+            foreach (var scriptAssembly in _scriptAssembly)
+            {
+                var classType = scriptAssembly.GetType(scriptNamespace + "." + scriptClass, false);
+
+                if (classType == null)
+                {
+                    continue;
+                }
+
                 var desiredFunction = classType.GetMethod(scriptFunction, BindingFlags.Public | BindingFlags.Static);
+
                 if (desiredFunction != null)
-                    return (T) (object) Delegate.CreateDelegate(typeof(T), desiredFunction, false);
+                {
+                    return (T)(object)Delegate.CreateDelegate(typeof(T), desiredFunction, false);
+                }
             }
 
             return default(T);
@@ -130,17 +142,27 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
 
         public T CreateObject<T>(string scriptNamespace, string scriptClass)
         {
-            scriptClass = scriptClass.Replace(" ", "_");
-            if (_scriptAssembly == null) return default(T);
-
-            var classType = _scriptAssembly.GetType(scriptNamespace + "." + scriptClass);
-            if (classType == null)
+            if (_scriptAssembly == null || !_scriptAssembly.Any())
             {
-                _logger.Warn($"Failed to load script: {scriptNamespace}.{scriptClass}");
                 return default(T);
             }
 
-            return (T) Activator.CreateInstance(classType);
+            scriptClass = scriptClass.Replace(" ", "_");
+
+            foreach (var scriptAssembly in _scriptAssembly)
+            {
+                var classType = scriptAssembly.GetType(scriptNamespace + "." + scriptClass);
+
+                if (classType == null)
+                {
+                    continue;
+                }
+
+                return (T)Activator.CreateInstance(classType);
+            }
+
+            _logger.Warn($"Failed to load script: {scriptNamespace}.{scriptClass}");
+            return default(T);
         }
 
         public static object RunFunctionOnObject(object obj, string method, params object[] args)

--- a/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
+++ b/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
@@ -115,7 +115,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
 
         public T GetStaticMethod<T>(string scriptNamespace, string scriptClass, string scriptFunction)
         {
-            if (_scriptAssembly == null || !_scriptAssembly.Any())
+            if (_scriptAssembly == null || _scriptAssembly.Count > 0)
             {
                 return default(T);
             }
@@ -142,7 +142,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
 
         public T CreateObject<T>(string scriptNamespace, string scriptClass)
         {
-            if (_scriptAssembly == null || !_scriptAssembly.Any())
+            if (_scriptAssembly == null || _scriptAssembly.Count > 0)
             {
                 return default(T);
             }


### PR DESCRIPTION
As seen in issue https://github.com/LeagueSandbox/GameServer/issues/855 only scripts from the latest loaded package are loaded in, this is due to the Assembly being overwritten by the latest package.

Every loaded package will now have it's own assembly loaded in, this means every script can now be loaded in instead of only scripts in the last loaded package.