### PR TITLE
Surrender support (#736)

### DIFF
--- a/GameServerCore/Domain/IMapProperties.cs
+++ b/GameServerCore/Domain/IMapProperties.cs
@@ -32,5 +32,7 @@ namespace GameServerCore.Domain
         float GetExperienceFor(IAttackableUnit u);
 
         Vector3 GetEndGameCameraPosition(TeamId team);
+
+        void HandleSurrender(int userId, IChampion who, bool vote);
     }
 }

--- a/GameServerCore/GameServerCore.csproj
+++ b/GameServerCore/GameServerCore.csproj
@@ -113,6 +113,7 @@
     <Compile Include="IPlayerManager.cs" />
     <Compile Include="Maps\IMap.cs" />
     <Compile Include="MovementVector.cs" />
+    <Compile Include="Packets\Enums\SurrenderReason.cs" />
     <Compile Include="Packets\Handlers\NetworkHandler.cs" />
     <Compile Include="Packets\PacketDefinitions\ICoreRequest.cs" />
     <Compile Include="Packets\PacketDefinitions\ICoreResponse.cs" />

--- a/GameServerCore/Packets/Enums/SurrenderReason.cs
+++ b/GameServerCore/Packets/Enums/SurrenderReason.cs
@@ -1,0 +1,11 @@
+﻿namespace GameServerCore.Packets.Enums
+{
+    public enum SurrenderReason : uint
+    {
+        SURRENDER_FAILED = 0,
+        SURRENDER_TOO_EARLY = 1,
+        SURRENDER_TOO_QUICKLY = 2,
+        SURRENDER_ALREADY_VOTED = 3,
+        SURRENDER_PASSED = 4
+    }
+}

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -94,9 +94,9 @@ namespace GameServerCore.Packets.Interfaces
         void NotifySpawnStart(int userId);
         void NotifySpellAnimation(IAttackableUnit u, string animation);
         void NotifyStaticObjectSpawn(int userId, uint netId);
-        void NotifySurrender(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, float timeOut);
-        void NotifySurrenderStatus(int userId, TeamId team, SurrenderReason reason, byte yesVotes, byte noVotes);
-        void NotifyCanSurrender(bool can, TeamId team);
+        void NotifyTeamSurrenderVote(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, float timeOut);
+        void NotifyTeamSurrenderStatus(int userId, TeamId team, SurrenderReason reason, byte yesVotes, byte noVotes);
+        void NotifySetCanSurrender(bool can, TeamId team);
         void NotifySynchVersion(int userId, List<Pair<uint, ClientInfo>> players, string version, string gameMode, int mapId);
         void NotifyTeleport(IAttackableUnit u, Vector2 pos);
         void NotifyTint(TeamId team, bool enable, float speed, Color color);

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -94,7 +94,9 @@ namespace GameServerCore.Packets.Interfaces
         void NotifySpawnStart(int userId);
         void NotifySpellAnimation(IAttackableUnit u, string animation);
         void NotifyStaticObjectSpawn(int userId, uint netId);
-        void NotifySurrender(IChampion starter, byte flag, byte yesVotes, byte noVotes, byte maxVotes, TeamId team, float timeOut);
+        void NotifySurrender(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, TeamId team, float timeOut);
+        void NotifySurrenderStatus(uint reason, byte yesVotes, byte noVotes, TeamId team);
+        void NotifyCanSurrender(bool can, TeamId team);
         void NotifySynchVersion(int userId, List<Pair<uint, ClientInfo>> players, string version, string gameMode, int mapId);
         void NotifyTeleport(IAttackableUnit u, Vector2 pos);
         void NotifyTint(TeamId team, bool enable, float speed, Color color);

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -94,8 +94,8 @@ namespace GameServerCore.Packets.Interfaces
         void NotifySpawnStart(int userId);
         void NotifySpellAnimation(IAttackableUnit u, string animation);
         void NotifyStaticObjectSpawn(int userId, uint netId);
-        void NotifySurrender(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, TeamId team, float timeOut);
-        void NotifySurrenderStatus(uint reason, byte yesVotes, byte noVotes, TeamId team);
+        void NotifySurrender(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, float timeOut);
+        void NotifySurrenderStatus(int userId, TeamId team, uint reason, byte yesVotes, byte noVotes);
         void NotifyCanSurrender(bool can, TeamId team);
         void NotifySynchVersion(int userId, List<Pair<uint, ClientInfo>> players, string version, string gameMode, int mapId);
         void NotifyTeleport(IAttackableUnit u, Vector2 pos);

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -95,7 +95,7 @@ namespace GameServerCore.Packets.Interfaces
         void NotifySpellAnimation(IAttackableUnit u, string animation);
         void NotifyStaticObjectSpawn(int userId, uint netId);
         void NotifySurrender(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, float timeOut);
