### PR TITLE
Progress #1055 -- Added disconnected check to allow players to reconnect

### DIFF
--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -304,7 +304,7 @@ namespace PacketDefinitions420
                 return false;
             }
             
-            if(_peers.ContainsKey(request.PlayerID))
+            if(_peers.ContainsKey(request.PlayerID) && !_playerManager.GetPeerInfo(request.PlayerID).IsDisconnected)
             {
                 Debug.WriteLine($"Player {request.PlayerID} is already connected. Request from {peer.Address.ToString()}.");
                 return false;


### PR DESCRIPTION
Disconnected players can now reconnect. There are still problems with sending packets (either explicitly or by broadcasting) to disconnected peers and also the re-notification of player spawned for all the other players. Tested and works fine with 1 player (skills are still unusable due to #400)

Progress #1055

EDIT: It will be great if there is anyone that can just copy-paste this PR into a new PR of theirs, and I'll merge their PR with co-authored by field indicating this is a collaborative PR.