### PR TITLE
Resolve #881 -- Projectiles use their own spell data

### DIFF
--- a/GameServerLib/GameObjects/Spells/Spell.cs
+++ b/GameServerLib/GameObjects/Spells/Spell.cs
@@ -259,25 +259,31 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
 
         public void AddProjectileTarget(string nameMissile, ITarget target, bool isServerOnly = false)
         {
+            ISpellData projectileSpellData = this._game.Config.ContentManager.GetSpellData(nameMissile);
+
             var p = new Projectile(
                 _game,
                 Owner.X,
                 Owner.Y,
-                (int)SpellData.LineWidth,
+                (int)projectileSpellData.LineWidth,
                 Owner,
                 target,
                 this,
-                SpellData.MissileSpeed,
+                projectileSpellData.MissileSpeed,
                 nameMissile,
-                SpellData.Flags,
+                projectileSpellData.Flags,
                 _futureProjNetId
             );
+
             Projectiles.Add(p.NetId, p);
+
             _game.ObjectManager.AddObject(p);
+
             if (!isServerOnly)
             {
                 _game.PacketNotifier.NotifyMissileReplication(p);
             }
+
             _futureProjNetId = _networkIdManager.GetNewNetId();
         }
 

--- a/GameServerLib/GameObjects/Spells/Spell.cs
+++ b/GameServerLib/GameObjects/Spells/Spell.cs
@@ -228,26 +228,32 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
 
         public void AddProjectile(string nameMissile, float fromX, float fromY, float toX, float toY, bool isServerOnly = false)
         {
+            ISpellData projectileSpellData = this._game.Config.ContentManager.GetSpellData(nameMissile);
+
             var p = new Projectile(
                     _game,
                     fromX,
                     fromY,
-                    (int)SpellData.LineWidth,
+                    (int)projectileSpellData.LineWidth,
                     Owner,
                     new Target(toX, toY),
                     this,
-                    SpellData.MissileSpeed,
+                    projectileSpellData.MissileSpeed,
                     nameMissile,
-                    SpellData.Flags,
+                    projectileSpellData.Flags,
                     _futureProjNetId,
                     isServerOnly
                 );
+
             Projectiles.Add(p.NetId, p);
+
             _game.ObjectManager.AddObject(p);
+
             if (!isServerOnly)
             {
                 _game.PacketNotifier.NotifyMissileReplication(p);
             }
+
             _futureProjNetId = _networkIdManager.GetNewNetId();
         }
 


### PR DESCRIPTION
Projectiles were first using the origin spell's speed, width and flags. 

This is now changed so that the projectile uses it's own data.