-        void NotifySurrenderStatus(int userId, TeamId team, uint reason, byte yesVotes, byte noVotes);
+        void NotifySurrenderStatus(int userId, TeamId team, SurrenderReason reason, byte yesVotes, byte noVotes);
         void NotifyCanSurrender(bool can, TeamId team);
         void NotifySynchVersion(int userId, List<Pair<uint, ClientInfo>> players, string version, string gameMode, int mapId);
         void NotifyTeleport(IAttackableUnit u, Vector2 pos);

--- a/GameServerCore/Packets/Interfaces/IPacketReader.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketReader.cs
@@ -4,6 +4,7 @@ namespace GameServerCore.Packets.Interfaces
 {
     public interface IPacketReader
     {
+        SurrenderRequest ReadSurrenderRequest(byte[] data);
         SwapItemsRequest ReadSwapItemsRequest(byte[] data);
         AttentionPingRequest ReadAttentionPingRequest(byte[] data);
         AutoAttackOptionRequest ReadAutoAttackOptionRequest(byte[] data);

--- a/GameServerCore/Packets/PacketDefinitions/Requests/SurrenderRequest.cs
+++ b/GameServerCore/Packets/PacketDefinitions/Requests/SurrenderRequest.cs
@@ -2,5 +2,11 @@
 {
     public class SurrenderRequest : ICoreRequest
     {
+        public bool VotedYes { get; }
+
+        public SurrenderRequest(bool vote)
+        {
+            VotedYes = vote;
+        }
     }
 }

--- a/GameServerLib/GameServerLib.csproj
+++ b/GameServerLib/GameServerLib.csproj
@@ -270,6 +270,7 @@
     <Compile Include="Items\Shop.cs" />
     <Compile Include="Logging\LoggerProvider.cs" />
     <Compile Include="Maps\Map.cs" />
+    <Compile Include="Maps\Surrender.cs" />
     <Compile Include="ObjectManager.cs" />
     <Compile Include="Packets\NetworkIdManager.cs" />
     <Compile Include="Attributes\DisabledHandlerAttribute.cs" />

--- a/GameServerLib/GameServerLib.csproj
+++ b/GameServerLib/GameServerLib.csproj
@@ -270,7 +270,7 @@
     <Compile Include="Items\Shop.cs" />
     <Compile Include="Logging\LoggerProvider.cs" />
     <Compile Include="Maps\Map.cs" />
-    <Compile Include="Maps\Surrender.cs" />
+    <Compile Include="Maps\SurrenderHandler.cs" />
     <Compile Include="ObjectManager.cs" />
     <Compile Include="Packets\NetworkIdManager.cs" />
     <Compile Include="Attributes\DisabledHandlerAttribute.cs" />

--- a/GameServerLib/Maps/SummonersRift.cs
+++ b/GameServerLib/Maps/SummonersRift.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
+using GameServerCore.Maps;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
@@ -155,6 +156,7 @@ namespace LeagueSandbox.GameServer.Maps
         private long _nextSpawnTime = 90 * 1000;
         private readonly long _spawnInterval = 30 * 1000;
         private readonly Dictionary<TeamId, Fountain> _fountains;
+        private readonly Dictionary<TeamId, Surrender> _surrenders;
 
         public List<int> ExpToLevelUp { get; set; } = new List<int>
         {
@@ -192,6 +194,11 @@ namespace LeagueSandbox.GameServer.Maps
             {
                 { TeamId.TEAM_BLUE, new Fountain(game, TeamId.TEAM_BLUE, 11, 250, 1000) },
                 { TeamId.TEAM_PURPLE, new Fountain(game, TeamId.TEAM_PURPLE, 13950, 14200, 1000) }
+            };
+            _surrenders = new Dictionary<TeamId, Surrender>
+            {
+                { TeamId.TEAM_BLUE, new Surrender(game, TeamId.TEAM_BLUE, 1200000.0f , 300000.0f , 30.0f) },
+                { TeamId.TEAM_PURPLE, new Surrender(game, TeamId.TEAM_PURPLE, 1200000.0f, 300000.0f, 30.0f) }
             };
             SpawnEnabled = _game.Config.MinionSpawnsEnabled;
         }
@@ -319,6 +326,9 @@ namespace LeagueSandbox.GameServer.Maps
             {
                 fountain.Update(diff);
             }
+
+            foreach(var surrender in _surrenders.Values)
+                surrender.Update(diff);
         }
 
         public ITarget GetRespawnLocation(TeamId team)
@@ -623,6 +633,12 @@ namespace LeagueSandbox.GameServer.Maps
             }
 
             return EndGameCameraPosition[team];
