### PR TITLE
[WIP] Buffs rework

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Aatrox/AatroxR.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Aatrox/AatroxR.cs
@@ -47,14 +47,14 @@ namespace AatroxR
                 StatsModifier.AttackSpeed.PercentBonus = (0.4f + (0.1f * (ownerSpell.Level - 1))) * buff.StackCount; // StackCount included here as an example
                 StatsModifier.Range.FlatBonus = 175f * buff.StackCount;
 
-                unit.AddStatModifier(StatsModifier);
+                unit.Stats.AddModifier(StatsModifier);
             }
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
             RemoveParticle(pmodel);
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/EzrealWBuff/EzrealWBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/EzrealWBuff/EzrealWBuff.cs
@@ -25,12 +25,12 @@ namespace EzrealWBuff
         {
             StatsModifier.AttackSpeed.PercentBonus = StatsModifier.AttackSpeed.PercentBonus + (0.15f + 0.05f * ownerSpell.Level);
 
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/HealSpeed/HealSpeed.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/HealSpeed/HealSpeed.cs
@@ -19,12 +19,12 @@ namespace HealSpeed
         public void OnActivate(IObjAiBase unit, IBuff buff, ISpell ownerSpell)
         {
             StatsModifier.MoveSpeed.PercentBonus = 0.3f;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/Highlander/Highlander.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Highlander/Highlander.cs
@@ -21,13 +21,13 @@ namespace Highlander
         {
             StatsModifier.MoveSpeed.PercentBonus = StatsModifier.MoveSpeed.PercentBonus + (15f + ownerSpell.Level * 10) / 100f;
             StatsModifier.AttackSpeed.PercentBonus = StatsModifier.AttackSpeed.PercentBonus + (5f + ownerSpell.Level * 25) / 100f;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
             // TODO: add immunity to slows
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         private void OnAutoAttack(IAttackableUnit target, bool isCrit)

--- a/Content/LeagueSandbox-Scripts/Buffs/LuluR/LuluR.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LuluR/LuluR.cs
@@ -28,7 +28,7 @@ namespace LuluR
             _healthBonus = 150 + 150 * ownerSpell.Level;
             StatsModifier.HealthPoints.BaseBonus = StatsModifier.HealthPoints.BaseBonus + 150 + 150 * ownerSpell.Level;
             unit.Stats.CurrentHealth = unit.Stats.CurrentHealth + 150 + 150 * ownerSpell.Level;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
@@ -36,7 +36,7 @@ namespace LuluR
             _healthNow = unit.Stats.CurrentHealth - _healthBonus;
             _meantimeDamage = _healthBefore - _healthNow;
             var bonusDamage = _healthBonus - _meantimeDamage;
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
             if (unit.Stats.CurrentHealth > unit.Stats.HealthPoints.Total)
             {
                 unit.Stats.CurrentHealth = unit.Stats.CurrentHealth - bonusDamage;

--- a/Content/LeagueSandbox-Scripts/Buffs/LuluWBuff/LuluWBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LuluWBuff/LuluWBuff.cs
@@ -20,13 +20,13 @@ namespace LuluWBuff
         {
             var ap = ownerSpell.Owner.Stats.AbilityPower.Total * 0.001;
             StatsModifier.MoveSpeed.PercentBonus = StatsModifier.MoveSpeed.PercentBonus + 0.3f + (float)ap;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
             var time = 2.5f + 0.5f * ownerSpell.Level;
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/LuluWDebuff/LuluWDebuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LuluWDebuff/LuluWDebuff.cs
@@ -25,7 +25,7 @@ namespace LuluWDebuff
             StatsModifier.MoveSpeed.BaseBonus = StatsModifier.MoveSpeed.BaseBonus - 60;
             unit.ApplyCrowdControl(_crowdDisarm);
             unit.ApplyCrowdControl(_crowdSilence);
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
             var time = 1 + 0.25f * ownerSpell.Level;
         }
 
@@ -33,7 +33,7 @@ namespace LuluWDebuff
         {
             unit.RemoveCrowdControl(_crowdDisarm);
             unit.RemoveCrowdControl(_crowdSilence);
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/Overdrive/Overdrive.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Overdrive/Overdrive.cs
@@ -23,14 +23,14 @@ namespace Overdrive
             //p = AddParticleTarget(unit, "Overdrive_buf.troy", unit, 1);
             StatsModifier.MoveSpeed.PercentBonus = StatsModifier.MoveSpeed.PercentBonus + (12f + ownerSpell.Level * 4) / 100f;
             StatsModifier.AttackSpeed.PercentBonus = StatsModifier.AttackSpeed.PercentBonus + (22f + 8f * ownerSpell.Level) / 100f;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
 
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
             //RemoveParticle(p);
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/OverdriveSlow/OverdriveSlow.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/OverdriveSlow/OverdriveSlow.cs
@@ -18,12 +18,12 @@ namespace OverdriveSlow
         public void OnActivate(IObjAiBase unit, IBuff buff, ISpell ownerSpell)
         {
             StatsModifier.MoveSpeed.PercentBonus = StatsModifier.MoveSpeed.PercentBonus - 0.3f;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/Quickdraw/Quickdraw.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Quickdraw/Quickdraw.cs
@@ -24,12 +24,12 @@ namespace Quickdraw
         public void OnActivate(IObjAiBase unit, IBuff buff, ISpell ownerSpell)
         {
             StatsModifier.AttackSpeed.PercentBonus = 0.2f + (0.1f * ownerSpell.Level);
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
     }
 }

--- a/Content/LeagueSandbox-Scripts/Buffs/Recall/Recall.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Recall/Recall.cs
@@ -3,6 +3,7 @@ using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using System;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
 namespace Recall
@@ -26,7 +27,7 @@ namespace Recall
             owner = champion;
             sourceBuff = buff;
 
-            _createdParticle = AddParticleTarget(champion, "TeleportHome.troy", champion);
+            _createdParticle = AddParticleTarget(champion, "TeleportHome.troy", champion, 1, "", default(System.Numerics.Vector3), 8.0f);
         }
 
         public void OnDeactivate(IObjAiBase unit)

--- a/Content/LeagueSandbox-Scripts/Buffs/Recall/Recall.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Recall/Recall.cs
@@ -32,11 +32,7 @@ namespace Recall
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            LogInfo("sourceBuff.TimeElapsed: " + sourceBuff.TimeElapsed);
-            if (sourceBuff.TimeElapsed >= sourceBuff.Duration)
-            {
-                owner.Recall();
-            }
+            owner.Recall();
             RemoveParticle(_createdParticle);
         }
 

--- a/Content/LeagueSandbox-Scripts/Buffs/SummonerExhaustDebuff/SummonerExhaustDebuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/SummonerExhaustDebuff/SummonerExhaustDebuff.cs
@@ -22,12 +22,12 @@ namespace SummonerExhaustDebuff
             StatsModifier.AttackSpeed.PercentBonus = -0.3f;
             StatsModifier.Armor.BaseBonus = -10;
             StatsModifier.MagicResist.BaseBonus = -10;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/SummonerHasteBuff/SummonerHasteBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/SummonerHasteBuff/SummonerHasteBuff.cs
@@ -19,12 +19,12 @@ namespace SummonerHasteBuff
         public void OnActivate(IObjAiBase unit, IBuff buff, ISpell ownerSpell)
         {
             StatsModifier.MoveSpeed.PercentBonus = 27 / 100.0f;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/SummonerReviveSpeedBoost/SummonerReviveSpeedBoost.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/SummonerReviveSpeedBoost/SummonerReviveSpeedBoost.cs
@@ -19,12 +19,12 @@ namespace SummonerReviveSpeedBoost
         public void OnActivate(IObjAiBase unit, IBuff buff, ISpell ownerSpell)
         {
             StatsModifier.MoveSpeed.PercentBonus = 1.25f;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/Taric/Radiance/Radiance-ally.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Taric/Radiance/Radiance-ally.cs
@@ -20,12 +20,12 @@ namespace Radiance_ally
         {
             StatsModifier.AttackDamage.FlatBonus += (10f + ownerSpell.Level * 20) / 2;
             StatsModifier.AbilityPower.FlatBonus += (10f + ownerSpell.Level * 20) / 2;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/Taric/Radiance/Radiance.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Taric/Radiance/Radiance.cs
@@ -20,12 +20,12 @@ namespace Radiance
         {
             StatsModifier.AttackDamage.FlatBonus += 10f + ownerSpell.Level * 20;
             StatsModifier.AbilityPower.FlatBonus += 10f + ownerSpell.Level * 20;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/YoumuusGhostblade/YoumuusGhostblade.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/YoumuusGhostblade/YoumuusGhostblade.cs
@@ -20,12 +20,12 @@ namespace YoumuusGhostblade
         {
             StatsModifier.MoveSpeed.PercentBonus = 0.2f;
             StatsModifier.AttackSpeed.PercentBonus = 0.4f;
-            unit.AddStatModifier(StatsModifier);
+            unit.Stats.AddModifier(StatsModifier);
         }
 
         public void OnDeactivate(IObjAiBase unit)
         {
-            unit.RemoveStatModifier(StatsModifier);
+            unit.Stats.RemoveModifier(StatsModifier);
         }
 
         public void OnUpdate(double diff)

--- a/Content/LeagueSandbox-Scripts/Champions/Global/Recall.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Global/Recall.cs
@@ -9,14 +9,18 @@ namespace Spells
 {
     public class Recall : IGameScript
     {
+        protected IBuff _buff;
+
         public void OnStartCasting(IObjAiBase owner, ISpell spell, IAttackableUnit target)
         {
         }
 
         public void OnFinishCasting(IObjAiBase owner, ISpell spell, IAttackableUnit target)
         {
-            // @TODO Interrupt the script when owner uses movement spells
-            AddBuff("Recall", 8.0f, 1, spell, owner, owner);
+            _buff = AddBuff("Recall", 8.0f, 1, spell, owner, owner);
+            ApiEventManager.OnChampionMove.AddListener(this, (IChampion)owner, _buff.DeactivateBuff);
+            ApiEventManager.OnChampionDamageTaken.AddListener(this, (IChampion)owner, _buff.DeactivateBuff);
+            ApiEventManager.OnChampionCrowdControlled.AddListener(this, (IChampion)owner, _buff.DeactivateBuff);
         }
 
         public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, IProjectile projectile)
@@ -29,13 +33,6 @@ namespace Spells
 
         public void OnActivate(IObjAiBase owner)
         {
-            ApiEventManager.OnChampionDamageTaken.AddListener(this, (IChampion)owner, () =>
-            {
-                if (HasBuff(owner, "Recall"))
-                {
-                    RemoveBuff(owner, "Recall");
-                }
-            });
         }
 
         public void OnDeactivate(IObjAiBase owner)

--- a/Content/LeagueSandbox-Scripts/Champions/Global/SummonerHeal.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Global/SummonerHeal.cs
@@ -47,7 +47,7 @@ namespace Spells
         private void PerformHeal(IObjAiBase owner, ISpell spell, IChampion target)
         {
             float healthGain = 75 + (target.Stats.Level * 15);
-            if (target.HasBuff("HealCheck"))
+            if (target.Buffs.Has("HealCheck"))
             {
                 healthGain *= 0.5f;
             }

--- a/Content/LeagueSandbox-Scripts/Champions/Taric/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Taric/R.cs
@@ -28,7 +28,7 @@ namespace Spells
         {
             var p1 = AddParticleTarget(owner, "TaricHammerSmash_nova.troy", owner);
             var p2 = AddParticleTarget(owner, "TaricHammerSmash_shatter.troy", owner);
-            var hasbuff = owner.HasBuff("Radiance");
+            var hasbuff = owner.Buffs.Has("Radiance");
             var ap = owner.Stats.AbilityPower.Total * 0.5f;
             var damage = 50 + spell.Level * 100 + ap;
 

--- a/Content/LeagueSandbox-Scripts/Champions/Yasuo/E.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Yasuo/E.cs
@@ -31,7 +31,7 @@ namespace Spells
             _target = (IObjAiBase)target;
             _owner = (IChampion)owner;
 
-            if (!_target.HasBuff("YasuoEBlock"))
+            if (!_target.Buffs.Has("YasuoEBlock"))
             {
                 AddBuff("YasuoE", 0.395f - spell.Level * 0.012f, 1, spell, _owner, _owner);            
                 AddBuff("YasuoEBlock", 11f - spell.Level * 1f, 1, spell, _target, _owner);

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -20,28 +20,16 @@ namespace GameServerCore.Domain.GameObjects
         bool IsMelee { get; set; }
         MoveOrder MoveOrder { get; }
         IAttackableUnit TargetUnit { get; set;  }
+        IBuffManager Buffs { get; }
 
-        void AddBuff(IBuff b);
-        void AddStatModifier(IStatsModifier statModifier);
+        
         void ApplyCrowdControl(ICrowdControl cc);
         void AutoAttackHit(IAttackableUnit target);
         void ChangeAutoAttackSpellData(string newAutoAttackSpellDataName);
         void ChangeAutoAttackSpellData(ISpellData newAutoAttackSpellData);
         void DashToTarget(ITarget t, float dashSpeed, float followTargetMaxDistance, float backDistance, float travelTime);
-        IBuff GetBuffWithName(string name);
-        int GetBuffsCount();
-        List<IBuff> GetBuffs();
-        List<IBuff> GetBuffsWithName(string buffName);
-        byte GetNewBuffSlot(IBuff b);
         uint GetObjHash();
-        bool HasBuff(IBuff buff);
-        bool HasBuff(string buffName);
-        void RemoveBuff(IBuff b);
-        void RemoveBuff(string b);
-        void RemoveBuffSlot(IBuff b);
-        void RemoveBuffsWithName(string buffName);
         void RemoveCrowdControl(ICrowdControl cc);
-        void RemoveStatModifier(IStatsModifier statModifier);
         void ResetAutoAttackSpellData();
         void SetDashingState(bool state);
         void SetTargetUnit(IAttackableUnit target);

--- a/GameServerCore/Domain/IBuff.cs
+++ b/GameServerCore/Domain/IBuff.cs
@@ -1,5 +1,6 @@
 ﻿using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
+using System.Collections.Generic;
 
 namespace GameServerCore.Domain
 {
@@ -23,5 +24,8 @@ namespace GameServerCore.Domain
         bool IsBuffSame(string buffName);
         void ResetTimeElapsed();
         void SetSlot(byte slot);
+
+        bool HasFlag(BuffFlag flag);
+        bool HasFlags(List<BuffFlag> flags);
     }
 }

--- a/GameServerCore/Domain/IBuffManager.cs
+++ b/GameServerCore/Domain/IBuffManager.cs
@@ -1,0 +1,46 @@
+﻿using GameServerCore.Domain.GameObjects;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GameServerCore.Domain
+{
+    public interface IBuffManager
+    {
+
+        /// <summary>
+        /// get buff count
+        /// </summary>
+        /// <returns>buff count</returns>
+        int Count();
+
+        void Add(IBuff buff);
+        void Add(List<IBuff> buffs);
+
+        List<IBuff> Get();
+        IBuff Get(string buffName);
+        IBuff Get(Predicate<IBuff> filter);
+
+        List<IBuff> GetAll(string buffName);
+        List<IBuff> GetAll(Predicate<IBuff> filter);
+
+        bool Has(string buffName);
+        bool Has(List<string> buffNames);
+        bool Has(IBuff buff);
+        bool Has(List<IBuff>buffs);
+        bool Has(Predicate<IBuff> buffFilter);
+        bool Has(List<Predicate<IBuff>> buffFilters);
+
+        void Remove(IBuff buff);
+        void Remove(string name);
+        void Remove(List<IBuff> buffs);
+        void Remove(Predicate<IBuff> buffFilter);
+        void Remove(List<Predicate<IBuff>> buffFilters);
+
+        byte GetSlot(IBuff buff);
+        void RemoveSlot(IBuff buff);
+
+        void AddStatModifier(IStatsModifier statModifier);
+        void RemoveStatModifier(IStatsModifier statModifier);
+    }
+}

--- a/GameServerCore/Domain/IBuffManager.cs
+++ b/GameServerCore/Domain/IBuffManager.cs
@@ -9,35 +9,140 @@ namespace GameServerCore.Domain
     {
 
         /// <summary>
-        /// get buff count
+        /// get the number of buffs
         /// </summary>
         /// <returns>buff count</returns>
         int Count();
 
+        /// <summary>
+        /// add a buff
+        /// </summary>
+        /// <param name="buff">buff to add</param>
         void Add(IBuff buff);
+
+        /// <summary>
+        /// add multiple buffs
+        /// </summary>
+        /// <param name="buffs">list of buffs</param>
         void Add(List<IBuff> buffs);
 
+        /// <summary>
+        /// get all buffs
+        /// </summary>
+        /// <returns>list of all buffs</returns>
         List<IBuff> Get();
+
+        /// <summary>
+        /// get a buff by name
+        /// </summary>
+        /// <param name="buffName">name of buff</param>
+        /// <returns>buff</returns>
         IBuff Get(string buffName);
+
+        /// <summary>
+        /// get a buff by filter
+        /// </summary>
+        /// <param name="filter">filter for buff</param>
+        /// <returns>buff</returns>
         IBuff Get(Predicate<IBuff> filter);
 
+        /// <summary>
+        /// get all buffs with name
+        /// </summary>
+        /// <param name="buffName">buff name</param>
+        /// <returns>buffs</returns>
         List<IBuff> GetAll(string buffName);
+
+        /// <summary>
+        /// get a filtered list of buffs
+        /// </summary>
+        /// <param name="filter">filter</param>
+        /// <returns>buffs</returns>
         List<IBuff> GetAll(Predicate<IBuff> filter);
 
+        /// <summary>
+        /// check if unit has buff
+        /// </summary>
+        /// <param name="buffName">name of buff to check</param>
+        /// <returns>unit has buff ?</returns>
         bool Has(string buffName);
+
+        /// <summary>
+        /// check if unit has buffs
+        /// </summary>
+        /// <param name="buffNames">list of buff names to check</param>
+        /// <returns>unit has buffs ?</returns>
         bool Has(List<string> buffNames);
+
+        /// <summary>
+        /// check if unit has buff
+        /// </summary>
+        /// <param name="buff">buff to check</param>
+        /// <returns>unít has buff ?</returns>
         bool Has(IBuff buff);
+
+        /// <summary>
+        /// check if unit has buffs
+        /// </summary>
+        /// <param name="buffs">buffs to check</param>
+        /// <returns>unit has buffs ?</returns>
         bool Has(List<IBuff>buffs);
+
+        /// <summary>
+        /// check if unit has buff
+        /// </summary>
+        /// <param name="buffFilter">predicate filter of buff</param>
+        /// <returns>unit has buff ?</returns>
         bool Has(Predicate<IBuff> buffFilter);
+
+        /// <summary>
+        /// check if unit has buffs
+        /// </summary>
+        /// <param name="buffFilters">predicate filters of buff</param>
+        /// <returns>unit has buffs ?</returns>
         bool Has(List<Predicate<IBuff>> buffFilters);
 
+        /// <summary>
+        /// remove buff from unit
+        /// </summary>
+        /// <param name="buff">buff to remove</param>
         void Remove(IBuff buff);
+
+        /// <summary>
+        /// remove buff from unit
+        /// </summary>
+        /// <param name="name">name of buff to remove</param>
         void Remove(string name);
+
+        /// <summary>
+        /// removes multiple buffs from unit
+        /// </summary>
+        /// <param name="buffs">buffs to remove</param>
         void Remove(List<IBuff> buffs);
+
+        /// <summary>
+        /// remove buff from unit
+        /// </summary>
+        /// <param name="buffFilter">predicate filter for buff</param>
         void Remove(Predicate<IBuff> buffFilter);
+
+        /// <summary>
+        /// remove buffs from unit
+        /// </summary>
+        /// <param name="buffFilters">predicate filters for buff</param>
         void Remove(List<Predicate<IBuff>> buffFilters);
 
-        byte GetSlot(IBuff buff);
+        /// <summary>
+        /// get slot of the buff or a new one
+        /// </summary>
+        /// <param name="buff">buff of slot</param>
+        /// <returns>slot of buff</returns>
+        byte GetSlot(IBuff buff = null);
+
+        /// <summary>
+        /// remove slot of the buff
+        /// </summary>
+        /// <param name="buff">buff to remove slot from</param>
         void RemoveSlot(IBuff buff);
     }
 }

--- a/GameServerCore/Domain/IBuffManager.cs
+++ b/GameServerCore/Domain/IBuffManager.cs
@@ -113,7 +113,7 @@ namespace GameServerCore.Domain
         /// remove buff from unit
         /// </summary>
         /// <param name="name">name of buff to remove</param>
-        void Remove(string name);
+        void Remove(string name, bool removeAll = false);
 
         /// <summary>
         /// removes multiple buffs from unit

--- a/GameServerCore/Domain/IBuffManager.cs
+++ b/GameServerCore/Domain/IBuffManager.cs
@@ -39,8 +39,5 @@ namespace GameServerCore.Domain
 
         byte GetSlot(IBuff buff);
         void RemoveSlot(IBuff buff);
-
-        void AddStatModifier(IStatsModifier statModifier);
-        void RemoveStatModifier(IStatsModifier statModifier);
     }
 }

--- a/GameServerCore/Domain/IBuffManager.cs
+++ b/GameServerCore/Domain/IBuffManager.cs
@@ -1,4 +1,5 @@
 ﻿using GameServerCore.Domain.GameObjects;
+using Priority_Queue;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -30,7 +31,7 @@ namespace GameServerCore.Domain
         /// get all buffs
         /// </summary>
         /// <returns>list of all buffs</returns>
-        List<IBuff> Get();
+        IEnumerable<IBuff> Get();
 
         /// <summary>
         /// get a buff by name
@@ -44,21 +45,27 @@ namespace GameServerCore.Domain
         /// </summary>
         /// <param name="filter">filter for buff</param>
         /// <returns>buff</returns>
-        IBuff Get(Predicate<IBuff> filter);
+        IBuff Get(Func<IBuff, bool> filter);
 
         /// <summary>
         /// get all buffs with name
         /// </summary>
         /// <param name="buffName">buff name</param>
         /// <returns>buffs</returns>
-        List<IBuff> GetAll(string buffName);
+        IEnumerable<IBuff> GetAll(string buffName);
 
         /// <summary>
         /// get a filtered list of buffs
         /// </summary>
         /// <param name="filter">filter</param>
         /// <returns>buffs</returns>
-        List<IBuff> GetAll(Predicate<IBuff> filter);
+        IEnumerable<IBuff> GetAll(Func<IBuff, bool> filter);
+
+        /// <summary>
+        /// get the buff priority queue
+        /// </summary>
+        /// <returns>buff priority queue</returns>
+        SimplePriorityQueue<IBuff> GetQueue();
 
         /// <summary>
         /// check if unit has buff
@@ -72,7 +79,7 @@ namespace GameServerCore.Domain
         /// </summary>
         /// <param name="buffNames">list of buff names to check</param>
         /// <returns>unit has buffs ?</returns>
-        bool Has(List<string> buffNames);
+        bool Has(IEnumerable<string> buffNames);
 
         /// <summary>
         /// check if unit has buff
@@ -86,21 +93,21 @@ namespace GameServerCore.Domain
         /// </summary>
         /// <param name="buffs">buffs to check</param>
         /// <returns>unit has buffs ?</returns>
-        bool Has(List<IBuff>buffs);
+        bool Has(IEnumerable<IBuff> buffs);
 
         /// <summary>
         /// check if unit has buff
         /// </summary>
         /// <param name="buffFilter">predicate filter of buff</param>
         /// <returns>unit has buff ?</returns>
-        bool Has(Predicate<IBuff> buffFilter);
+        bool Has(Func<IBuff, bool> buffFilter);
 
         /// <summary>
         /// check if unit has buffs
         /// </summary>
         /// <param name="buffFilters">predicate filters of buff</param>
         /// <returns>unit has buffs ?</returns>
-        bool Has(List<Predicate<IBuff>> buffFilters);
+        bool Has(IEnumerable<Func<IBuff, bool>> buffFilters);
 
         /// <summary>
         /// remove buff from unit
@@ -118,19 +125,19 @@ namespace GameServerCore.Domain
         /// removes multiple buffs from unit
         /// </summary>
         /// <param name="buffs">buffs to remove</param>
-        void Remove(List<IBuff> buffs);
+        void Remove(IEnumerable<IBuff> buffs);
 
         /// <summary>
         /// remove buff from unit
         /// </summary>
         /// <param name="buffFilter">predicate filter for buff</param>
-        void Remove(Predicate<IBuff> buffFilter);
+        void Remove(Func<IBuff, bool> buffFilter);
 
         /// <summary>
         /// remove buffs from unit
         /// </summary>
         /// <param name="buffFilters">predicate filters for buff</param>
-        void Remove(List<Predicate<IBuff>> buffFilters);
+        void Remove(IEnumerable<Func<IBuff, bool>> buffFilters);
 
         /// <summary>
         /// get slot of the buff or a new one

--- a/GameServerCore/Domain/IBuffManager.cs
+++ b/GameServerCore/Domain/IBuffManager.cs
@@ -143,8 +143,9 @@ namespace GameServerCore.Domain
         /// get slot of the buff or a new one
         /// </summary>
         /// <param name="buff">buff of slot</param>
+        /// <param name="createNewOne">should create a new slot ?</param>
         /// <returns>slot of buff</returns>
-        byte GetSlot(IBuff buff = null);
+        byte GetSlot(IBuff buff = null, bool createNewOne = false);
 
         /// <summary>
         /// remove slot of the buff

--- a/GameServerCore/Domain/IBuffManager.cs
+++ b/GameServerCore/Domain/IBuffManager.cs
@@ -25,7 +25,7 @@ namespace GameServerCore.Domain
         /// add multiple buffs
         /// </summary>
         /// <param name="buffs">list of buffs</param>
-        void Add(List<IBuff> buffs);
+        void Add(IEnumerable<IBuff> buffs);
 
         /// <summary>
         /// get all buffs
@@ -60,12 +60,6 @@ namespace GameServerCore.Domain
         /// <param name="filter">filter</param>
         /// <returns>buffs</returns>
         IEnumerable<IBuff> GetAll(Func<IBuff, bool> filter);
-
-        /// <summary>
-        /// get the buff priority queue
-        /// </summary>
-        /// <returns>buff priority queue</returns>
-        SimplePriorityQueue<IBuff, float> GetQueue();
 
         /// <summary>
         /// check if unit has buff
@@ -152,5 +146,11 @@ namespace GameServerCore.Domain
         /// </summary>
         /// <param name="buff">buff to remove slot from</param>
         void RemoveSlot(IBuff buff);
+
+        /// <summary>
+        /// removes elapsed buffs and updates current
+        /// </summary>
+        /// <param name="diff">time difference since last update</param>
+        void Update(float diff);
     }
 }

--- a/GameServerCore/Domain/IBuffManager.cs
+++ b/GameServerCore/Domain/IBuffManager.cs
@@ -65,7 +65,7 @@ namespace GameServerCore.Domain
         /// get the buff priority queue
         /// </summary>
         /// <returns>buff priority queue</returns>
-        SimplePriorityQueue<IBuff> GetQueue();
+        SimplePriorityQueue<IBuff, float> GetQueue();
 
         /// <summary>
         /// check if unit has buff

--- a/GameServerCore/Enums/BuffFlag.cs
+++ b/GameServerCore/Enums/BuffFlag.cs
@@ -1,0 +1,7 @@
+﻿namespace GameServerCore.Enums
+{
+    public enum BuffFlag
+    {
+        INTERRUPTED_BY_MOVEMENT
+    }
+}

--- a/GameServerCore/GameServerCore.csproj
+++ b/GameServerCore/GameServerCore.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="OptimizedPriorityQueue" Version="4.2.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -99,7 +99,7 @@ namespace LeagueSandbox.GameServer.API
 
             try
             {
-                buff = new Buff(_game, buffName, duration, stacks, originspell, onto, from, infiniteduration);
+                buff = new Buff(_game, buffName, duration, stacks, originspell, onto, from);
             }
             catch (ArgumentException exception)
             {
@@ -107,18 +107,18 @@ namespace LeagueSandbox.GameServer.API
                 return null;
             }
 
-            onto.AddBuff(buff);
+            onto.Buffs.Add(buff);
             return buff;
         }
 
         public static bool HasBuff(IObjAiBase unit, IBuff b)
         {
-            return unit.HasBuff(b);
+            return unit.Buffs.Has(b);
         }
 
         public static bool HasBuff(IObjAiBase unit, string b)
         {
-            return unit.HasBuff(b);
+            return unit.Buffs.Has(b);
         }
 
         public static void EditBuff(IBuff b, byte newStacks)
@@ -133,7 +133,7 @@ namespace LeagueSandbox.GameServer.API
 
         public static void RemoveBuff(IObjAiBase target, string buff)
         {
-            target.RemoveBuffsWithName(buff);
+            target.Buffs.Remove(buff);
         }
 
         public static IParticle AddParticle(IObjAiBase unit, string particle, float toX, float toY, float size = 1.0f, string bone = "", Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true)

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -58,7 +58,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             _itemManager = game.ItemManager;
             _scriptEngine = game.ScriptEngine;
-            Buffs = new BuffManager(game, this);
+            Buffs = new BuffManager(_game.PacketNotifier, this);
 
             CharData = _game.Config.ContentManager.GetCharData(Model);
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -8,6 +8,7 @@ using GameServerCore.Content;
 using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
+using GameServerLib.GameObjects.Spells;
 using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.Content;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.AnimatedBuildings;
@@ -57,6 +58,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             _itemManager = game.ItemManager;
             _scriptEngine = game.ScriptEngine;
+            Buffs = new BuffManager(game, this);
 
             CharData = _game.Config.ContentManager.GetCharData(Model);
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -25,7 +25,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         private float _autoAttackCurrentCooldown;
         private float _autoAttackCurrentDelay;
         private uint _autoAttackProjId;
-        private object _buffsLock;
         private List<ICrowdControl> _crowdControlList = new List<ICrowdControl>();
         private bool _isNextAutoCrit;
         protected ItemManager _itemManager;

--- a/GameServerLib/GameObjects/Spells/Buff.cs
+++ b/GameServerLib/GameObjects/Spells/Buff.cs
@@ -6,6 +6,7 @@ using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.Other;
+using System.Collections.Generic;
 
 namespace LeagueSandbox.GameServer.GameObjects.Spells
 {
@@ -27,8 +28,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
         protected Game _game;
         protected bool _remove;
         protected CSharpScriptEngine _scriptEngine;
+        protected List<BuffFlag> _flags;
 
-        public Buff(Game game, string buffName, float duration, int stacks, ISpell originspell, IObjAiBase onto, IObjAiBase from, bool infiniteDuration = false)
+        public Buff(Game game, string buffName, float duration, int stacks, ISpell originspell, IObjAiBase onto, IObjAiBase from, bool infiniteDuration = false, List<BuffFlag> flags = null)
         {
             if (duration < 0)
             {
@@ -39,6 +41,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             _game = game;
             _remove = false;
             _scriptEngine = game.ScriptEngine;
+            _flags = flags != null ? flags : new List<BuffFlag>();
 
             _buffGameScript = _scriptEngine.CreateObject<IBuffGameScript>(buffName, buffName);
 
@@ -61,16 +64,16 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             }
             Name = buffName;
             OriginSpell = originspell;
-            if (onto.HasBuff(Name) && BuffAddType == BuffAddType.STACKS_AND_OVERLAPS)
+            if (onto.Buffs.Has(Name) && BuffAddType == BuffAddType.STACKS_AND_OVERLAPS)
             {
                 // Put parent buff data into children buffs
-                StackCount = onto.GetBuffWithName(Name).StackCount;
-                Slot = onto.GetBuffWithName(Name).Slot;
+                StackCount = onto.Buffs.Get(Name).StackCount;
+                Slot = onto.Buffs.Get(Name).Slot;
             }
             else
             {
                 StackCount = stacks;
-                Slot = onto.GetNewBuffSlot(this);
+                Slot = onto.Buffs.GetSlot(this);
             }
             SourceUnit = from;
             TimeElapsed = 0;
@@ -138,6 +141,22 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
                     DeactivateBuff();
                 }
             }
+        }
+
+        public bool HasFlag(BuffFlag flag)
+        {
+            return _flags.Contains(flag);
+        }
+
+        public bool HasFlags(List<BuffFlag> flags)
+        {
+            foreach(var flag in flags)
+            {
+                if (!_flags.Contains(flag))
+                    return false;
+            }
+
+            return true;
         }
     }
 }

--- a/GameServerLib/GameObjects/Spells/Buff.cs
+++ b/GameServerLib/GameObjects/Spells/Buff.cs
@@ -7,6 +7,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.Other;
 using System.Collections.Generic;
+using Priority_Queue;
 
 namespace LeagueSandbox.GameServer.GameObjects.Spells
 {
@@ -30,7 +31,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
         protected CSharpScriptEngine _scriptEngine;
         protected List<BuffFlag> _flags;
 
-        public Buff(Game game, string buffName, float duration, int stacks, ISpell originspell, IObjAiBase onto, IObjAiBase from, bool infiniteDuration = false, List<BuffFlag> flags = null)
+        public Buff(Game game, string buffName, float duration, int stacks, ISpell originspell, IObjAiBase onto, IObjAiBase from, bool infiniteDuration = false, BuffFlag[] flags = null)
         {
             if (duration < 0)
             {
@@ -41,7 +42,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             _game = game;
             _remove = false;
             _scriptEngine = game.ScriptEngine;
-            _flags = flags != null ? flags : new List<BuffFlag>();
+            _flags = flags != null ? new List<BuffFlag>(flags) : new List<BuffFlag>();
 
             _buffGameScript = _scriptEngine.CreateObject<IBuffGameScript>(buffName, buffName);
 

--- a/GameServerLib/GameObjects/Spells/Buff.cs
+++ b/GameServerLib/GameObjects/Spells/Buff.cs
@@ -74,7 +74,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             else
             {
                 StackCount = stacks;
-                Slot = onto.Buffs.GetSlot(this);
+                Slot = onto.Buffs.GetSlot(this, true);
             }
             SourceUnit = from;
             TimeElapsed = 0;

--- a/GameServerLib/GameObjects/Spells/Buff.cs
+++ b/GameServerLib/GameObjects/Spells/Buff.cs
@@ -137,6 +137,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
                 {
                     _buffGameScript.OnUpdate(diff);
                 }
+                Console.WriteLine($"## TimeElapsed: {TimeElapsed}, Duration: {Duration}");
                 if (TimeElapsed >= Duration)
                 {
                     DeactivateBuff();

--- a/GameServerLib/GameObjects/Spells/Buff.cs
+++ b/GameServerLib/GameObjects/Spells/Buff.cs
@@ -131,16 +131,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             }
 
             TimeElapsed += diff / 1000.0f;
-            if (Math.Abs(Duration) > Extensions.COMPARE_EPSILON)
+            if(_buffGameScript != null)
             {
-                if (_buffGameScript != null)
-                {
-                    _buffGameScript.OnUpdate(diff);
-                }
-                if (TimeElapsed >= Duration)
-                {
-                    DeactivateBuff();
-                }
+                _buffGameScript.OnUpdate(diff);
             }
         }
 

--- a/GameServerLib/GameObjects/Spells/Buff.cs
+++ b/GameServerLib/GameObjects/Spells/Buff.cs
@@ -137,7 +137,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
                 {
                     _buffGameScript.OnUpdate(diff);
                 }
-                Console.WriteLine($"## TimeElapsed: {TimeElapsed}, Duration: {Duration}");
                 if (TimeElapsed >= Duration)
                 {
                     DeactivateBuff();

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -2,6 +2,7 @@
 using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
+using GameServerCore.Packets.Interfaces;
 using LeagueSandbox.GameServer;
 using LeagueSandbox.GameServer.GameObjects.Spells;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -19,12 +20,12 @@ namespace GameServerLib.GameObjects.Spells
     {
         private List<IBuff> _buffs;
         private IBuff[] _slots;
-        private Game _game;
+        IPacketNotifier _packetNotifier;
         private IObjAiBase _target;
 
-        public BuffManager(Game game, IObjAiBase target, IBuff[] initialBuffs = null)
+        public BuffManager(IPacketNotifier packetNotifier, IObjAiBase target, IBuff[] initialBuffs = null)
         {
-            _game = game;
+            _packetNotifier = packetNotifier;
             _target = target;
 
             _buffs = new List<IBuff>();
@@ -55,7 +56,7 @@ namespace GameServerLib.GameObjects.Spells
             // notify
             if (!buff.IsHidden)
             {
-                _game.PacketNotifier.NotifyNPC_BuffReplace(buff);
+                _packetNotifier.NotifyNPC_BuffReplace(buff);
             }
 
             buff.ActivateBuff();
@@ -68,7 +69,7 @@ namespace GameServerLib.GameObjects.Spells
 
             if (!buff.IsHidden)
             {
-                _game.PacketNotifier.NotifyNPC_BuffReplace(actualBuff);
+                _packetNotifier.NotifyNPC_BuffReplace(actualBuff);
             }
 
             _target.Stats.RemoveModifier(actualBuff.GetStatsModifier());
@@ -96,11 +97,11 @@ namespace GameServerLib.GameObjects.Spells
                 {
                     if (actualBuff.BuffType == BuffType.COUNTER)
                     {
-                        _game.PacketNotifier.NotifyNPC_BuffUpdateNumCounter(Get(buff.Name));
+                        _packetNotifier.NotifyNPC_BuffUpdateNumCounter(Get(buff.Name));
                     }
                     else
                     {
-                        _game.PacketNotifier.NotifyNPC_BuffUpdateCount(buff, buff.Duration, buff.TimeElapsed);
+                        _packetNotifier.NotifyNPC_BuffUpdateCount(buff, buff.Duration, buff.TimeElapsed);
                     }
                 }
 
@@ -117,11 +118,11 @@ namespace GameServerLib.GameObjects.Spells
                 {
                     if (buff.BuffType == BuffType.COUNTER)
                     {
-                        _game.PacketNotifier.NotifyNPC_BuffUpdateNumCounter(Get(buff.Name));
+                        _packetNotifier.NotifyNPC_BuffUpdateNumCounter(Get(buff.Name));
                     }
                     else
                     {
-                        _game.PacketNotifier.NotifyNPC_BuffUpdateCount(buff, buff.Duration, buff.TimeElapsed);
+                        _packetNotifier.NotifyNPC_BuffUpdateCount(buff, buff.Duration, buff.TimeElapsed);
                     }
                 }
 
@@ -142,11 +143,11 @@ namespace GameServerLib.GameObjects.Spells
             {
                 if (actualBuff.BuffType == BuffType.COUNTER)
                 {
-                    _game.PacketNotifier.NotifyNPC_BuffUpdateNumCounter(actualBuff);
+                    _packetNotifier.NotifyNPC_BuffUpdateNumCounter(actualBuff);
                 }
                 else
                 {
-                    _game.PacketNotifier.NotifyNPC_BuffUpdateCount(actualBuff, actualBuff.Duration, actualBuff.TimeElapsed);
+                    _packetNotifier.NotifyNPC_BuffUpdateCount(actualBuff, actualBuff.Duration, actualBuff.TimeElapsed);
                 }
             }
 
@@ -167,7 +168,7 @@ namespace GameServerLib.GameObjects.Spells
 
             if (!buff.IsHidden)
             {
-                _game.PacketNotifier.NotifyNPC_BuffAdd2(buff);
+                _packetNotifier.NotifyNPC_BuffAdd2(buff);
             }
 
             buff.ActivateBuff();
@@ -329,17 +330,17 @@ namespace GameServerLib.GameObjects.Spells
                 {
                     if (buff.BuffType == BuffType.COUNTER)
                     {
-                        _game.PacketNotifier.NotifyNPC_BuffUpdateNumCounter(Get(buff.Name));
+                        _packetNotifier.NotifyNPC_BuffUpdateNumCounter(Get(buff.Name));
                     }                        
                     else
                     {
                         if(buff.StackCount == 1)
                         {
-                            _game.PacketNotifier.NotifyNPC_BuffUpdateCount(newestBuff, buff.Duration - newestBuff.TimeElapsed, newestBuff.TimeElapsed);
+                            _packetNotifier.NotifyNPC_BuffUpdateCount(newestBuff, buff.Duration - newestBuff.TimeElapsed, newestBuff.TimeElapsed);
                         }
                         else
                         {
-                            _game.PacketNotifier.NotifyNPC_BuffUpdateCountGroup(_target, tempBuffs, buff.Duration - newestBuff.TimeElapsed, newestBuff.TimeElapsed);
+                            _packetNotifier.NotifyNPC_BuffUpdateCountGroup(_target, tempBuffs, buff.Duration - newestBuff.TimeElapsed, newestBuff.TimeElapsed);
                         }
                     }
                 }
@@ -352,7 +353,7 @@ namespace GameServerLib.GameObjects.Spells
 
                 if(!buff.IsHidden)
                 {
-                    _game.PacketNotifier.NotifyNPC_BuffRemove2(buff);
+                    _packetNotifier.NotifyNPC_BuffRemove2(buff);
                 }
             }
         }

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -15,7 +15,6 @@ namespace GameServerLib.GameObjects.Spells
 {
     class BuffManager : IBuffManager
     {
-        // TODO: maybe change to a List<IBuff> and access names per LINQ
         private Dictionary<string, IBuff> _buffs;
         private IBuff[] _slots;
         private Game _game;
@@ -39,15 +38,19 @@ namespace GameServerLib.GameObjects.Spells
         {
             var previousBuff = _buffs[buff.Name];
 
+            // remove old buff
             previousBuff.DeactivateBuff();
             Remove(buff);
             RemoveSlot(buff);
 
+            // replace old buff with new one in slots
             _slots[previousBuff.Slot] = buff;
             buff.SetSlot(previousBuff.Slot);
 
+            // add new buff
             _buffs.Add(buff.Name, buff);
 
+            // notify
             if (!buff.IsHidden)
             {
                 _game.PacketNotifier.NotifyNPC_BuffReplace(buff);

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -117,8 +117,6 @@ namespace GameServerLib.GameObjects.Spells
             }
             else
             {
-                buff.IncrementStackCount();
-                Console.WriteLine($"Add new stack of {buff.Name}. Current Stacks: {buff.StackCount}");
                 _buffQueue.Enqueue(buff, buff.Duration);
 
                 GetAll(buff.Name).ToList().ForEach(x => x.SetStacks(buff.StackCount));

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -306,7 +306,9 @@ namespace GameServerLib.GameObjects.Spells
 
         public void Remove(string buffName)
         {
-            _buffs.Where(x => x.IsBuffSame(buffName)).ToList().ForEach(x => { x.DeactivateBuff(); _buffs.Remove(x); });
+            //_buffs.Where(x => x.IsBuffSame(buffName)).ToList().ForEach(x => { x.DeactivateBuff(); _buffs.Remove(x); });
+            var buff = Get(buffName);
+            Remove(buff);
         }
 
         public void Remove(IBuff buff)
@@ -347,10 +349,11 @@ namespace GameServerLib.GameObjects.Spells
             }
             else
             {
-                _buffs.Where(buff => buff.Elapsed()).ToList().ForEach(x => _buffs.Remove(x));
+                _buffs.Where(buff => buff.Elapsed()).ToList().ForEach(x => { x.DeactivateBuff(); _buffs.Remove(x); });
                 Remove(buff.Name);
                 RemoveSlot(buff);
 
+                Console.WriteLine($"## removing buff {buff.Name}");
                 if(!buff.IsHidden)
                 {
                     _packetNotifier.NotifyNPC_BuffRemove2(buff);

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -222,17 +222,17 @@ namespace GameServerLib.GameObjects.Spells
 
         public IBuff Get(string buffName)
         {
-            return _buffQueue.Where(x => x.Name.Equals(buffName)).FirstOrDefault();
+            return _buffQueue.Where(x => x.Name.Equals(buffName)).First();
         }
 
         public IBuff Get(Func<IBuff, bool> filter)
         {
-            return _buffQueue.Where(filter).FirstOrDefault();
+            return _buffQueue.Where(filter).First();
         }
 
         public IEnumerable<IBuff> GetAll(string buffName)
         {
-            return _buffQueue.Where(buff => buff.IsBuffSame(buffName));
+            return _buffQueue.Where(buff => buff.Name.Equals(buffName));
         }
 
         public IEnumerable<IBuff> GetAll(Func<IBuff, bool> filter)
@@ -379,12 +379,21 @@ namespace GameServerLib.GameObjects.Spells
             }
         }
 
-        public byte GetSlot(IBuff buff = null)
+        public byte GetSlot(IBuff buff = null, bool createNew = false)
         {
+            IBuff tempBuff = null;
+            if(createNew)
+            {
+                tempBuff = buff;
+                buff = null;
+            }
+
             for (byte i = 1; i < _slots.Length; i++)
             {
                 if (_slots[i] == buff)
                 {
+                    if (createNew)
+                        _slots[i] = tempBuff;
                     return i;
                 }
             }

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -26,6 +26,9 @@ namespace GameServerLib.GameObjects.Spells
             _game = game;
             _target = target;
 
+            _buffs = new Dictionary<string, IBuff>();
+            _slots = new IBuff[256];
+
             if (initialBuffs != null)
             {
                 Add(initialBuffs.ToList());

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -18,7 +18,7 @@ namespace GameServerLib.GameObjects.Spells
     class BuffManager : IBuffManager
     {
         //private Dictionary<string, IBuff> _buffs;
-        private SimplePriorityQueue<IBuff, float> _buffQueue;
+        private List<IBuff> _buffQueue;
         private IBuff[] _slots;
         private Game _game;
         private IObjAiBase _target;
@@ -28,7 +28,7 @@ namespace GameServerLib.GameObjects.Spells
             _game = game;
             _target = target;
 
-            _buffQueue = new SimplePriorityQueue<IBuff, float>();
+            _buffQueue = new List<IBuff>();
             _slots = new IBuff[256];
 
             if (initialBuffs != null)
@@ -51,7 +51,7 @@ namespace GameServerLib.GameObjects.Spells
             buff.SetSlot(previousBuff.Slot);
 
             // add new buff
-            _buffQueue.Enqueue(buff, buff.Duration);
+            _buffQueue.Add(buff);
 
             // notify
             if (!buff.IsHidden)
@@ -91,7 +91,7 @@ namespace GameServerLib.GameObjects.Spells
                 tempBuffs = GetAll(buff.Name);
 
                 _slots[oldestBuff.Slot] = tempBuffs.First();
-                _buffQueue.Enqueue(actualBuff, tempBuffs.First().Duration);
+                _buffQueue.Add(actualBuff);
 
                 if (!buff.IsHidden)
                 {
@@ -160,11 +160,11 @@ namespace GameServerLib.GameObjects.Spells
             if(Has(buff.Name)) // TODO: is this realy needed ?
             {
                 var actualBuff = Get(buff.Name);
-                _buffQueue.Enqueue(actualBuff, actualBuff.Duration);
+                _buffQueue.Add(actualBuff);
                 return;
             }
 
-            _buffQueue.Enqueue(buff, buff.Duration);
+            _buffQueue.Add(buff);
 
             if (!buff.IsHidden)
             {
@@ -212,12 +212,12 @@ namespace GameServerLib.GameObjects.Spells
 
         public int Count()
         {
-            return _buffQueue.Count;
+            return _buffQueue.Count();
         }
 
         public IEnumerable<IBuff> Get()
         {
-            return _buffQueue.ToList();
+            return _buffQueue;
         }
 
         public IBuff Get(string buffName)
@@ -242,7 +242,11 @@ namespace GameServerLib.GameObjects.Spells
 
         public SimplePriorityQueue<IBuff, float> GetQueue()
         {
-            return _buffQueue;
+            var queue = new SimplePriorityQueue<IBuff, float>();
+            foreach (var buff in _buffQueue)
+                queue.Enqueue(buff, buff.Duration);
+
+            return queue;
         }
 
 
@@ -318,7 +322,7 @@ namespace GameServerLib.GameObjects.Spells
                 tempBuffs.ForEach(tempBuff => tempBuff.SetStacks(buff.StackCount));
 
                 _slots[buff.Slot] = tempBuffs[0];
-                _buffQueue.Enqueue(tempBuffs[0], tempBuffs[0].Duration);
+                _buffQueue.Add(tempBuffs[0]);
 
                 var newestBuff = tempBuffs.Last();
 

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -17,8 +17,7 @@ namespace GameServerLib.GameObjects.Spells
 {
     class BuffManager : IBuffManager
     {
-        //private Dictionary<string, IBuff> _buffs;
-        private List<IBuff> _buffQueue;
+        private List<IBuff> _buffs;
         private IBuff[] _slots;
         private Game _game;
         private IObjAiBase _target;
@@ -28,7 +27,7 @@ namespace GameServerLib.GameObjects.Spells
             _game = game;
             _target = target;
 
-            _buffQueue = new List<IBuff>();
+            _buffs = new List<IBuff>();
             _slots = new IBuff[256];
 
             if (initialBuffs != null)
@@ -51,7 +50,7 @@ namespace GameServerLib.GameObjects.Spells
             buff.SetSlot(previousBuff.Slot);
 
             // add new buff
-            _buffQueue.Add(buff);
+            _buffs.Add(buff);
 
             // notify
             if (!buff.IsHidden)
@@ -91,7 +90,7 @@ namespace GameServerLib.GameObjects.Spells
                 tempBuffs = GetAll(buff.Name);
 
                 _slots[oldestBuff.Slot] = tempBuffs.First();
-                _buffQueue.Add(actualBuff);
+                _buffs.Add(actualBuff);
 
                 if (!buff.IsHidden)
                 {
@@ -160,11 +159,11 @@ namespace GameServerLib.GameObjects.Spells
             if(Has(buff.Name)) // TODO: is this realy needed ?
             {
                 var actualBuff = Get(buff.Name);
-                _buffQueue.Add(actualBuff);
+                _buffs.Add(actualBuff);
                 return;
             }
 
-            _buffQueue.Add(buff);
+            _buffs.Add(buff);
 
             if (!buff.IsHidden)
             {
@@ -177,7 +176,7 @@ namespace GameServerLib.GameObjects.Spells
         public void Add(IBuff buff)
         {
             // add a new buff
-            if (_buffQueue.Where(x => x.Name.Equals(buff.Name)).Count() == 0)
+            if (_buffs.Where(x => x.Name.Equals(buff.Name)).Count() == 0)
             {
                 AddNew(buff);
             }
@@ -212,38 +211,38 @@ namespace GameServerLib.GameObjects.Spells
 
         public int Count()
         {
-            return _buffQueue.Count();
+            return _buffs.Count();
         }
 
         public IEnumerable<IBuff> Get()
         {
-            return _buffQueue;
+            return _buffs;
         }
 
         public IBuff Get(string buffName)
         {
-            return _buffQueue.Where(x => x.Name.Equals(buffName)).First();
+            return _buffs.Where(x => x.Name.Equals(buffName)).First();
         }
 
         public IBuff Get(Func<IBuff, bool> filter)
         {
-            return _buffQueue.Where(filter).First();
+            return _buffs.Where(filter).First();
         }
 
         public IEnumerable<IBuff> GetAll(string buffName)
         {
-            return _buffQueue.Where(buff => buff.Name.Equals(buffName));
+            return _buffs.Where(buff => buff.Name.Equals(buffName));
         }
 
         public IEnumerable<IBuff> GetAll(Func<IBuff, bool> filter)
         {
-            return _buffQueue.Where(filter);
+            return _buffs.Where(filter);
         }
 
         public SimplePriorityQueue<IBuff, float> GetQueue()
         {
             var queue = new SimplePriorityQueue<IBuff, float>();
-            foreach (var buff in _buffQueue)
+            foreach (var buff in _buffs)
                 queue.Enqueue(buff, buff.Duration);
 
             return queue;
@@ -252,7 +251,7 @@ namespace GameServerLib.GameObjects.Spells
 
         public bool Has(string buffName)
         {
-            return _buffQueue.Where(x => x.IsBuffSame(buffName)).Count() > 0;
+            return _buffs.Where(x => x.IsBuffSame(buffName)).Count() > 0;
         }
 
         public bool Has(IEnumerable<string> buffNames)
@@ -288,7 +287,7 @@ namespace GameServerLib.GameObjects.Spells
 
         public bool Has(Func<IBuff, bool> buffFilter)
         {
-            return _buffQueue.Where(buffFilter).Count() > 0;
+            return _buffs.Where(buffFilter).Count() > 0;
         }
 
         public bool Has(IEnumerable<Func<IBuff, bool>> buffFilters)
@@ -306,7 +305,7 @@ namespace GameServerLib.GameObjects.Spells
 
         public void Remove(string buffName)
         {
-            _buffQueue.Where(x => x.IsBuffSame(buffName)).ToList().ForEach(x => { x.DeactivateBuff(); _buffQueue.Remove(x); });
+            _buffs.Where(x => x.IsBuffSame(buffName)).ToList().ForEach(x => { x.DeactivateBuff(); _buffs.Remove(x); });
         }
 
         public void Remove(IBuff buff)
@@ -322,7 +321,7 @@ namespace GameServerLib.GameObjects.Spells
                 tempBuffs.ForEach(tempBuff => tempBuff.SetStacks(buff.StackCount));
 
                 _slots[buff.Slot] = tempBuffs[0];
-                _buffQueue.Add(tempBuffs[0]);
+                _buffs.Add(tempBuffs[0]);
 
                 var newestBuff = tempBuffs.Last();
 
@@ -347,7 +346,7 @@ namespace GameServerLib.GameObjects.Spells
             }
             else
             {
-                _buffQueue.Where(buff => buff.Elapsed()).ToList().ForEach(x => _buffQueue.Remove(x));
+                _buffs.Where(buff => buff.Elapsed()).ToList().ForEach(x => _buffs.Remove(x));
                 Remove(buff.Name);
                 RemoveSlot(buff);
 
@@ -368,7 +367,7 @@ namespace GameServerLib.GameObjects.Spells
 
         public void Remove(Func<IBuff, bool> buffFilter)
         {
-            var buffsToRemove = _buffQueue.Where(buffFilter);
+            var buffsToRemove = _buffs.Where(buffFilter);
 
             foreach (var buffToRemove in buffsToRemove)
             {

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -306,9 +306,7 @@ namespace GameServerLib.GameObjects.Spells
 
         public void Remove(string buffName)
         {
-            //_buffs.Where(x => x.IsBuffSame(buffName)).ToList().ForEach(x => { x.DeactivateBuff(); _buffs.Remove(x); });
-            var buff = Get(buffName);
-            Remove(buff);
+            _buffs.Where(x => x.IsBuffSame(buffName)).ToList().ForEach(x => { x.DeactivateBuff(); _buffs.Remove(x); });
         }
 
         public void Remove(IBuff buff)
@@ -349,11 +347,9 @@ namespace GameServerLib.GameObjects.Spells
             }
             else
             {
-                _buffs.Where(buff => buff.Elapsed()).ToList().ForEach(x => { x.DeactivateBuff(); _buffs.Remove(x); });
                 Remove(buff.Name);
                 RemoveSlot(buff);
 
-                Console.WriteLine($"## removing buff {buff.Name}");
                 if(!buff.IsHidden)
                 {
                     _packetNotifier.NotifyNPC_BuffRemove2(buff);

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -1,0 +1,372 @@
+﻿using GameServerCore;
+using GameServerCore.Domain;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Enums;
+using LeagueSandbox.GameServer;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using PacketDefinitions420.PacketDefinitions.S2C;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace GameServerLib.GameObjects.Spells
+{
+    class BuffManager : IBuffManager
+    {
+        // TODO: maybe change to a List<IBuff> and access names per LINQ
+        private Dictionary<string, IBuff> _buffs;
+        private IBuff[] _slots;
+        private Game _game;
+        private IObjAiBase _target;
+
+        public BuffManager(Game game, IObjAiBase target, IBuff[] initialBuffs = null)
+        {
+            _game = game;
+            _target = target;
+
+            if (initialBuffs != null)
+            {
+                Add(initialBuffs.ToList());
+            }
+        }
+
+        protected void Replace(IBuff buff)
+        {
+            var previousBuff = _buffs[buff.Name];
+
+            previousBuff.DeactivateBuff();
+            Remove(buff);
+            RemoveSlot(buff);
+
+            _slots[previousBuff.Slot] = buff;
+            buff.SetSlot(previousBuff.Slot);
+
+            _buffs.Add(buff.Name, buff);
+
+            if (!buff.IsHidden)
+            {
+                _game.PacketNotifier.NotifyNPC_BuffReplace(buff);
+            }
+
+            buff.ActivateBuff();
+        }
+
+        protected void Renew(IBuff buff)
+        {
+            _buffs[buff.Name].ResetTimeElapsed();
+
+            if (!buff.IsHidden)
+            {
+                _game.PacketNotifier.NotifyNPC_BuffReplace(_buffs[buff.Name]);
+            }
+
+            RemoveStatModifier(_buffs[buff.Name].GetStatsModifier());
+            _buffs[buff.Name].ActivateBuff();
+        }
+
+        protected void StackOverlap(IBuff buff)
+        {
+            if(_buffs[buff.Name].StackCount >= _buffs[buff.Name].MaxStacks)
+            {
+                var tempBuffs = GetAll(buff.Name);
+                var oldestBuff = tempBuffs[0];
+
+                oldestBuff.DeactivateBuff();
+                Remove(buff);
+                RemoveSlot(buff);
+
+                tempBuffs = GetAll(buff.Name);
+
+                _slots[oldestBuff.Slot] = tempBuffs[0];
+                _buffs.Add(oldestBuff.Name, tempBuffs[0]);
+
+                if (!buff.IsHidden)
+                {
+                    if (_buffs[buff.Name].BuffType == BuffType.COUNTER)
+                    {
+                        _game.PacketNotifier.NotifyNPC_BuffUpdateNumCounter(_buffs[buff.Name]);
+                    }
+                    else
+                    {
+                        _game.PacketNotifier.NotifyNPC_BuffUpdateCount(buff, buff.Duration, buff.TimeElapsed);
+                    }
+                }
+
+                buff.ActivateBuff();
+            }
+        }
+
+        protected void StackRenew(IBuff buff)
+        {
+            RemoveSlot(buff);
+
+            _buffs[buff.Name].ResetTimeElapsed();
+            _buffs[buff.Name].IncrementStackCount();
+
+            if (!buff.IsHidden)
+            {
+                if (_buffs[buff.Name].BuffType == BuffType.COUNTER)
+                {
+                    _game.PacketNotifier.NotifyNPC_BuffUpdateNumCounter(_buffs[buff.Name]);
+                }
+                else
+                {
+                    _game.PacketNotifier.NotifyNPC_BuffUpdateCount(_buffs[buff.Name], _buffs[buff.Name].Duration, _buffs[buff.Name].TimeElapsed);
+                }
+            }
+
+            RemoveStatModifier(_buffs[buff.Name].GetStatsModifier()); // TODO: Replace with a better method that unloads -> reloads all data of a script
+            _buffs[buff.Name].ActivateBuff();
+        }
+
+        protected void AddNew(IBuff buff)
+        {
+            if(Has(buff.Name)) // TODO: is this realy needed ?
+            {
+                var actualBuff = Get(buff.Name);
+                _buffs.Add(buff.Name, actualBuff);
+                return;
+            }
+
+            _buffs.Add(buff.Name, buff);
+
+            if (!buff.IsHidden)
+            {
+                _game.PacketNotifier.NotifyNPC_BuffAdd2(buff);
+            }
+
+            buff.ActivateBuff();
+        }
+
+        public void AddStatModifier(IStatsModifier statModifier)
+        {
+            _target.Stats.AddModifier(statModifier);
+        }
+
+        public void RemoveStatModifier(IStatsModifier statModifier)
+        {
+            _target.Stats.RemoveModifier(statModifier);
+        }
+
+        public void Add(IBuff buff)
+        {
+            // add a new buff
+            if (!_buffs.ContainsKey(buff.Name))
+            {
+                AddNew(buff);
+            }
+            // handle overbuffing
+            else
+            {
+                switch (buff.BuffAddType)
+                {
+                    case BuffAddType.REPLACE_EXISTING:
+                        Replace(buff);
+                        break;
+                    case BuffAddType.RENEW_EXISTING:
+                        Renew(buff);
+                        break;
+                    case BuffAddType.STACKS_AND_OVERLAPS:
+                        StackOverlap(buff);
+                        break;
+                    case BuffAddType.STACKS_AND_RENEWS:
+                        StackRenew(buff);
+                        break;
+                }
+            }
+        }
+
+        public void Add(List<IBuff> buffs)
+        {
+            foreach (IBuff buff in buffs)
+            {
+                Add(buff);
+            }
+        }
+
+        public int Count()
+        {
+            return _buffs.Count;
+        }
+
+        public List<IBuff> Get()
+        {
+            return _buffs.Values.ToList();
+        }
+
+        public IBuff Get(string buffName)
+        {
+            return _buffs[buffName];
+        }
+
+        public IBuff Get(Predicate<IBuff> filter)
+        {
+            return _buffs.Values.ToList().Find(filter);
+        }
+
+        public List<IBuff> GetAll(string buffName)
+        {
+            return _buffs.Values.ToList().FindAll(buff => buff.IsBuffSame(buffName));
+        }
+
+        public List<IBuff> GetAll(Predicate<IBuff> filter)
+        {
+            return _buffs.Values.ToList().FindAll(filter);
+        }
+
+        public byte GetSlot(IBuff buff = null)
+        {
+            for(byte i = 1; i < _slots.Length; i++)
+            {
+                if (_slots[i] == buff)
+                {
+                    return i;
+                }
+            }
+
+            throw new Exception($"No slot found with {buff.ToString()}");
+        }
+
+        public bool Has(string buffName)
+        {
+            return _buffs.Values.Where(x => x.IsBuffSame(buffName)).Count() > 0;
+        }
+
+        public bool Has(List<string> buffNames)
+        {
+            foreach (var buffName in buffNames)
+            {
+                if (!Has(buffName))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public bool Has(IBuff buff)
+        {
+            return Has(buff.Name);
+        }
+
+        public bool Has(List<IBuff> buffs)
+        {
+            foreach (var buff in buffs)
+            {
+                if (!Has(buff))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public bool Has(Predicate<IBuff> buffFilter)
+        {
+            return _buffs.Values.ToList().FindAll(buffFilter).Count > 0;
+        }
+
+        public bool Has(List<Predicate<IBuff>> buffFilters)
+        {
+            foreach (var filter in buffFilters)
+            {
+                if (!Has(filter))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public void Remove(IBuff buff)
+        {
+            if(buff.BuffAddType == BuffAddType.STACKS_AND_OVERLAPS && buff.StackCount > 1)
+            {
+                buff.DecrementStackCount();
+
+                Remove(buff.Name);
+                RemoveSlot(buff);
+
+                var tempBuffs = GetAll(buff.Name);
+                tempBuffs.ForEach(tempBuff => tempBuff.SetStacks(buff.StackCount));
+
+                _slots[buff.Slot] = tempBuffs[0];
+                _buffs.Add(buff.Name, tempBuffs[0]);
+
+                var newestBuff = tempBuffs[tempBuffs.Count - 1];
+
+                if (!buff.IsHidden)
+                {
+                    if (buff.BuffType == BuffType.COUNTER)
+                    {
+                        _game.PacketNotifier.NotifyNPC_BuffUpdateNumCounter(_buffs[buff.Name]);
+                    }                        
+                    else
+                    {
+                        if(buff.StackCount == 1)
+                        {
+                            _game.PacketNotifier.NotifyNPC_BuffUpdateCount(newestBuff, buff.Duration - newestBuff.TimeElapsed, newestBuff.TimeElapsed);
+                        }
+                        else
+                        {
+                            _game.PacketNotifier.NotifyNPC_BuffUpdateCountGroup(_target, tempBuffs, buff.Duration - newestBuff.TimeElapsed, newestBuff.TimeElapsed);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                _buffs.Values.ToList().RemoveAll(buff => buff.Elapsed());
+                Remove(buff.Name);
+                RemoveSlot(buff);
+
+                if(!buff.IsHidden)
+                {
+                    _game.PacketNotifier.NotifyNPC_BuffRemove2(buff);
+                }
+            }
+        }
+
+        public void Remove(string buffName)
+        {
+            _buffs.Remove(buffName);
+        }
+
+        public void Remove(List<IBuff> buffs)
+        {
+            foreach (var buff in buffs)
+            {
+                Remove(buff);
+            }
+        }
+
+        public void Remove(Predicate<IBuff> buffFilter)
+        {
+            var buffsToRemove = _buffs.Values.ToList().FindAll(buffFilter);
+
+            foreach (var buffToRemove in buffsToRemove)
+            {
+                Remove(buffToRemove);
+            }
+        }
+
+        public void Remove(List<Predicate<IBuff>> buffFilters)
+        {
+            foreach (var filter in buffFilters)
+            {
+                Remove(filter);
+            }
+        }
+
+        public void RemoveSlot(IBuff buff)
+        {
+            var slot = GetSlot(buff);
+            _slots[slot] = null;
+        }
+    }
+}

--- a/GameServerLib/GameObjects/Spells/BuffManager.cs
+++ b/GameServerLib/GameObjects/Spells/BuffManager.cs
@@ -62,7 +62,7 @@ namespace GameServerLib.GameObjects.Spells
                 _game.PacketNotifier.NotifyNPC_BuffReplace(_buffs[buff.Name]);
             }
 
-            RemoveStatModifier(_buffs[buff.Name].GetStatsModifier());
+            _target.Stats.RemoveModifier(_buffs[buff.Name].GetStatsModifier());
             _buffs[buff.Name].ActivateBuff();
         }
 
@@ -117,7 +117,7 @@ namespace GameServerLib.GameObjects.Spells
                 }
             }
 
-            RemoveStatModifier(_buffs[buff.Name].GetStatsModifier()); // TODO: Replace with a better method that unloads -> reloads all data of a script
+            _target.Stats.RemoveModifier(_buffs[buff.Name].GetStatsModifier()); // TODO: Replace with a better method that unloads -> reloads all data of a script
             _buffs[buff.Name].ActivateBuff();
         }
 
@@ -138,16 +138,6 @@ namespace GameServerLib.GameObjects.Spells
             }
 
             buff.ActivateBuff();
-        }
-
-        public void AddStatModifier(IStatsModifier statModifier)
-        {
-            _target.Stats.AddModifier(statModifier);
-        }
-
-        public void RemoveStatModifier(IStatsModifier statModifier)
-        {
-            _target.Stats.RemoveModifier(statModifier);
         }
 
         public void Add(IBuff buff)

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -139,13 +139,13 @@ namespace LeagueSandbox.GameServer
                 var ai = u as IObjAiBase;
                 if (ai != null)
                 {
-                    var tempBuffs = ai.Buffs.GetQueue();  
+                    var buffQueue = ai.Buffs.GetQueue();  
                     
                     // TODO: add propper dequeing for buffs ? -> will result in bugs
                     //foreach(var buff in tempBuffs)
-                    while(tempBuffs.Count > 0)
+                    while(buffQueue.Count > 0)
                     {
-                        var buff = tempBuffs.Dequeue();
+                        var buff = buffQueue.Dequeue();
                         if(buff.Elapsed())
                         {
                             ai.Buffs.Remove(buff.Name);

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -139,19 +139,7 @@ namespace LeagueSandbox.GameServer
                 var ai = u as IObjAiBase;
                 if (ai != null)
                 {
-                    var buffQueue = ai.Buffs.GetQueue();  
-                    while(buffQueue.Count > 0)
-                    {
-                        var buff = buffQueue.Dequeue();
-                        if(buff.Elapsed())
-                        {
-                            ai.Buffs.Remove(buff);
-                        }
-                        else
-                        {
-                            buff.Update(diff);
-                        }
-                    }
+                    ai.Buffs.Update(diff);
                 }
 
                 // TODO: send this in one place only

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using GameServerCore;
+using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects;
@@ -134,16 +135,17 @@ namespace LeagueSandbox.GameServer
                 var ai = u as IObjAiBase;
                 if (ai != null)
                 {
-                    var tempBuffs = ai.Buffs.Get();
-                    for (int i = tempBuffs.Count - 1; i >= 0; i--)
+                    var tempBuffs = ai.Buffs.GetQueue();
+                    while(tempBuffs.Count > 0)
                     {
-                        if (tempBuffs[i].Elapsed())
+                        IBuff buff = tempBuffs.Dequeue();
+                        if(buff.Elapsed())
                         {
-                            ai.Buffs.Remove(tempBuffs[i]);
+                            ai.Buffs.Remove(buff);
                         }
                         else
                         {
-                            tempBuffs[i].Update(diff);
+                            buff.Update(diff);
                         }
                     }
                 }

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -1,16 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
 using GameServerCore;
 using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
+using GameServerLib;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.AnimatedBuildings;
 using LeagueSandbox.GameServer.GameObjects.Other;
 using LeagueSandbox.GameServer.Logging;
+using Priority_Queue;
 
 namespace LeagueSandbox.GameServer
 {
@@ -135,13 +139,14 @@ namespace LeagueSandbox.GameServer
                 var ai = u as IObjAiBase;
                 if (ai != null)
                 {
-                    var tempBuffs = ai.Buffs.GetQueue();
-                    while(tempBuffs.Count > 0)
+                    var tempBuffs = ai.Buffs.Get();  
+                    
+                    // TODO: add propper dequeing for buffs ? -> will result in bugs
+                    foreach(var buff in tempBuffs)
                     {
-                        IBuff buff = tempBuffs.Dequeue();
                         if(buff.Elapsed())
                         {
-                            ai.Buffs.Remove(buff);
+                            ai.Buffs.Remove(buff.Name);
                         }
                         else
                         {

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -145,7 +145,7 @@ namespace LeagueSandbox.GameServer
                         var buff = buffQueue.Dequeue();
                         if(buff.Elapsed())
                         {
-                            ai.Buffs.Remove(buff.Name);
+                            ai.Buffs.Remove(buff);
                         }
                         else
                         {

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -134,12 +134,12 @@ namespace LeagueSandbox.GameServer
                 var ai = u as IObjAiBase;
                 if (ai != null)
                 {
-                    var tempBuffs = ai.GetBuffs();
+                    var tempBuffs = ai.Buffs.Get();
                     for (int i = tempBuffs.Count - 1; i >= 0; i--)
                     {
                         if (tempBuffs[i].Elapsed())
                         {
-                            ai.RemoveBuff(tempBuffs[i]);
+                            ai.Buffs.Remove(tempBuffs[i]);
                         }
                         else
                         {

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -140,9 +140,6 @@ namespace LeagueSandbox.GameServer
                 if (ai != null)
                 {
                     var buffQueue = ai.Buffs.GetQueue();  
-                    
-                    // TODO: add propper dequeing for buffs ? -> will result in bugs
-                    //foreach(var buff in tempBuffs)
                     while(buffQueue.Count > 0)
                     {
                         var buff = buffQueue.Dequeue();

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -139,11 +139,13 @@ namespace LeagueSandbox.GameServer
                 var ai = u as IObjAiBase;
                 if (ai != null)
                 {
-                    var tempBuffs = ai.Buffs.Get();  
+                    var tempBuffs = ai.Buffs.GetQueue();  
                     
                     // TODO: add propper dequeing for buffs ? -> will result in bugs
-                    foreach(var buff in tempBuffs)
+                    //foreach(var buff in tempBuffs)
+                    while(tempBuffs.Count > 0)
                     {
+                        var buff = tempBuffs.Dequeue();
                         if(buff.Elapsed())
                         {
                             ai.Buffs.Remove(buff.Name);

--- a/GameServerLib/ProtectionManager.cs
+++ b/GameServerLib/ProtectionManager.cs
@@ -116,7 +116,7 @@ namespace LeagueSandbox.GameServer
             {
                 if (!_protectedPlayers.Contains(champion))
                 {
-                    champion.AddStatModifier(AFK_PROT_MODIFIER);
+                    champion.Stats.AddModifier(AFK_PROT_MODIFIER);
                     _protectedPlayers.Add(champion);
                 }
             }
@@ -124,7 +124,7 @@ namespace LeagueSandbox.GameServer
             {
                 if (_protectedPlayers.Contains(champion))
                 {
-                    champion.RemoveStatModifier(AFK_PROT_MODIFIER);
+                    champion.Stats.RemoveModifier(AFK_PROT_MODIFIER);
                     _protectedPlayers.Remove(champion);
                 }
             }


### PR DESCRIPTION
> **This is a WIP and still needs a few bugfixes and improvements but I'm looking forward to suggestions already :)**

The buff system is currently lacking a bit functionality and a lot of code style compliance which this PR solves.

## changelist

1. introduced `IBuffManager` and `BuffManager` to decouple buff logic from `ObjAIBase` (#1001)
   > *all buff related functions are now accessable in `IObjAIBase` through `Buffs`*
   > *for eg:`aiBase.Buffs.Add()`*
3. introduced flags for buffs to mark a buff as not interruptable by cc for eg. (#973)
4. introduced a real priority queue for Buffs (#886)

## small improvements
| what                                               | why                                  | where        |
| -------------------------------------------------- | ------------------------------------ | ------------ |

## temporary buglist

*These are curren't known bugs (as of WIP).*

1. last stack of overlapping buff not removed
1. recall animation is 4 seconds long instead of 8
1. still can cast spell while recall/tping

*Refs:* #1001, #973, #886