### PR TITLE
Resolve #1016 -- Server Crashes when Casting Heal Twice Fast

### DIFF
--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -134,7 +134,7 @@ namespace LeagueSandbox.GameServer
                 var ai = u as IObjAiBase;
                 if (ai != null)
                 {
-                    var tempBuffs = new List<GameServerCore.Domain.IBuff> (ai.GetBuffs ());
+                    var tempBuffs = new List<GameServerCore.Domain.IBuff>(ai.GetBuffs());
                     for (int i = tempBuffs.Count - 1; i >= 0; i--)
                     {
                         if (tempBuffs[i].Elapsed())

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -134,7 +134,7 @@ namespace LeagueSandbox.GameServer
                 var ai = u as IObjAiBase;
                 if (ai != null)
                 {
-                    var tempBuffs = ai.GetBuffs();
+                    var tempBuffs = new List<GameServerCore.Domain.IBuff> (ai.GetBuffs ());
                     for (int i = tempBuffs.Count - 1; i >= 0; i--)
                     {
                         if (tempBuffs[i].Elapsed())


### PR DESCRIPTION
Fixed summoner spell buff crash by copying the list of buffs before removal

Refs #1016