+        }
+
+        public void HandleSurrender(int userId, IChampion who, bool vote)
+        {
+            if (_surrenders.ContainsKey(who.Team))
+                _surrenders[who.Team].HandleSurrender(userId, who, vote);
         }
     }
 }

--- a/GameServerLib/Maps/SummonersRift.cs
+++ b/GameServerLib/Maps/SummonersRift.cs
@@ -156,7 +156,7 @@ namespace LeagueSandbox.GameServer.Maps
         private long _nextSpawnTime = 90 * 1000;
         private readonly long _spawnInterval = 30 * 1000;
         private readonly Dictionary<TeamId, Fountain> _fountains;
-        private readonly Dictionary<TeamId, Surrender> _surrenders;
+        private readonly Dictionary<TeamId, SurrenderHandler> _surrenders;
 
         public List<int> ExpToLevelUp { get; set; } = new List<int>
         {
@@ -195,10 +195,10 @@ namespace LeagueSandbox.GameServer.Maps
                 { TeamId.TEAM_BLUE, new Fountain(game, TeamId.TEAM_BLUE, 11, 250, 1000) },
                 { TeamId.TEAM_PURPLE, new Fountain(game, TeamId.TEAM_PURPLE, 13950, 14200, 1000) }
             };
-            _surrenders = new Dictionary<TeamId, Surrender>
+            _surrenders = new Dictionary<TeamId, SurrenderHandler>
             {
-                { TeamId.TEAM_BLUE, new Surrender(game, TeamId.TEAM_BLUE, 1200000.0f , 300000.0f , 30.0f) },
-                { TeamId.TEAM_PURPLE, new Surrender(game, TeamId.TEAM_PURPLE, 1200000.0f, 300000.0f, 30.0f) }
+                { TeamId.TEAM_BLUE, new SurrenderHandler(game, TeamId.TEAM_BLUE, 1200000.0f , 300000.0f , 30.0f) },
+                { TeamId.TEAM_PURPLE, new SurrenderHandler(game, TeamId.TEAM_PURPLE, 1200000.0f, 300000.0f, 30.0f) }
             };
             SpawnEnabled = _game.Config.MinionSpawnsEnabled;
         }

--- a/GameServerLib/Maps/Surrender.cs
+++ b/GameServerLib/Maps/Surrender.cs
@@ -1,0 +1,113 @@
+﻿using GameServerCore;
+using GameServerCore.Domain;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Enums;
+using GameServerCore.Maps;
+using GameServerCore.NetInfo;
+using GameServerCore.Packets.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LeagueSandbox.GameServer.Maps
+{
+    // TODO: Make the surrender UI button become clickable upon hitting SurrenderMinimumTime
+    public class Surrender : IUpdate
+    {
+        private Dictionary<IChampion, bool> _votes = new Dictionary<IChampion, bool>();
+        private Game _game;
+
+        public float SurrenderMinimumTime { get; set; }
+        public float SurrenderRestTime { get; set; }
+        public float SurrenderLength { get; set; }
+        public float LastSurrenderTime { get; set; }
+        public bool IsSurrenderActive { get; set; }
+        public TeamId Team { get; set; }
+
+        // TODO: The first two parameters are in milliseconds, the third is seconds. QoL fix this?
+        public Surrender(Game g, TeamId team, float minTime, float restTime, float length)
+        {
+            _game = g;
+            Team = team;
+            SurrenderMinimumTime = minTime;
+            SurrenderRestTime = restTime;
+            SurrenderLength = length;
+        }
+
+        public Pair<int, int> GetVoteCounts()
+        {
+            int yes = _votes.Count(kv => kv.Value == true);
+            int no = _votes.Count - yes;
+            return new Pair<int, int>(yes, no);
+        }
+
+        public void HandleSurrender(int userId, IChampion who, bool vote)
+        {
+            if (_game.GameTime < SurrenderMinimumTime)
+            {
+                _game.PacketNotifier.NotifySurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_TOO_EARLY, 0, 0);
+                return;
+            }
+            
+            bool open = !IsSurrenderActive;
+            if (!IsSurrenderActive)
+            {
+                if (_game.GameTime < LastSurrenderTime + SurrenderRestTime)
+                {
+                    _game.PacketNotifier.NotifySurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_TOO_QUICKLY, 0, 0);
+                    return;
+                }
+                IsSurrenderActive = true;
+                LastSurrenderTime = _game.GameTime;
+                _votes.Clear();
+            }
+
+            if (_votes.ContainsKey(who))
+            {
+                _game.PacketNotifier.NotifySurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_ALREADY_VOTED, 0, 0);
+                return;
+            }
+            _votes[who] = vote;
+            Pair<int, int> voteCounts = GetVoteCounts();
+            int total = _game.PlayerManager.GetPlayers().Count;
+
+            Console.WriteLine($"Champion {who.Model} voted {vote}. Currently {voteCounts.Item1} yes votes, {voteCounts.Item2} no votes, with {total} total players");
+
+            _game.PacketNotifier.NotifySurrender(who, open, vote, (byte)voteCounts.Item1, (byte)voteCounts.Item2, (byte)total, SurrenderLength);
+
+            if (voteCounts.Item1 >= total - 1)
+            {
+                IsSurrenderActive = false;
+                foreach (Pair<uint, ClientInfo> p in _game.PlayerManager.GetPlayers())
+                {
+                    _game.PacketNotifier.NotifySurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_PASSED, (byte)voteCounts.Item1, (byte)voteCounts.Item2); // TOOD: fix id casting
+                }
+
+                API.ApiFunctionManager.CreateTimer(3.0f, () =>
+                {
+                    INexus ourNexus = (INexus)_game.ObjectManager.GetObjects().First(o => o.Value is INexus && o.Value.Team == Team).Value;
+                    if (ourNexus == null)
+                    {
+                        Console.WriteLine("Unable to surrender correctly, couldn't find the nexus!");
+                        return;
+                    }
+                    ourNexus.Die(null);
+                });
+            }
+        }
+
+        public void Update(float diff)
+        {
+            if (IsSurrenderActive)
+            {
+                if (_game.GameTime >= LastSurrenderTime + (SurrenderLength * 1000.0f))
+                {
+                    IsSurrenderActive = false;
+                    Pair<int, int> count = GetVoteCounts();
+                    foreach (Pair<uint, ClientInfo> p in _game.PlayerManager.GetPlayers().Where(kv => kv.Item2.Team == Team))
+                        _game.PacketNotifier.NotifySurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_FAILED, (byte)count.Item1, (byte)count.Item2); // TODO: fix id casting
+                }
+            }
+        }
+    }
+}

