### PR TITLE
resolve #999 - crash when handling disconnect by abusing client

### DIFF
--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -244,7 +244,13 @@ namespace PacketDefinitions420
         public bool HandleDisconnect(Peer peer)
         {
             ulong playerId = _peers.FirstOrDefault(x => x.Value.Address.Equals(peer.Address)).Key;
-            var player = _game.PlayerManager.GetPlayers().Find(x => x.Item2.PlayerId == playerId).Item2;
+            var player = _game.PlayerManager.GetPlayers().Find(x => x.Item2.PlayerId == playerId)?.Item2;
+            if(player == null)
+            {
+                Debug.WriteLine($"prevented double disconnect of {playerId}");
+                return true;
+            }
+            
             var peerInfo = _game.PlayerManager.GetPeerInfo(player.PlayerId);
 
             if (peerInfo != null)

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -245,7 +245,7 @@ namespace PacketDefinitions420
         {
             ulong playerId = _peers.FirstOrDefault(x => x.Value.Address.Equals(peer.Address)).Key;
             var player = _game.PlayerManager.GetPlayers().Find(x => x.Item2.PlayerId == playerId)?.Item2;
-            if(player == null)
+            if (player == null)
             {
                 Debug.WriteLine($"prevented double disconnect of {playerId}");
                 return true;


### PR DESCRIPTION
This will fix a hard to reach crash :)

- added null check after find and abort disconnection
- added log message to keep track of this curios event (when this is caused unintentionally it's most likely a severe bug)

Refs #999 