### PR TITLE
Object Hash Function

### DIFF
--- a/GameServerCore/Content/HashFunctions.cs
+++ b/GameServerCore/Content/HashFunctions.cs
@@ -23,19 +23,7 @@ namespace GameServerCore.Content
 
         public static uint HashStringSdbm(string section, string name)
         {
-            uint hash = 0;
-            foreach (var c in section)
-            {
-                hash = char.ToLower(c) + 65599 * hash;
-            }
-
-            hash = char.ToLower('*') + 65599 * hash;
-            foreach (var c in name)
-            {
-                hash = char.ToLower(c) + 65599 * hash;
-            }
-
-            return hash;
+            return HashStringNorm(section + '*' + name);
         }
 
         public static uint HashStringNorm(string str)

--- a/GameServerCore/Content/HashFunctions.cs
+++ b/GameServerCore/Content/HashFunctions.cs
@@ -37,5 +37,17 @@ namespace GameServerCore.Content
 
             return hash;
         }
+
+        public static uint HashStringNorm(string str)
+        {
+            uint hash = 0;
+
+            for (var i = 0; i < str.Length; i++)
+            {
+                hash = char.ToLower(str[i]) + 65599 * hash;
+            }
+
+            return hash;
+        }
     }
 }

--- a/GameServerCore/Domain/GameObjects/IChampion.cs
+++ b/GameServerCore/Domain/GameObjects/IChampion.cs
@@ -16,7 +16,6 @@ namespace GameServerCore.Domain.GameObjects
 
         // basic
         void UpdateSkin(int skinNo);
-        int GetChampionHash();
         void StopChampionMovement();
         bool CanMove();
         void UpdateMoveOrder(MoveOrder order);

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -24,6 +24,7 @@ namespace GameServerCore.Domain.GameObjects
         void RemoveStatModifier(IStatsModifier statModifier);
         void SetTargetUnit(IAttackableUnit target);
         void AutoAttackHit(IAttackableUnit target);
+        int GetObjHash();
 
         // buffs
         bool HasBuffGameScriptActive(string buffNamespace, string buffClass);

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -24,7 +24,7 @@ namespace GameServerCore.Domain.GameObjects
         void RemoveStatModifier(IStatsModifier statModifier);
         void SetTargetUnit(IAttackableUnit target);
         void AutoAttackHit(IAttackableUnit target);
-        int GetObjHash();
+        uint GetObjHash();
 
         // buffs
         bool HasBuffGameScriptActive(string buffNamespace, string buffClass);

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -367,40 +367,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             TeleportTo(spawnPos.X, spawnPos.Y);
         }
 
-        public int GetChampionHash()
-        {
-            var szSkin = "";
-
-            if (Skin < 10)
-            {
-                szSkin = "0" + Skin;
-            }
-            else
-            {
-                szSkin = Skin.ToString();
-            }
-
-            var hash = 0;
-            var gobj = "[Character]";
-
-            for (var i = 0; i < gobj.Length; i++)
-            {
-                hash = char.ToLower(gobj[i]) + 0x1003F * hash;
-            }
-
-            for (var i = 0; i < Model.Length; i++)
-            {
-                hash = char.ToLower(Model[i]) + 0x1003F * hash;
-            }
-
-            for (var i = 0; i < szSkin.Length; i++)
-            {
-                hash = char.ToLower(szSkin[i]) + 0x1003F * hash;
-            }
-
-            return hash;
-        }
-
         public bool LevelUp()
         {
             var stats = Stats;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using GameMaths.Geometry.Polygons;
 using GameServerCore;
+using GameServerCore.Content;
 using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
@@ -677,45 +678,26 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             IsDashing = state;
         }
 
-        public int GetObjHash()
+        public uint GetObjHash()
         {
-            var hash = 0;
-            var gobj = "[Character]";
+            var gobj = "[Character]" + Model;
 
-            for (var i = 0; i < gobj.Length; i++)
-            {
-                hash = char.ToLower(gobj[i]) + 0x1003F * hash;
-            }
-
-            for (var i = 0; i < Model.Length; i++)
-            {
-                hash = char.ToLower(Model[i]) + 0x1003F * hash;
-            }
-
-            if (this is IChampion || this is IMinion)
+            // TODO: Account for any other units that have skins (requires skins to be implemented for those units)
+            if (this is IChampion c)
             {
                 var szSkin = "";
-
-                if (this is IChampion c)
+                if (c.Skin < 10)
                 {
-                    if (c.Skin < 10)
-                    {
-                        szSkin = "0" + c.Skin;
-                    }
-                    else
-                    {
-                        szSkin = c.Skin.ToString();
-                    }
+                    szSkin = "0" + c.Skin;
                 }
-                // TODO: Account for Skin of Minions
-
-                for (var i = 0; i < szSkin.Length; i++)
+                else
                 {
-                    hash = char.ToLower(szSkin[i]) + 0x1003F * hash;
+                    szSkin = c.Skin.ToString();
                 }
+                gobj += szSkin;
             }
 
-            return hash;
+            return HashFunctions.HashStringNorm(gobj);
         }
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -676,5 +676,46 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             IsDashing = state;
         }