--- a/GameServerLib/Maps/SurrenderHandler.cs
+++ b/GameServerLib/Maps/SurrenderHandler.cs
@@ -54,17 +54,14 @@ namespace LeagueSandbox.GameServer.Maps
             }
             
             bool open = !IsSurrenderActive;
-            if (!IsSurrenderActive)
+            if (IsSurrenderActive && _game.GameTime < LastSurrenderTime + SurrenderRestTime)
             {
-                if (_game.GameTime < LastSurrenderTime + SurrenderRestTime)
-                {
-                    _game.PacketNotifier.NotifySurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_TOO_QUICKLY, 0, 0);
-                    return;
-                }
-                IsSurrenderActive = true;
-                LastSurrenderTime = _game.GameTime;
-                _votes.Clear();
+                _game.PacketNotifier.NotifySurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_TOO_QUICKLY, 0, 0);
+                return;
             }
+            IsSurrenderActive = true;
+            LastSurrenderTime = _game.GameTime;
+            _votes.Clear();
 
             if (_votes.ContainsKey(who))
             {

--- a/GameServerLib/Maps/SurrenderHandler.cs
+++ b/GameServerLib/Maps/SurrenderHandler.cs
@@ -12,7 +12,7 @@ using System.Linq;
 namespace LeagueSandbox.GameServer.Maps
 {
     // TODO: Make the surrender UI button become clickable upon hitting SurrenderMinimumTime
-    public class Surrender : IUpdate
+    public class SurrenderHandler : IUpdate
     {
         private Dictionary<IChampion, bool> _votes = new Dictionary<IChampion, bool>();
         private Game _game;
@@ -25,7 +25,7 @@ namespace LeagueSandbox.GameServer.Maps
         public TeamId Team { get; set; }
 
         // TODO: The first two parameters are in milliseconds, the third is seconds. QoL fix this?
-        public Surrender(Game g, TeamId team, float minTime, float restTime, float length)
+        public SurrenderHandler(Game g, TeamId team, float minTime, float restTime, float length)
         {
             _game = g;
             Team = team;

--- a/GameServerLib/Maps/SurrenderHandler.cs
+++ b/GameServerLib/Maps/SurrenderHandler.cs
@@ -99,15 +99,12 @@ namespace LeagueSandbox.GameServer.Maps
 
         public void Update(float diff)
         {
-            if (IsSurrenderActive)
+            if (IsSurrenderActive && _game.GameTime >= LastSurrenderTime + (SurrenderLength * 1000.0f))
             {
-                if (_game.GameTime >= LastSurrenderTime + (SurrenderLength * 1000.0f))
-                {
-                    IsSurrenderActive = false;
-                    Tuple<int, int> count = GetVoteCounts();
-                    foreach (var p in _game.PlayerManager.GetPlayers().Where(kv => kv.Item2.Team == Team))
-                        _game.PacketNotifier.NotifySurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_FAILED, (byte)count.Item1, (byte)count.Item2); // TODO: fix id casting
-                }
+                IsSurrenderActive = false;
+                Tuple<int, int> count = GetVoteCounts();
+                foreach (var p in _game.PlayerManager.GetPlayers().Where(kv => kv.Item2.Team == Team))
+                    _game.PacketNotifier.NotifySurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_FAILED, (byte)count.Item1, (byte)count.Item2); // TODO: fix id casting
             }
         }
     }

--- a/GameServerLib/Maps/SurrenderHandler.cs
+++ b/GameServerLib/Maps/SurrenderHandler.cs
@@ -34,11 +34,11 @@ namespace LeagueSandbox.GameServer.Maps
             SurrenderLength = length;
         }
 
