### PR TITLE
Resolve #1070 -- Fix Commands

### DIFF
--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -62,7 +62,7 @@ namespace PacketDefinitions420
                 {
                     if (attr is PacketType)
                     {
-                        if (((PacketType)attr).ChannelId == Channel.CHL_LOADING_SCREEN)
+                        if (((PacketType)attr).ChannelId == Channel.CHL_LOADING_SCREEN || ((PacketType)attr).ChannelId == Channel.CHL_COMMUNICATION)
                         {
                             var method = (RequestConvertor)Delegate.CreateDelegate(typeof(RequestConvertor), m);
                             _loadScreenConvertorTable.Add(((PacketType)attr).LoadScreenPacketId, method);


### PR DESCRIPTION
Some loading screen packets do not use the loading screen channel, so this fix accounts for loading screen packets which use the communication channel.

Resolve #1070 