+
+        public int GetObjHash()
+        {
+            var hash = 0;
+            var gobj = "[Character]";
+
+            for (var i = 0; i < gobj.Length; i++)
+            {
+                hash = char.ToLower(gobj[i]) + 0x1003F * hash;
+            }
+
+            for (var i = 0; i < Model.Length; i++)
+            {
+                hash = char.ToLower(Model[i]) + 0x1003F * hash;
+            }
+
+            if (this is IChampion || this is IMinion)
+            {
+                var szSkin = "";
+
+                if (this is IChampion c)
+                {
+                    if (c.Skin < 10)
+                    {
+                        szSkin = "0" + c.Skin;
+                    }
+                    else
+                    {
+                        szSkin = c.Skin.ToString();
+                    }
+                }
+                // TODO: Account for Skin of Minions
+
+                for (var i = 0; i < szSkin.Length; i++)
+                {
+                    hash = char.ToLower(szSkin[i]) + 0x1003F * hash;
+                }
+            }
+
+            return hash;
+        }
     }
 }

--- a/PacketDefinitions420/PacketDefinitions/S2C/CastSpellResponse.cs
+++ b/PacketDefinitions420/PacketDefinitions/S2C/CastSpellResponse.cs
@@ -19,7 +19,7 @@ namespace PacketDefinitions420.PacketDefinitions.S2C
             Write(1.0f); // attackSpeedMod
             WriteNetId(s.Owner);
             WriteNetId(s.Owner);
-            Write((int)s.Owner.GetChampionHash());
+            Write((int)s.Owner.GetObjHash());
             Write((uint)futureProjNetId); // The projectile ID that will be spawned
             Write((float)x);
             Write((float)navGrid.GetHeightAtLocation(x, y));

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -561,7 +561,7 @@ namespace PacketDefinitions420
             cast.CasterNetID = p.OriginSpell != null ? p.OriginSpell.Owner.NetId : p.Owner.NetId;
             //TODO: Implement spell chains
             cast.SpellChainOwnerNetID = p.OriginSpell != null ? p.OriginSpell.Owner.NetId : p.Owner.NetId; // TODO: Implement spell chains
-            cast.PackageHash = p.OriginSpell != null ? (uint)(p.Owner as IObjAiBase).GetObjHash() : 0;
+            cast.PackageHash = p.OriginSpell != null ? (p.Owner as IObjAiBase).GetObjHash() : 0;
             cast.MissileNetID = p.NetId;
             // Not sure if we want to add height for these, but i did it anyway
             cast.TargetPosition = new Vector3(p.Target.X, _navGrid.GetHeightAtLocation(p.Target.X, p.Target.Y), p.Target.Y);