-        public Pair<int, int> GetVoteCounts()
+        public Tuple<int, int> GetVoteCounts()
         {
             int yes = _votes.Count(kv => kv.Value == true);
             int no = _votes.Count - yes;
-            return new Pair<int, int>(yes, no);
+            return new Tuple<int, int>(yes, no);
         }
 
         public void HandleSurrender(int userId, IChampion who, bool vote)
@@ -68,7 +68,7 @@ namespace LeagueSandbox.GameServer.Maps
                 return;
             }
             _votes[who] = vote;
-            Pair<int, int> voteCounts = GetVoteCounts();
+            Tuple<int, int> voteCounts = GetVoteCounts();
             int total = _game.PlayerManager.GetPlayers().Count;
 
             Console.WriteLine($"Champion {who.Model} voted {vote}. Currently {voteCounts.Item1} yes votes, {voteCounts.Item2} no votes, with {total} total players");
@@ -78,7 +78,7 @@ namespace LeagueSandbox.GameServer.Maps
             if (voteCounts.Item1 >= total - 1)
             {
                 IsSurrenderActive = false;
-                foreach (Pair<uint, ClientInfo> p in _game.PlayerManager.GetPlayers())
+                foreach (var p in _game.PlayerManager.GetPlayers())
                 {
                     _game.PacketNotifier.NotifySurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_PASSED, (byte)voteCounts.Item1, (byte)voteCounts.Item2); // TOOD: fix id casting
                 }
@@ -103,8 +103,8 @@ namespace LeagueSandbox.GameServer.Maps
                 if (_game.GameTime >= LastSurrenderTime + (SurrenderLength * 1000.0f))
                 {
                     IsSurrenderActive = false;
-                    Pair<int, int> count = GetVoteCounts();
-                    foreach (Pair<uint, ClientInfo> p in _game.PlayerManager.GetPlayers().Where(kv => kv.Item2.Team == Team))
+                    Tuple<int, int> count = GetVoteCounts();
+                    foreach (var p in _game.PlayerManager.GetPlayers().Where(kv => kv.Item2.Team == Team))
                         _game.PacketNotifier.NotifySurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_FAILED, (byte)count.Item1, (byte)count.Item2); // TODO: fix id casting
                 }
             }

--- a/GameServerLib/Maps/SurrenderHandler.cs
+++ b/GameServerLib/Maps/SurrenderHandler.cs
@@ -49,14 +49,14 @@ namespace LeagueSandbox.GameServer.Maps
         {
             if (_game.GameTime < SurrenderMinimumTime)
             {
-                _game.PacketNotifier.NotifySurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_TOO_EARLY, 0, 0);
+                _game.PacketNotifier.NotifyTeamSurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_TOO_EARLY, 0, 0);
                 return;
             }
             
             bool open = !IsSurrenderActive;
             if (!IsSurrenderActive && _game.GameTime < LastSurrenderTime + SurrenderRestTime)
             {
-                _game.PacketNotifier.NotifySurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_TOO_QUICKLY, 0, 0);
+                _game.PacketNotifier.NotifyTeamSurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_TOO_QUICKLY, 0, 0);
                 return;
             }
             IsSurrenderActive = true;
@@ -65,7 +65,7 @@ namespace LeagueSandbox.GameServer.Maps
 
             if (_votes.ContainsKey(who))
             {
-                _game.PacketNotifier.NotifySurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_ALREADY_VOTED, 0, 0);
+                _game.PacketNotifier.NotifyTeamSurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_ALREADY_VOTED, 0, 0);
                 return;
             }
             _votes[who] = vote;
