### PR TITLE
 Resolve #1064, Resolve #1062 -- Implement Auto Casting for Skillshots

### DIFF
--- a/Content/LeagueSandbox-Scripts/Champions/Ezreal/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Ezreal/Q.cs
@@ -1,12 +1,12 @@
-using System.Numerics;
-using GameServerCore.Enums;
-using GameServerCore.Domain.GameObjects;
-using static LeagueSandbox.GameServer.API.ApiFunctionManager;
-using LeagueSandbox.GameServer.Scripting.CSharp;
-using LeagueSandbox.GameServer.API;
 using System.Collections.Generic;
+using System.Numerics;
+using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
+using GameServerCore.Enums;
+using LeagueSandbox.GameServer.API;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace Spells
 {

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -771,16 +771,14 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// <returns>Newly created spell set.</returns>
         public ISpell SetSpell(string name, byte slot, bool enabled)
         {
-            if (Spells[slot].CastInfo.IsAutoAttack)
+            if (!Spells.ContainsKey(slot) || Spells[slot].CastInfo.IsAutoAttack)
             {
                 return null;
             }
+
             ISpell newSpell = new Spell.Spell(_game, this, name, slot);
 
-            if (Spells[slot] != null)
-            {
-                newSpell.SetLevel(Spells[slot].CastInfo.SpellLevel);
-            }
+            newSpell.SetLevel(Spells[slot].CastInfo.SpellLevel);
 
             Spells[slot] = newSpell;
             Stats.SetSpellEnabled(slot, enabled);

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -138,7 +138,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
                 // InventorySlots
                 // 6 - 12 (12 = TrinketSlot)
-                for (byte i = 6; i < 12; i++)
+                for (byte i = 6; i < 13; i++)
                 {
                     Spells[i] = new Spell.Spell(game, this, "BaseSpell", i);
                 }

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -249,7 +249,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                         CastInfo.Owner.StopMovement();
                     }
 
-                    var goingTo = start - CastInfo.Owner.Position;
+                    var goingTo = new Vector2(CastInfo.TargetPosition.X, CastInfo.TargetPosition.Z) - CastInfo.Owner.Position;
 
                     if (unit != null)
                     {
@@ -264,6 +264,14 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 {
                     CastInfo.Owner.UpdateMoveOrder(OrderType.CastSpell, true);
                 }
+            }
+
+            // If we are supposed to automatically cast a skillshot for this spell, then calculate the proper end position before casting.
+            if (_spellScript.ScriptMetadata.MissileParameters != null && _spellScript.ScriptMetadata.MissileParameters.Type == MissileType.Circle)
+            {
+                var targetPos = ApiFunctionManager.GetPointFromUnit(CastInfo.Owner, GetCurrentCastRange());
+                CastInfo.TargetPosition = new Vector3(targetPos.X, _game.Map.NavigationGrid.GetHeightAtLocation(targetPos.X, targetPos.Y), targetPos.Y);
+                // TODO: Verify if we should also override TargetPositionEnd (probably not due to things like Viktor E).
             }
 
             if (CastInfo.IsAutoAttack && CastInfo.Owner.IsMelee)
@@ -831,7 +839,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 isServerOnly = true;
             }
 
-            var p = new SpellLineMissile(
+            var p = new SpellCircleMissile(
                 _game,
                 (int)SpellData.LineWidth,
                 this,

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -1011,8 +1011,12 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             if (newCd <= 0)
             {
                 _game.PacketNotifier.NotifyCHAR_SetCooldown(CastInfo.Owner, CastInfo.SpellSlot, 0, 0);
-                State = SpellState.STATE_READY;
-                CurrentCooldown = 0;
+                // Changing the state of the spell to READY during casting prevents the spell from finishing casting, thus locking the player in the move order CastSpell.
+                if (State != SpellState.STATE_CASTING && State != SpellState.STATE_CHANNELING)
+                {
+                    State = SpellState.STATE_READY;
+                    CurrentCooldown = 0;
+                }
             }
             else
             {

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -556,7 +556,7 @@ namespace PacketDefinitions420
                 Cooldown = currentCd,
                 MaxCooldownForDisplay = totalCd
             };
-            if (u is IChampion && (slotId == 0 || slotId == 1))
+            if (u is IChampion && (slotId == 4 || slotId == 5))
             {
                 cdPacket.IsSummonerSpell = true; // TODO: Verify functionality
             }


### PR DESCRIPTION
* ObjAiBase:
  * Trinket spell slot is now properly initialized.
* Spells:
  * CreateSpellCircleMissile fixed to actually spawn a SpellCirleMissile.
  * FaceDirection when spell casts are triggered now uses CastInfo.TargetPosition.
  * Implemented re-targeting for skillshot spells.
  * Spells whos cooldown is lowered mid-cast no longer lockout movement (ex: Ezreal Q).
* Scripts:
  * Re-implemented Caitlyn Q as an example.

Resolve #1064, Resolve #1062