### PR TITLE
Resolve #862 

### DIFF
--- a/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
+++ b/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
@@ -39,17 +39,14 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         //Takes about 300 milliseconds for a single script
         public bool Load(List<string> scriptLocations)
         {
-            var treeList = new List<SyntaxTree>();
+            var treeList = new SyntaxTree[scriptLocations.Count];
             Parallel.For(0, scriptLocations.Count, i =>
             {
                 using (var sr = new StreamReader(scriptLocations[i]))
                 {
                     // Read the stream to a string, and write the string to the console.
                     var syntaxTree = CSharpSyntaxTree.ParseText(sr.ReadToEnd(), null, scriptLocations[i]);
-                    lock (treeList)
-                    {
-                        treeList.Add(syntaxTree);
-                    }
+                    treeList[i] = syntaxTree;
                 }
             });
             var assemblyName = Path.GetRandomFileName();

--- a/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
+++ b/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
@@ -16,7 +16,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
     {
         private readonly ILog _logger;
         private List<Assembly> _scriptAssembly = new List<Assembly>();
-        private Dictionary<string, Type> types = new Dictionary<string, Type>();
+        private readonly Dictionary<string, Type> types = new Dictionary<string, Type>();
 
         public CSharpScriptEngine()
         {


### PR DESCRIPTION
#862 

1) Remove lock.
2) Add cache for types 
testing on:
```
           c = new CSharpScriptEngine();
            c.LoadSubdirectoryScripts(@"L:\Development\hack\Cake.Issues.GitRepository");
            c.LoadSubdirectoryScripts(@"L:\Development\hack\Cake.Issues.Reporting.Generic");
            c.LoadSubdirectoryScripts(@"L:\Development\hack\GameServer\GameServerLib");
            c.LoadSubdirectoryScripts(@"L:\Development\hack\GameServer\GameServerCore");
```
Total 381 classes.

```
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
Intel Core i5-4690 CPU 3.50GHz (Haswell), 1 CPU, 4 logical and 4 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4018.0), X86 LegacyJIT
  DefaultJob : .NET Framework 4.8 (4.8.4018.0), X86 LegacyJIT
```

| Method |     Mean |    Error |   StdDev | Rank |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|------- |---------:|---------:|---------:|-----:|-----------:|----------:|----------:|----------:|
|    Old | 908.8 ms | 18.12 ms | 24.80 ms |    1 | 17000.0000 | 7000.0000 | 2000.0000 |  82.07 MB |
|    New | 923.0 ms | 18.27 ms | 20.31 ms |    1 | 15000.0000 | 6000.0000 | 1000.0000 |  81.32 MB |

Get Object `c1.CreateObject<object>("LeagueSandbox.GameServer", "Config")`

```
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
Intel Core i5-4690 CPU 3.50GHz (Haswell), 1 CPU, 4 logical and 4 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4018.0), X86 LegacyJIT
  DefaultJob : .NET Framework 4.8 (4.8.4018.0), X86 LegacyJIT
```

| Method |       Mean |    Error |   StdDev | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |-----------:|---------:|---------:|-----:|-------:|------:|------:|----------:|
|    Old | 3,064.7 ns | 59.52 ns | 61.12 ns |    2 | 0.1335 |     - |     - |     429 B |
|    New |   207.0 ns |  3.32 ns |  3.10 ns |    1 | 0.0637 |     - |     - |     200 B |

Plan B.  We can use "lazy". 