@@ -74,14 +74,14 @@ namespace LeagueSandbox.GameServer.Maps
 
             _log.Info($"Champion {who.Model} voted {vote}. Currently {voteCounts.Item1} yes votes, {voteCounts.Item2} no votes, with {total} total players");
 
-            _game.PacketNotifier.NotifySurrender(who, open, vote, (byte)voteCounts.Item1, (byte)voteCounts.Item2, (byte)total, SurrenderLength);
+            _game.PacketNotifier.NotifyTeamSurrenderVote(who, open, vote, (byte)voteCounts.Item1, (byte)voteCounts.Item2, (byte)total, SurrenderLength);
 
             if (voteCounts.Item1 >= total - 1)
             {
                 IsSurrenderActive = false;
                 foreach (var p in _game.PlayerManager.GetPlayers())
                 {
-                    _game.PacketNotifier.NotifySurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_PASSED, (byte)voteCounts.Item1, (byte)voteCounts.Item2); // TOOD: fix id casting
+                    _game.PacketNotifier.NotifyTeamSurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_PASSED, (byte)voteCounts.Item1, (byte)voteCounts.Item2); // TOOD: fix id casting
                 }
 
                 API.ApiFunctionManager.CreateTimer(3.0f, () =>
@@ -104,7 +104,7 @@ namespace LeagueSandbox.GameServer.Maps
                 IsSurrenderActive = false;
                 Tuple<int, int> count = GetVoteCounts();
                 foreach (var p in _game.PlayerManager.GetPlayers().Where(kv => kv.Item2.Team == Team))
-                    _game.PacketNotifier.NotifySurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_FAILED, (byte)count.Item1, (byte)count.Item2); // TODO: fix id casting
+                    _game.PacketNotifier.NotifyTeamSurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_FAILED, (byte)count.Item1, (byte)count.Item2); // TODO: fix id casting
             }
         }
     }

--- a/GameServerLib/Maps/SurrenderHandler.cs
+++ b/GameServerLib/Maps/SurrenderHandler.cs
@@ -54,7 +54,7 @@ namespace LeagueSandbox.GameServer.Maps
             }
             
             bool open = !IsSurrenderActive;
