### PR TITLE
Buffs should callback on remove #887

### DIFF
--- a/GameServerCore/Domain/IBuff.cs
+++ b/GameServerCore/Domain/IBuff.cs
@@ -13,6 +13,5 @@ namespace GameServerCore.Domain
         string Name { get; }
         byte Slot { get; }
         void ResetDuration();
-        bool Elapsed();
     }
 }

--- a/GameServerLib/GameObjects/Spells/Buff.cs
+++ b/GameServerLib/GameObjects/Spells/Buff.cs
@@ -13,7 +13,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
         public float Duration { get; private set; }
         protected float _movementSpeedPercentModifier;
         public float TimeElapsed { get; private set; }
-        protected bool _remove;
         public IObjAiBase TargetUnit { get; private set; }
         public IObjAiBase SourceUnit { get; private set; } // who added this buff to the unit it's attached to
         public BuffType BuffType { get; private set; }
@@ -24,11 +23,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
         protected bool _infiniteDuration;
 
         protected Game _game;
-
-        public bool Elapsed()
-        {
-            return _remove;
-        }
 
         public Buff(Game game, string buffName, float dur, byte stacks, BuffType buffType, IObjAiBase onto, IObjAiBase from, bool infiniteDuration = false)
         {
@@ -43,7 +37,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             StackCount = stacks;
             Name = buffName;
             TimeElapsed = 0;
-            _remove = false;
             TargetUnit = onto;
             SourceUnit = from;
             BuffType = buffType;
@@ -68,7 +61,12 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             {
                 if (TimeElapsed >= Duration)
                 {
-                    _remove = true;
+                    if (Name != "")
+                    {
+                        _game.PacketNotifier.NotifyRemoveBuff(TargetUnit, Name, Slot);
+                    }
+
+                    TargetUnit.RemoveBuff(this);
                 }
             }
         }

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -136,18 +136,7 @@ namespace LeagueSandbox.GameServer
                 {
                     var tempBuffs = ai.GetBuffs();
                     foreach (var buff in tempBuffs.Values)
-                    {
-                        if (buff.Elapsed())
-                        {
-                            if (buff.Name != "")
-                            {
-                                _game.PacketNotifier.NotifyRemoveBuff(buff.TargetUnit, buff.Name, buff.Slot);
-                            }
-
-                            ai.RemoveBuff(buff);
-                            continue;
-                        }
-
+                    {                       
                         buff.Update(diff);
                     }
                 }


### PR DESCRIPTION
Hi,

I didn't see how callbacks would help since there still needs to be a loop over all buffs to update them.

But, I've removed checks for `Elapsed` and buffs will now remove themselves - all necessary references were already in place.

Let me know if it's OK for you.