### PR TITLE
Resolve #1040 -- Don't throw errors on script compilation when reloading

### DIFF
--- a/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
+++ b/GameServerLib/Scripting/CSharp/CSharpScriptEngine.cs
@@ -109,7 +109,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
                         _scriptAssembly.Add(assembly);
                         foreach (var type in assembly.GetTypes())
                         {
-                            types.Add(type.FullName, type);
+                            types[type.FullName] = type;
                         }
                         return state;
                     }


### PR DESCRIPTION
Resolves #1040.

> If a PR is made for this, the author should also keep in mind this issue since it is related: #723
_Originally posted by @microsoftv in https://github.com/LeagueSandbox/GameServer/issues/1040#issuecomment-772973627_

There are other improvements that should be made to hot reloading--a file watcher could definitely be good, yeah, and there's also the fact that old script data could be left hanging (i.e. your champion may hold a reference to a script that was compiled BEFORE the reload), but I think it's better to keep each issue + PR small.