-            if (IsSurrenderActive && _game.GameTime < LastSurrenderTime + SurrenderRestTime)
+            if (!IsSurrenderActive && _game.GameTime < LastSurrenderTime + SurrenderRestTime)
             {
                 _game.PacketNotifier.NotifySurrenderStatus(userId, who.Team, SurrenderReason.SURRENDER_TOO_QUICKLY, 0, 0);
                 return;

--- a/GameServerLib/Maps/SurrenderHandler.cs
+++ b/GameServerLib/Maps/SurrenderHandler.cs
@@ -5,6 +5,8 @@ using GameServerCore.Enums;
 using GameServerCore.Maps;
 using GameServerCore.NetInfo;
 using GameServerCore.Packets.Enums;
+using LeagueSandbox.GameServer.Logging;
+using log4net;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,6 +18,7 @@ namespace LeagueSandbox.GameServer.Maps
     {
         private Dictionary<IChampion, bool> _votes = new Dictionary<IChampion, bool>();
         private Game _game;
+        private ILog _log;
 
         public float SurrenderMinimumTime { get; set; }
         public float SurrenderRestTime { get; set; }
@@ -27,6 +30,7 @@ namespace LeagueSandbox.GameServer.Maps
         // TODO: The first two parameters are in milliseconds, the third is seconds. QoL fix this?
         public SurrenderHandler(Game g, TeamId team, float minTime, float restTime, float length)
         {
+            _log = LoggerProvider.GetLogger();
             _game = g;
             Team = team;
             SurrenderMinimumTime = minTime;
@@ -71,7 +75,7 @@ namespace LeagueSandbox.GameServer.Maps
             Tuple<int, int> voteCounts = GetVoteCounts();
             int total = _game.PlayerManager.GetPlayers().Count;
 
-            Console.WriteLine($"Champion {who.Model} voted {vote}. Currently {voteCounts.Item1} yes votes, {voteCounts.Item2} no votes, with {total} total players");
+            _log.Info($"Champion {who.Model} voted {vote}. Currently {voteCounts.Item1} yes votes, {voteCounts.Item2} no votes, with {total} total players");
 
             _game.PacketNotifier.NotifySurrender(who, open, vote, (byte)voteCounts.Item1, (byte)voteCounts.Item2, (byte)total, SurrenderLength);
 
@@ -88,7 +92,7 @@ namespace LeagueSandbox.GameServer.Maps
                     INexus ourNexus = (INexus)_game.ObjectManager.GetObjects().First(o => o.Value is INexus && o.Value.Team == Team).Value;
                     if (ourNexus == null)
                     {
-                        Console.WriteLine("Unable to surrender correctly, couldn't find the nexus!");
+                        _log.Error("Unable to surrender correctly, couldn't find the nexus!");
                         return;
                     }
                     ourNexus.Die(null);

--- a/GameServerLib/Packets/PacketHandlers/HandleSurrender.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSurrender.cs
@@ -1,6 +1,7 @@
 ﻿using GameServerCore;
 using GameServerCore.Packets.Handlers;
 using GameServerCore.Packets.PacketDefinitions.Requests;
+using System;
 
 namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 {
@@ -18,7 +19,8 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
         public override bool HandlePacket(int userId, SurrenderRequest req)
         {
             var c = _pm.GetPeerInfo((ulong)userId).Champion;
-             _game.PacketNotifier.NotifySurrender(c, 0x03, 1, 0, 5, c.Team, 10.0f);
+            //_game.PacketNotifier.NotifySurrender( c, false, true, 2, 0, (byte)_game.PlayerManager.GetPlayers().Count, c.Team, 10.0f );
+            Console.WriteLine( $"Champion {c.Model} voted {req.VotedYes} towards surrender" );
             return true;
         }
     }

--- a/GameServerLib/Packets/PacketHandlers/HandleSurrender.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSurrender.cs
@@ -19,8 +19,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
         public override bool HandlePacket(int userId, SurrenderRequest req)
         {
             var c = _pm.GetPeerInfo((ulong)userId).Champion;
-            //_game.PacketNotifier.NotifySurrender( c, false, true, 2, 0, (byte)_game.PlayerManager.GetPlayers().Count, c.Team, 10.0f );
-            Console.WriteLine( $"Champion {c.Model} voted {req.VotedYes} towards surrender" );
+            _game.Map.MapProperties.HandleSurrender(userId, c, req.VotedYes);
             return true;
         }
     }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -225,7 +225,7 @@ namespace PacketDefinitions420
             _packetHandlerManager.UnpauseGame();
         }
 
-        public void NotifySurrender(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, float timeOut)
+        public void NotifyTeamSurrenderVote(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, float timeOut)
         {
             var surrender = new S2C_TeamSurrenderVote()
             {
@@ -241,7 +241,7 @@ namespace PacketDefinitions420
             _packetHandlerManager.BroadcastPacketTeam(starter.Team, surrender.GetBytes(), Channel.CHL_S2C);
         }
 
-        public void NotifySurrenderStatus(int userId, TeamId team, SurrenderReason reason, byte yesVotes, byte noVotes)
+        public void NotifyTeamSurrenderStatus(int userId, TeamId team, SurrenderReason reason, byte yesVotes, byte noVotes)
         {
             var surrenderStatus = new S2C_TeamSurrenderStatus()
             {
@@ -253,7 +253,7 @@ namespace PacketDefinitions420
             _packetHandlerManager.SendPacket(userId, surrenderStatus.GetBytes(), Channel.CHL_S2C);
         }
 
-        public void NotifyCanSurrender(bool can, TeamId team)
+        public void NotifySetCanSurrender(bool can, TeamId team)
         {
             var canSurrender = new S2C_SetCanSurrender()
             {

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -225,7 +225,7 @@ namespace PacketDefinitions420
             _packetHandlerManager.UnpauseGame();
         }
 
-        public void NotifySurrender(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, TeamId team, float timeOut)
+        public void NotifySurrender(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, float timeOut)
         {
             var surrender = new S2C_TeamSurrenderVote()
             {
@@ -235,13 +235,13 @@ namespace PacketDefinitions420
                 ForVote = yesVotes,
                 AgainstVote = noVotes,
                 NumPlayers = maxVotes,
-                TeamID = (uint)team,
+                TeamID = (uint)starter.Team,
                 TimeOut = timeOut,
             };
-            _packetHandlerManager.BroadcastPacketTeam(team, surrender.GetBytes(), Channel.CHL_S2C);
+            _packetHandlerManager.BroadcastPacketTeam(starter.Team, surrender.GetBytes(), Channel.CHL_S2C);
         }
 
-        public void NotifySurrenderStatus(uint reason, byte yesVotes, byte noVotes, TeamId team)
+        public void NotifySurrenderStatus(int userId, TeamId team, uint reason, byte yesVotes, byte noVotes)
         {
             var surrenderStatus = new S2C_TeamSurrenderStatus()
             {
@@ -250,7 +250,7 @@ namespace PacketDefinitions420
                 AgainstVote = noVotes,
                 TeamID = (uint)team,
             };
-            _packetHandlerManager.BroadcastPacketTeam(team, surrenderStatus.GetBytes(), Channel.CHL_S2C);
+            _packetHandlerManager.SendPacket(userId, surrenderStatus.GetBytes(), Channel.CHL_S2C);
         }
 
         public void NotifyCanSurrender(bool can, TeamId team)

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -225,11 +225,41 @@ namespace PacketDefinitions420
             _packetHandlerManager.UnpauseGame();
         }
 
-        public void NotifySurrender(IChampion starter, byte flag, byte yesVotes, byte noVotes, byte maxVotes, TeamId team,
-            float timeOut)
+        public void NotifySurrender(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, TeamId team, float timeOut)
         {
-            var surrender = new Surrender(starter, flag, yesVotes, noVotes, maxVotes, team, timeOut);
-            _packetHandlerManager.BroadcastPacketTeam(team, surrender, Channel.CHL_S2C);
+            var surrender = new S2C_TeamSurrenderVote()
+            {
+                PlayerNetID = starter.NetId,
+                OpenVoteMenu = open,
+                VoteYes = votedYes,
+                ForVote = yesVotes,
+                AgainstVote = noVotes,
+                NumPlayers = maxVotes,
+                TeamID = (uint)team,
+                TimeOut = timeOut,
+            };
+            _packetHandlerManager.BroadcastPacketTeam(team, surrender.GetBytes(), Channel.CHL_S2C);
+        }
+
+        public void NotifySurrenderStatus(uint reason, byte yesVotes, byte noVotes, TeamId team)
+        {
+            var surrenderStatus = new S2C_TeamSurrenderStatus()
+            {
+                SurrenderReason = reason,
+                ForVote = yesVotes,
+                AgainstVote = noVotes,
+                TeamID = (uint)team,
+            };
+            _packetHandlerManager.BroadcastPacketTeam(team, surrenderStatus.GetBytes(), Channel.CHL_S2C);
+        }
+
+        public void NotifyCanSurrender(bool can, TeamId team)
+        {
+            var canSurrender = new S2C_SetCanSurrender()
+            {
+                CanSurrender = can
+            };
+            _packetHandlerManager.BroadcastPacketTeam(team, canSurrender.GetBytes(), Channel.CHL_S2C );
         }
 
         public void NotifyGameStart()

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -241,11 +241,11 @@ namespace PacketDefinitions420
             _packetHandlerManager.BroadcastPacketTeam(starter.Team, surrender.GetBytes(), Channel.CHL_S2C);
         }
 
-        public void NotifySurrenderStatus(int userId, TeamId team, uint reason, byte yesVotes, byte noVotes)
+        public void NotifySurrenderStatus(int userId, TeamId team, SurrenderReason reason, byte yesVotes, byte noVotes)
         {
             var surrenderStatus = new S2C_TeamSurrenderStatus()
             {
-                SurrenderReason = reason,
+                SurrenderReason = (uint)reason,
                 ForVote = yesVotes,
                 AgainstVote = noVotes,
                 TeamID = (uint)team,

--- a/PacketDefinitions420/PacketReader.cs
+++ b/PacketDefinitions420/PacketReader.cs
@@ -1,5 +1,7 @@
 ﻿using GameServerCore.Packets.Enums;
 using GameServerCore.Packets.PacketDefinitions.Requests;
+using LeaguePackets;
+using LeaguePackets.Game;
 using PacketDefinitions420.Enums;
 using PacketDefinitions420.PacketDefinitions;
 using PacketDefinitions420.PacketDefinitions.C2S;
@@ -73,7 +75,8 @@ namespace PacketDefinitions420
         [PacketType(PacketCmd.PKT_C2S_SURRENDER)]
         public static SurrenderRequest ReadSurrenderRequest(byte[] data)
         {
-            return new SurrenderRequest();
+            var rq = (C2S_TeamSurrenderVote)GamePacket.Create( data);
+            return new SurrenderRequest(rq.VotedYes);
         }
         [PacketType(PacketCmd.PKT_UNPAUSE_GAME)]
         public static UnpauseRequest ReadUnpauseRequest(byte[] data)


### PR DESCRIPTION
Allows for surrendering, with configuration for time until surrender, time between unsuccessful surrenders, and surrender duration, on a per-map basis.

I implemented this on Summoner's Rift, with (what I believe to be) the correct values. (20 minutes until surrender, 5 minutes between each surrender, 30 second duration)

Unimplemented is the surrender UI button on the escape menu, however you can still use /ff or any alias.

Uses LeaguePackets where possible.

Probably a few style issues, so please do make amends where needed.