### PR TITLE
Dash Fixes

### DIFF
--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -22,10 +22,6 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         float AutoAttackProjectileSpeed { get; set; }
         /// <summary>
-        /// This AI's current auto attack target. Null if no target.
-        /// </summary>
-        IAttackableUnit AutoAttackTarget { get; set; }
-        /// <summary>
         /// Variable containing all data about the AI's current character such as base health, base mana, whether or not they are melee, base movespeed, per level stats, etc.
         /// </summary>
         /// TODO: Move to AttackableUnit as it relates to stats..
@@ -59,6 +55,10 @@ namespace GameServerCore.Domain.GameObjects
         /// Unit this AI will auto attack when it is in auto attack range.
         /// </summary>
         IAttackableUnit TargetUnit { get; set;  }
+        /// <summary>
+        /// Unit this AI will dash to (assuming they are performing a targeted dash).
+        /// </summary>
+        IAttackableUnit DashTarget { get; }
 
         /// <summary>
         /// Function called by this AI's auto attack projectile when it hits its target.

--- a/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
@@ -193,7 +193,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             // Lose focus of the unit target if the target is out of range
             if (TargetUnit != null && Vector2.DistanceSquared(Position, TargetUnit.Position) > Stats.Range.Total * Stats.Range.Total)
             {
-                TargetUnit = null;
+                SetTargetUnit(null);
                 _game.PacketNotifier.NotifySetTarget(this, null);
             }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -480,6 +480,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
         public override void OnCollision(IGameObject collider, bool isTerrain = false)
         {
+            if (IsDashing)
+            {
+                return;
+            }
             base.OnCollision(collider, isTerrain);
             if (isTerrain)
             {


### PR DESCRIPTION
* Collision no longer affects champions that are dashing.
* Unit targeted dashes:
   * No longer stop after losing sight of their target.
   * Continue to follow the target if they move.
   * No longer affected by normal pathfinding, instead going straight to the target.
   
Resolves #1048.