@@ -690,7 +690,7 @@ namespace PacketDefinitions420
             var fxGroupData1 = new FXCreateGroupData();
             if (particle.Owner is IObjAiBase o)
             {
-                fxGroupData1.PackageHash = (uint)o.GetObjHash();
+                fxGroupData1.PackageHash = o.GetObjHash();
             }
             else
             {

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -546,11 +546,11 @@ namespace PacketDefinitions420
             misPacket.StartPoint = new Vector3(p.X, p.GetZ(), p.Y);
             misPacket.EndPoint = new Vector3(p.Target.X, _navGrid.GetHeightAtLocation(p.Target.X, p.Target.Y), p.Target.Y);
             misPacket.UnitPosition = new Vector3(p.Owner.X, p.Owner.GetZ(), p.Owner.Y);
-            misPacket.TimeFromCreation = 0f; // Unsure of a use for this
+            misPacket.TimeFromCreation = 0f; // TODO: Unhardcode
             misPacket.Speed = p.GetMoveSpeed();
-            misPacket.LifePercentage = 0f; // Unsure of a use for this
+            misPacket.LifePercentage = 0f; // TODO: Unhardcode
             //TODO: Implement time limited projectiles
-            misPacket.TimedSpeedDelta = 0f; // Likely for time limited projectiles, implement this
+            misPacket.TimedSpeedDelta = 0f; // TODO: Implement time limited projectiles for this
             misPacket.TimedSpeedDeltaTime = 0x7F7FFFFF; // Same as above (this value is from the SpawnProjectile packet, it is a placeholder)
             misPacket.Bounced = false; //TODO: Implement bouncing projectiles
             var cast = new CastInfo();
@@ -560,8 +560,8 @@ namespace PacketDefinitions420
             cast.AttackSpeedModifier = 1.0f; // Unsure of a use for this
             cast.CasterNetID = p.OriginSpell != null ? p.OriginSpell.Owner.NetId : p.Owner.NetId;
             //TODO: Implement spell chains
-            cast.SpellChainOwnerNetID = p.OriginSpell != null ? p.OriginSpell.Owner.NetId : p.Owner.NetId; // Might change in the future, spell chains not implemented
-            cast.PackageHash = p.OriginSpell != null ? (uint)(p.Owner as IChampion).GetChampionHash() : 0; // Probably incorrect, taken from SpawnProjectile packet
+            cast.SpellChainOwnerNetID = p.OriginSpell != null ? p.OriginSpell.Owner.NetId : p.Owner.NetId; // TODO: Implement spell chains
+            cast.PackageHash = p.OriginSpell != null ? (uint)(p.Owner as IObjAiBase).GetObjHash() : 0;
             cast.MissileNetID = p.NetId;
             // Not sure if we want to add height for these, but i did it anyway
             cast.TargetPosition = new Vector3(p.Target.X, _navGrid.GetHeightAtLocation(p.Target.X, p.Target.Y), p.Target.Y);
@@ -572,16 +572,16 @@ namespace PacketDefinitions420
                 var targets = new List<CastInfo.Target>();
                 var tar = new CastInfo.Target();
                 tar.UnitNetID = (p.Target as IAttackableUnit).NetId;
-                tar.HitResult = 0; // Not sure what to put here
+                tar.HitResult = 0; // TODO: Unhardcode
                 targets.Add(tar);
                 cast.Targets = targets;
             }
 
-            cast.DesignerCastTime = p.OriginSpell != null ? p.OriginSpell.CastTime : 1.0f; // Probably incorrect
-            cast.ExtraCastTime = 0f; // Unsure of a use for this
-            cast.DesignerTotalTime = p.OriginSpell != null ? p.OriginSpell.CastTime : 1.0f; // Probably incorrect
+            cast.DesignerCastTime = p.OriginSpell != null ? p.OriginSpell.CastTime : 1.0f; // TODO: Verify
+            cast.ExtraCastTime = 0f; // TODO: Unhardcode
+            cast.DesignerTotalTime = p.OriginSpell != null ? p.OriginSpell.CastTime : 1.0f; // TODO: Verify
             cast.Cooldown = p.OriginSpell != null ? p.OriginSpell.GetCooldown() : 0f;
-            cast.StartCastTime = p.OriginSpell != null ? p.OriginSpell.CastTime : 0f; // Probably incorrect, maybe channel time?
+            cast.StartCastTime = p.OriginSpell != null ? p.OriginSpell.CastTime : 0f; // TODO: Verify
 
             //TODO: Implement spell flags so these aren't set manually
             cast.IsAutoAttack = false;
@@ -688,7 +688,14 @@ namespace PacketDefinitions420
             // TODO: implement option for multiple particles instead of hardcoding one
             fxDataList.Add(fxData1);
             var fxGroupData1 = new FXCreateGroupData();
-            fxGroupData1.PackageHash = (uint)particle.Owner.GetChampionHash();
+            if (particle.Owner is IObjAiBase o)
+            {
+                fxGroupData1.PackageHash = (uint)o.GetObjHash();
+            }
+            else
+            {
+                fxGroupData1.PackageHash = 0; // TODO: Verify
+            }
             fxGroupData1.EffectNameHash = HashFunctions.HashString(particle.Name);
             //TODO: un-hardcode flags
             fxGroupData1.Flags = 0x20; // Taken from SpawnParticle packet


### PR DESCRIPTION
Replaces GetChampionHash in the Champion class with GetObjHash in the ObjAiBase class.
Meant to be for future ease of access when assigning PackageHash in packets.
Will likely need to be modified in the future to account for units besides Champions that have skins.