### PR TITLE
Resolve #903 -- Fix server crash while other client is open

### DIFF
--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -286,8 +286,7 @@ namespace PacketDefinitions420
                 _playersConnected++;
 
             }
-
-            if (_peers.ContainsKey(request.PlayerID))
+            else
             {
                 return false;
             }

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -274,6 +274,7 @@ namespace PacketDefinitions420
             // TODO: keys for every player
             ulong playerID = (ulong)_blowfish.Decrypt(request.CheckId);
 
+            // Wrong Blowfish key, or the client is already connected
             if (request.PlayerID != playerID || _peers.ContainsKey(request.PlayerID))
             {
                 return false;
@@ -290,6 +291,7 @@ namespace PacketDefinitions420
 
             bool result = true;
 
+            // inform players about their player numbers
             foreach (var player in _peers.Keys.ToArray())
             {
                 var response = new KeyCheckResponse(player, _playerClient[player]);
@@ -297,6 +299,7 @@ namespace PacketDefinitions420
                 result = result && SendPacket((int)request.PlayerID, response.GetBytes(), Channel.CHL_HANDSHAKE);
             }
 
+            // only if all packets were sent successfully return true
             return result;
         }
     }

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -230,7 +230,7 @@ namespace PacketDefinitions420
             {
                 //TODO: improve dictionary reverse search
                 ulong playerId = _peers.First(x => x.Value.Address.Equals(peer.Address)).Key;
-                dynamic req = convertor(data);        
+                dynamic req = convertor(data);
                 // TODO: fix all to use ulong
                 _netReq.OnMessage((int)playerId, req);
                 return true;
@@ -286,6 +286,12 @@ namespace PacketDefinitions420
                 _playersConnected++;
 
             }
+
+            if (_peers.ContainsKey(request.PlayerID))
+            {
+                return false;
+            }
+
             _peers[request.PlayerID] = peer;
 
             bool result = true;


### PR DESCRIPTION
_peers now first checks if the request.PlayerId already exists in HandleHandshake and returns to prevent the server from crashing.