### PR TITLE
Resolve #973 - Cast spells and teleport fix

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -160,7 +160,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             return !HasCrowdControl(CrowdControlType.STUN) &&
                 !IsDashing &&
-                (GetBuffs().Exists(x => x.OriginSpell.SpellData.CanMoveWhileChanneling) || !IsCastingSpell) &&
+                (GetBuffs().Count(x => x.OriginSpell.SpellData.CanMoveWhileChanneling) == GetBuffsCount() || !IsCastingSpell) &&
                 !IsDead &&
                 !HasCrowdControl(CrowdControlType.ROOT);
         }
@@ -230,6 +230,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             l.Add(new Vector2(this.X, this.Y));
             this.SetWaypoints(l);
             _game.PacketNotifier.NotifyMovement(this);
+        }
+        
+        public void TeleportTo(float x, float y)
+        {
+            // @TODO: Maybe add a OnChampionTeleport event?
+            ApiEventManager.OnChampionMove.Publish(this);
+            base.TeleportTo(x, y);
         }
 
         public ISpell GetSpellBySlot(byte slot)

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -158,16 +158,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
         public bool CanMove()
         {
-            foreach (var buff in GetBuffs())
-            {
-                if (!buff.OriginSpell.SpellData.CanMoveWhileChanneling && buff.Name != "Recall")
-                {
-                    return false;
-                }
-            }
             return !HasCrowdControl(CrowdControlType.STUN) &&
                 !IsDashing &&
-                !IsCastingSpell &&
+                (GetBuffs().Exists(x => x.OriginSpell.SpellData.CanMoveWhileChanneling) || !IsCastingSpell) &&
                 !IsDead &&
                 !HasCrowdControl(CrowdControlType.ROOT);
         }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -158,6 +158,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
         public bool CanMove()
         {
+            foreach (var buff in GetBuffs())
+            {
+                if (!buff.OriginSpell.SpellData.CanMoveWhileChanneling && buff.Name != "Recall")
+                {
+                    return false;
+                }
+            }
             return !HasCrowdControl(CrowdControlType.STUN) &&
                 !IsDashing &&
                 !IsCastingSpell &&

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -692,14 +692,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 y = MovementVector.TargetYToNormalFormat(_game.Map.NavigationGrid, y);
             }
             
-            // If the unit is a champion, notify all listeners of their movement. 
-            // @TODO: Maybe add a OnChampionTeleport event?
-            if(this is IChampion)
-            {
-                IChampion champ = (IChampion)this;
-                ApiEventManager.OnChampionMove.Publish(champ);
-            }
-
             _game.PacketNotifier.NotifyTeleport(this, new Vector2(x, y));
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -691,6 +691,14 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 x = MovementVector.TargetXToNormalFormat(_game.Map.NavigationGrid, x);
                 y = MovementVector.TargetYToNormalFormat(_game.Map.NavigationGrid, y);
             }
+            
+            // If the unit is a champion, notify all listeners of their movement. 
+            // @TODO: Maybe add a OnChampionTeleport event?
+            if(this is IChampion)
+            {
+                IChampion champ = (IChampion)this;
+                ApiEventManager.OnChampionMove.Publish(champ);
+            }
 
             _game.PacketNotifier.NotifyTeleport(this, new Vector2(x, y));
         }

--- a/GameServerLib/GameObjects/Spells/Buff.cs
+++ b/GameServerLib/GameObjects/Spells/Buff.cs
@@ -3,6 +3,7 @@ using GameServerCore.Domain;
 using GameServerCore;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
+using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.Other;
@@ -80,6 +81,13 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
         public void ActivateBuff()
         {
             _buffGameScript.OnActivate(TargetUnit, this, OriginSpell);
+            if (!OriginSpell.SpellData.CantCancelWhileChanneling)
+            {
+                ApiEventManager.OnChampionDamageTaken.AddListener(this, (IChampion) TargetUnit, DeactivateBuff);
+                ApiEventManager.OnChampionMove.AddListener(this, (IChampion) TargetUnit, DeactivateBuff);
+                ApiEventManager.OnChampionCrowdControlled.AddListener(this, (IChampion) TargetUnit, DeactivateBuff);
+            }
+
             _remove = false;
         }
 

--- a/GameServerLib/GameObjects/Spells/Spell.cs
+++ b/GameServerLib/GameObjects/Spells/Spell.cs
@@ -112,6 +112,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spells
             if (SpellData.GetCastTime() > 0 && (SpellData.Flags & (int)SpellFlag.SPELL_FLAG_INSTANT_CAST) == 0)
             {
                 Owner.SetPosition(Owner.X, Owner.Y); //stop moving serverside too. TODO: check for each spell if they stop movement or not
+                Owner.IsCastingSpell = true;
                 State = SpellState.STATE_CASTING;
                 CurrentCastTime = SpellData.GetCastTime();
             }


### PR DESCRIPTION
Co-authored-by: ptkenny (#974)
Also refs #977, in Lux R json file INSTANT_CAST flag is set and thats the reason why the champion can move and deals damage before the animation. I didn't want to change it in spell casting, since it may break some other spells, also I think this will be for other PR but please leave your suggestions about this.

Refs #973 #977 #996 