### PR TITLE
Resolve #1075, Resolve #723 -- Scripts Hot Reload

### DIFF
--- a/GameServerCore/Domain/GameObjects/IBuff.cs
+++ b/GameServerCore/Domain/GameObjects/IBuff.cs
@@ -4,17 +4,61 @@ using GameServerCore.Enums;
 namespace GameServerCore.Domain.GameObjects
 {
     public interface IBuff : IStackable, IUpdate
-    {
+    {       
+        /// <summary>
+        /// How this buff should be added and treated when adding new buffs of the same name.
+        /// </summary>
         BuffAddType BuffAddType { get; }
+
+        /// <summary>
+        /// Type of buff to add. Determines how this buff interacts with mechanics of the game. Refer to BuffType.
+        /// </summary>
         BuffType BuffType { get; }
+
+        /// <summary>
+        /// Total time this buff should be applied to its target.
+        /// </summary>
         float Duration { get; }
+
+        /// <summary>
+        /// Whether or not this buff should be shown on clients' buff bar (HUD).
+        /// </summary>
         bool IsHidden { get; }
+
+        /// <summary>
+        /// Internal name of this buff.
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Spell which caused this buff to be applied.
+        /// </summary>
         ISpell OriginSpell { get; }
+
+        /// <summary>
+        /// Slot of this buff instance. Maximum allowed is 255 due to packets.
+        /// </summary>
         byte Slot { get; }
+
+        /// <summary>
+        /// Unit which applied this buff to its target.
+        /// </summary>
         IObjAiBase SourceUnit { get; }
+
+        /// <summary>
+        /// Unit which has this buff applied to it.
+        /// </summary>
         IAttackableUnit TargetUnit { get; }
+
+        /// <summary>
+        /// Time since this buff's timer started.
+        /// </summary>
         float TimeElapsed { get; }
+
+        /// <summary>
+        /// Used to load the script for the buff.
+        /// </summary>
+        void LoadScript();
 
         void ActivateBuff();
         void DeactivateBuff();

--- a/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
@@ -18,52 +18,98 @@ namespace GameServerCore.Domain.GameObjects.Spell
         string SpellName { get; }
         SpellState State { get; }
 
+        /// <returns>spell's unique ID</returns>
+        int GetId();
+
+        /// <summary>
+        /// Called by projectiles when they land / hit, this is where we apply damage/slows etc.
+        /// </summary>
         void ApplyEffects(IAttackableUnit u, ISpellMissile p);
+
         /// <summary>
         /// Called when the character casts this spell. Initializes the CastInfo for this spell and begins casting.
         /// </summary>
         bool Cast(Vector2 start, Vector2 end, IAttackableUnit unit = null);
+
         /// <summary>
         /// Called when a script manually casts this spell.
         /// </summary>
         bool Cast(ICastInfo castInfo, bool cast);
+
+        /// <summary>
+        /// Called after the spell has finished casting and is beginning a channel.
+        /// </summary>
+        public void Channel();
+
         /// <summary>
         /// Forces this spell to stop channeling based on the given condition for the given reason.
         /// </summary>
         /// <param name="condition">Canceled or successful?</param>
         /// <param name="reason">How it should be treated.</param>
         void StopChanneling(ChannelingStopCondition condition, ChannelingStopSource reason);
+
+        /// <summary>
+        /// Called when the spell is finished casting and we're supposed to do things such as projectile spawning, etc.
+        /// </summary>
+        void FinishCasting();
+
+        /// <summary>
+        /// Called when the character finished channeling
+        /// </summary>
+        void FinishChanneling();
+
         void Deactivate();
+
         /// <summary>
         /// Creates a single-target missile with the specified properties.
         /// </summary>
         ISpellMissile CreateSpellMissile();
+
         /// <summary>
         /// Creates a single-target bouncing missile with the specified properties.
         /// </summary>
         ISpellMissile CreateSpellChainMissile();
+
         /// <summary>
         /// Creates a line missile with the specified properties.
         /// </summary>
         ISpellMissile CreateSpellCircleMissile();
+
         /// <summary>
         /// Creates an arc missile with the specified properties.
         /// </summary>
         ISpellMissile CreateSpellLineMissile();
-        int GetId();
-        float GetCooldown();
+
         /// <summary>
         /// Gets the cast range for this spell (based on level).
         /// </summary>
         /// <returns>Cast range based on level.</returns>
         float GetCurrentCastRange();
-        string GetStringForSlot();
+
+        /// <summary>
+        /// Sets the state of the spell to the specified state. Often used when reseting time between spell casts.
+        /// </summary>
+        /// <param name="state"></param>
+        void SetSpellState(SpellState state);
+
+        /// <summary>
+        /// Sets the toggle state of this spell to the specified state. True = usable, false = sealed, unusable.
+        /// </summary>
+        /// <param name="toggle">True/False.</param>
+        void SetSpellToggle(bool toggle);
+
+        /// <summary>
+        /// Used to load the script for the spell.
+        /// </summary>
+        void LoadScript();
+
         void LevelUp();
+        string GetStringForSlot();
+        float GetCooldown();
+        void SetCooldown(float newCd);
         void LowerCooldown(float lowerValue);
         void ResetSpellDelay();
-        void SetCooldown(float newCd);
         void SetLevel(byte toLevel);
-        void SetSpellState(SpellState state);
-        void SetSpellToggle(bool toggle);
+
     }
 }

--- a/GameServerLib/Chatbox/Commands/HotReloadCommand.cs
+++ b/GameServerLib/Chatbox/Commands/HotReloadCommand.cs
@@ -1,0 +1,41 @@
+﻿using LeagueSandbox.GameServer.GameObjects;
+using LeagueSandbox.GameServer.GameObjects.Spell;
+
+namespace LeagueSandbox.GameServer.Chatbox.Commands
+{
+    public class HotReloadCommand : ChatCommandBase
+    {
+        public override string Command => "hotreload";
+        public override string Syntax => $"{Command} 0 (disable) / 1 (enable)";
+
+        public HotReloadCommand(ChatCommandManager chatCommandManager, Game game)
+            : base(chatCommandManager, game)
+        {
+        }
+
+        public override void Execute(int userId, bool hasReceivedArguments, string arguments = "")
+        {
+            var split = arguments.ToLower().Split(' ');
+
+            if (split.Length < 2 || !byte.TryParse(split[1], out byte input) || input > 1)
+            {
+                ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.SYNTAXERROR);
+                ShowSyntax();
+            }
+            else
+            {
+                if (input == 1)
+                {
+                    Game.EnableHotReload(true);
+                    ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "Scripts hot reload enabled.");
+                }
+                else
+                {
+                    Game.EnableHotReload(false);
+                    ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "Scripts hot reload disabled.");
+                }
+
+            }
+        }
+    }
+}

--- a/GameServerLib/Content/ContentManager.cs
+++ b/GameServerLib/Content/ContentManager.cs
@@ -14,11 +14,11 @@ namespace LeagueSandbox.GameServer.Content
     {
         private readonly ILog _logger;
         private readonly Game _game;
-        private readonly string _contentPath;
 
         private readonly List<Package> _loadedPackages;
         private readonly List<string> _dataPackageNames;
 
+        public string ContentPath { get; }
         public string PackageName { get; }
         public string PackagePath { get; }
 
@@ -26,7 +26,7 @@ namespace LeagueSandbox.GameServer.Content
         {
             _game = game;
 
-            _contentPath = contentPath;
+            ContentPath = contentPath;
 
             _loadedPackages = new List<Package>();
             _dataPackageNames = new List<string>{dataPackageName};
@@ -96,7 +96,7 @@ namespace LeagueSandbox.GameServer.Content
 
         private string GetPackagePath(string packageName)
         {
-            return $"{_contentPath}/{packageName}";
+            return $"{ContentPath}/{packageName}";
         }
 
         public bool LoadScripts()

--- a/GameServerLib/Content/Package.cs
+++ b/GameServerLib/Content/Package.cs
@@ -166,7 +166,7 @@ namespace LeagueSandbox.GameServer.Content
 
         public bool LoadScripts()
         {
-            var scriptLoadResult = _game.ScriptEngine.LoadSubdirectoryScripts(PackagePath);
+            var scriptLoadResult = _game.ScriptEngine.LoadSubDirectoryScripts(PackagePath);
             switch (scriptLoadResult)
             {
                 case Scripting.CSharp.CompilationStatus.Compiled:

--- a/GameServerLib/Game.cs
+++ b/GameServerLib/Game.cs
@@ -247,16 +247,10 @@ namespace LeagueSandbox.GameServer
 
             void ScriptsChanged(object _, FileSystemEventArgs ea)
             {
-                // try/finally used to avoid triggering LoadScripts() many times in a row after the first event
-                try
-                {
-                    ScriptsHotReloadWatcher.EnableRaisingEvents = false;
-                    ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, LoadScripts() ? "Scripts reloaded." : "Scripts failed to reload.");
-                }
-                finally
-                {
-                    ScriptsHotReloadWatcher.EnableRaisingEvents = true;
-                }
+                // Disable raising events to avoid triggering LoadScripts() many times in a row after the first event
+                ScriptsHotReloadWatcher.EnableRaisingEvents = false;
+                ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, LoadScripts() ? "Scripts reloaded." : "Scripts failed to reload.");
+                ScriptsHotReloadWatcher.EnableRaisingEvents = true;
             }
 
             if (status && ScriptsHotReloadWatcher == null)

--- a/GameServerLib/Game.cs
+++ b/GameServerLib/Game.cs
@@ -17,12 +17,16 @@ using PacketDefinitions420;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Timer = System.Timers.Timer;
 using GameServerCore.Packets.PacketDefinitions;
 using GameServerCore.Packets.PacketDefinitions.Requests;
+using LeagueSandbox.GameServer.GameObjects;
+using LeagueSandbox.GameServer.GameObjects.Spell;
 using LeagueSandbox.GameServer.Packets.PacketHandlers;
 
 namespace LeagueSandbox.GameServer
@@ -38,7 +42,7 @@ namespace LeagueSandbox.GameServer
         private List<GameScriptTimer> _gameScriptTimers;
 
         // Function Vars
-        private ILog _logger;
+        private readonly ILog _logger;
         private Timer _pauseTimer;
         private bool _autoResumeCheck;
         private float _nextSyncTime = 10 * 1000;
@@ -125,6 +129,8 @@ namespace LeagueSandbox.GameServer
         /// Class that compiles and loads all scripts which will be used for the game (ex: spells, items, AI, maps, etc).
         /// </summary>
         internal CSharpScriptEngine ScriptEngine { get; private set; }
+
+        internal FileSystemWatcher ScriptsHotReloadWatcher { get; private set; }
 
         /// <summary>
         /// Instantiates all game managers and handlers.
@@ -233,18 +239,67 @@ namespace LeagueSandbox.GameServer
         }
 
         /// <summary>
+        /// Enables or disables the hot reloading of scripts. Used only for development.
+        /// </summary>
+        public void EnableHotReload(bool status)
+        {
+            string scriptsPath = Config.ContentManager.GetLoadedPackage("LeagueSandbox-Scripts").PackagePath;
+
+            void ScriptsChanged(object _, FileSystemEventArgs ea)
+            {
+                // try/finally used to avoid triggering LoadScripts() many times in a row after the first event
+                try
+                {
+                    ScriptsHotReloadWatcher.EnableRaisingEvents = false;
+                    ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, LoadScripts() ? "Scripts reloaded." : "Scripts failed to reload.");
+                }
+                finally
+                {
+                    ScriptsHotReloadWatcher.EnableRaisingEvents = true;
+                }
+            }
+
+            if (status && ScriptsHotReloadWatcher == null)
+            {
+                ScriptsHotReloadWatcher = new FileSystemWatcher
+                {
+                    Path = scriptsPath,
+                    IncludeSubdirectories = true,
+                    EnableRaisingEvents = true,
+                    NotifyFilter = NotifyFilters.LastWrite,
+                    Filter = "*.*",
+                };
+                ScriptsHotReloadWatcher.Changed += ScriptsChanged;
+            }
+            else
+            {
+                ScriptsHotReloadWatcher.Changed -= ScriptsChanged;
+                ScriptsHotReloadWatcher = null;
+            }
+        }
+
+        /// <summary>
         /// Loads the scripts contained in every content package.
         /// </summary>
         /// <returns>Whether all scripts were loaded successfully or not.</returns>
         public bool LoadScripts()
         {
-            var scriptLoadingResults = Config.ContentManager.LoadScripts();
+            bool scriptLoadingResults = Config.ContentManager.LoadScripts();
+
+            if (scriptLoadingResults)
+            {
+                foreach (var champion in ObjectManager.GetAllChampions())
+                {
+                    champion.GetBuffs().ForEach(buff => buff.LoadScript());
+                    champion.Spells.Values.ToList().ForEach(spell => spell.LoadScript());
+                }
+            }
 
             return scriptLoadingResults;
         }
 
         /// <summary>
-        /// Function which initates ticking of the game's logic.
+        /// Function which initiates ticking of the game's logic.
         /// </summary>
         public void GameLoop()
         {
@@ -268,7 +323,7 @@ namespace LeagueSandbox.GameServer
                 if (_lastMapDurationWatch.Elapsed.TotalMilliseconds + 1.0 > REFRESH_RATE)
                 {
                     // Sets last tick time (diff).
-                    var sinceLastMapTime = _lastMapDurationWatch.Elapsed.TotalMilliseconds;
+                    double sinceLastMapTime = _lastMapDurationWatch.Elapsed.TotalMilliseconds;
                     _lastMapDurationWatch.Restart();
                     if (IsRunning)
                     {

--- a/GameServerLib/Game.cs
+++ b/GameServerLib/Game.cs
@@ -243,7 +243,7 @@ namespace LeagueSandbox.GameServer
         /// </summary>
         public void EnableHotReload(bool status)
         {
-            string scriptsPath = Config.ContentManager.GetLoadedPackage("LeagueSandbox-Scripts").PackagePath;
+            string scriptsPath = Config.ContentManager.ContentPath;
 
             void ScriptsChanged(object _, FileSystemEventArgs ea)
             {

--- a/GameServerLib/GameObjects/Buff.cs
+++ b/GameServerLib/GameObjects/Buff.cs
@@ -12,13 +12,13 @@ namespace LeagueSandbox.GameServer.GameObjects
     public class Buff : Stackable, IBuff
     {
         // Crucial Vars.
-        protected Game Game;
-        protected CSharpScriptEngine ScriptEngine;
+        private readonly Game _game;
+        private readonly CSharpScriptEngine _scriptEngine;
         private IBuffGameScript _buffGameScript;
 
         // Function Vars.
-        protected bool InfiniteDuration;
-        protected bool Remove;
+        private readonly bool _infiniteDuration;
+        private bool _remove;
 
         public BuffAddType BuffAddType { get; }
         public BuffType BuffType { get; } /// TODO: Add comments to BuffType enum.
@@ -38,10 +38,10 @@ namespace LeagueSandbox.GameServer.GameObjects
                 throw new ArgumentException("Error: Duration was set to under 0.");
             }
 
-            InfiniteDuration = infiniteDuration;
-            Game = game;
-            Remove = false;
-            ScriptEngine = game.ScriptEngine;
+            _infiniteDuration = infiniteDuration;
+            _game = game;
+            _remove = false;
+            _scriptEngine = game.ScriptEngine;
             Name = buffName;
 
             LoadScript();
@@ -83,23 +83,23 @@ namespace LeagueSandbox.GameServer.GameObjects
         public void LoadScript()
         {
             ApiEventManager.RemoveAllListenersForOwner(_buffGameScript);
-            _buffGameScript = ScriptEngine.CreateObject<IBuffGameScript>(Name, Name);
+            _buffGameScript = _scriptEngine.CreateObject<IBuffGameScript>(Name, Name);
         }
 
         public void ActivateBuff()
         {
             _buffGameScript.OnActivate(TargetUnit, this, OriginSpell);
 
-            Remove = false;
+            _remove = false;
         }
 
         public void DeactivateBuff()
         {
-            if (Remove)
+            if (_remove)
             {
                 return;
             }
-            Remove = true; // To prevent infinite loop with OnDeactivate calling events
+            _remove = true; // To prevent infinite loop with OnDeactivate calling events
 
             _buffGameScript.OnDeactivate(TargetUnit, this, OriginSpell);
 
@@ -111,7 +111,7 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         public bool Elapsed()
         {
-            return Remove;
+            return _remove;
         }
 
         public IStatsModifier GetStatsModifier()
@@ -121,7 +121,7 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         public bool IsBuffInfinite()
         {
-            return InfiniteDuration;
+            return _infiniteDuration;
         }
 
         public bool IsBuffSame(string buffName)
@@ -141,7 +141,7 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         public void Update(float diff)
         {
-            if (InfiniteDuration)
+            if (_infiniteDuration)
             {
                 return;
             }

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -16,32 +16,30 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
     public class Spell : ISpell
     {
         // Crucial Vars.
-        private CSharpScriptEngine _scriptEngine;
-        private Game _game;
-        protected NetworkIdManager _networkIdManager;
+        private readonly Game _game;
+        private readonly CSharpScriptEngine _scriptEngine;
         private uint _futureProjNetId;
         private ISpellScript _spellScript;
 
+        protected NetworkIdManager NetworkIdManager;
+
         public ICastInfo CastInfo { get; private set; } = new CastInfo();
-
-        public string SpellName { get; private set; }
+        public string SpellName { get; }
         public bool HasEmptyScript => _spellScript.GetType() == typeof(SpellScriptEmpty);
-
         public SpellState State { get; protected set; } = SpellState.STATE_READY;
         public float CurrentCooldown { get; protected set; }
         public float CurrentCastTime { get; protected set; }
         public float CurrentChannelDuration { get; protected set; }
         public float CurrentDelayTime { get; protected set; }
         public bool Toggle { get; protected set; }
-
-        public ISpellData SpellData { get; private set; }
+        public ISpellData SpellData { get; }
 
         public Spell(Game game, IObjAiBase owner, string spellName, byte slot)
         {
             _game = game;
             _scriptEngine = game.ScriptEngine;
-            _networkIdManager = game.NetworkIdManager;
-            _futureProjNetId = _networkIdManager.GetNewNetId();
+            NetworkIdManager = game.NetworkIdManager;
+            _futureProjNetId = NetworkIdManager.GetNewNetId();
 
             CastInfo.Owner = owner;
             SpellName = spellName;
@@ -61,7 +59,14 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             SpellData = game.Config.ContentManager.GetSpellData(spellName);
 
             //Set the game script for the spell
-            _spellScript = _scriptEngine.CreateObject<ISpellScript>("Spells", spellName) ?? new SpellScriptEmpty();
+            LoadScript();
+        }
+
+        public void LoadScript()
+        {
+            ApiEventManager.RemoveAllListenersForOwner(_spellScript);
+
+            _spellScript = _scriptEngine.CreateObject<ISpellScript>("Spells", SpellName) ?? new SpellScriptEmpty();
 
             if (_spellScript.ScriptMetadata.TriggersSpellCasts)
             {
@@ -77,12 +82,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             }
 
             //Activate spell - Notes: Deactivate is never called as spell removal hasn't been added
-            _spellScript.OnActivate(owner, this);
+            _spellScript.OnActivate(CastInfo.Owner, this);
         }
 
-        /// <summary>
-        /// Called by projectiles when they land / hit, this is where we apply damage/slows etc.
-        /// </summary>
         public void ApplyEffects(IAttackableUnit u, ISpellMissile p = null)
         {
             if (SpellData.HaveHitEffect && !string.IsNullOrEmpty(SpellData.HitEffectName) && !CastInfo.IsAutoAttack && HasEmptyScript)
@@ -100,9 +102,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             ApiEventManager.OnSpellHit.Publish(CastInfo.Owner, this, u, p);
         }
 
-        /// <summary>
-        /// Called when the character casts this spell. Initializes the CastInfo for this spell and begins casting.
-        /// </summary>
         public bool Cast(Vector2 start, Vector2 end, IAttackableUnit unit = null)
         {
             if (unit == null && SpellData.TargetingType == TargetingType.Target)
@@ -126,7 +125,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 return false;
             }
 
-            CastInfo.SpellNetID = _networkIdManager.GetNewNetId();
+            CastInfo.SpellNetID = NetworkIdManager.GetNewNetId();
 
             CastInfo.AttackSpeedModifier = stats.AttackSpeedMultiplier.Total;
 
@@ -135,7 +134,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 stats.CurrentMana -= SpellData.ManaCost[CastInfo.SpellLevel] * (1 - stats.SpellCostReduction);
             }
 
-            _futureProjNetId = _networkIdManager.GetNewNetId();
+            _futureProjNetId = NetworkIdManager.GetNewNetId();
 
             CastInfo.MissileNetID = _futureProjNetId;
 
@@ -359,9 +358,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             return true;
         }
 
-        /// <summary>
-        /// Called when a script manually casts this spell.
-        /// </summary>
         public bool Cast(ICastInfo castInfo, bool cast)
         {
             CastInfo = castInfo;
@@ -385,7 +381,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 }
             }
 
-            _futureProjNetId = _networkIdManager.GetNewNetId();
+            _futureProjNetId = NetworkIdManager.GetNewNetId();
 
             CastInfo.MissileNetID = _futureProjNetId;
 
@@ -587,9 +583,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             return true;
         }
 
-        /// <summary>
-        /// Called after the spell has finished casting and is beginning a channel.
-        /// </summary>
         public void Channel()
         {
             State = SpellState.STATE_CHANNELING;
@@ -606,11 +599,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             }
         }
 
-        /// <summary>
-        /// Forces this spell to stop channeling based on the given condition for the given reason.
-        /// </summary>
-        /// <param name="condition">Canceled or successful?</param>
-        /// <param name="reason">How it should be treated.</param>
         public void StopChanneling(ChannelingStopCondition condition, ChannelingStopSource reason)
         {
             if (condition == ChannelingStopCondition.Cancel)
@@ -632,9 +620,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             _spellScript.OnDeactivate(CastInfo.Owner, this);
         }
 
-        /// <summary>
-        /// Called when the spell is finished casting and we're supposed to do things such as projectile spawning, etc.
-        /// </summary>
         public void FinishCasting()
         {
             if (_spellScript.ScriptMetadata.TriggersSpellCasts)
@@ -740,9 +725,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             }
         }
 
-        /// <summary>
-        /// Creates a single-target missile with the specified properties.
-        /// </summary>
         public ISpellMissile CreateSpellMissile()
         {
             if (CastInfo.MissileNetID == 0)
@@ -751,12 +733,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 return null;
             }
 
-            var isServerOnly = false;
-
-            if (SpellData.MissileEffect != "")
-            {
-                isServerOnly = true;
-            }
+            bool isServerOnly = SpellData.MissileEffect != "";
 
             var p = new SpellMissile(
                 _game,
@@ -780,9 +757,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             return p;
         }
 
-        /// <summary>
-        /// Creates a single-target bouncing missile with the specified properties.
-        /// </summary>
         public ISpellMissile CreateSpellChainMissile()
         {
             if (CastInfo.MissileNetID == 0)
@@ -791,12 +765,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 return null;
             }
 
-            var isServerOnly = false;
-
-            if (SpellData.MissileEffect != "")
-            {
-                isServerOnly = true;
-            }
+            bool isServerOnly = SpellData.MissileEffect != "";
 
             var p = new SpellChainMissile(
                 _game,
@@ -821,9 +790,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             return p;
         }
 
-        /// <summary>
-        /// Creates a line missile with the specified properties.
-        /// </summary>
         public ISpellMissile CreateSpellCircleMissile()
         {
             if (CastInfo.MissileNetID == 0)
@@ -832,12 +798,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 return null;
             }
 
-            var isServerOnly = false;
-
-            if (SpellData.MissileEffect != "")
-            {
-                isServerOnly = true;
-            }
+            bool isServerOnly = SpellData.MissileEffect != "";
 
             var p = new SpellCircleMissile(
                 _game,
@@ -861,9 +822,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             return p;
         }
 
-        /// <summary>
-        /// Creates an arc missile with the specified properties.
-        /// </summary>
         public ISpellMissile CreateSpellLineMissile()
         {
             if (CastInfo.MissileNetID == 0)
@@ -872,12 +830,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 return null;
             }
 
-            var isServerOnly = false;
-
-            if (SpellData.MissileEffect != "")
-            {
-                isServerOnly = true;
-            }
+            bool isServerOnly = SpellData.MissileEffect != "";
 
             var p = new SpellLineMissile(
                 _game,
@@ -901,9 +854,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             return p;
         }
 
-        /// <summary>
-        /// Called when the character finished channeling
-        /// </summary>
         public void FinishChanneling()
         {
             ApiEventManager.OnSpellPostChannel.Publish(this);
@@ -927,13 +877,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             return _game.Config.CooldownsEnabled ? SpellData.Cooldown[CastInfo.SpellLevel] * (1 - CastInfo.Owner.Stats.CooldownReduction.Total) : 0;
         }
 
-        /// <summary>
-        /// Gets the cast range for this spell (based on level).
-        /// </summary>
-        /// <returns>Cast range based on level.</returns>
         public float GetCurrentCastRange()
         {
-            var castRange = SpellData.CastRange[0];
+            float castRange = SpellData.CastRange[0];
 
             if (CastInfo.SpellLevel == 0)
             {
@@ -954,7 +900,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             return castRange;
         }
 
-        /// <returns>spell's unique ID</returns>
         public int GetId()
         {
             return (int)HashFunctions.HashString(SpellName);
@@ -962,25 +907,16 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
 
         public string GetStringForSlot()
         {
-            switch (CastInfo.SpellSlot)
+            return CastInfo.SpellSlot switch
             {
-                case 0:
-                    return "Q";
-                case 1:
-                    return "W";
-                case 2:
-                    return "E";
-                case 3:
-                    return "R";
-                case 62:
-                    return "Passive";
-                case var n when (n <= 81 && n >= 64):
-                {
-                    return "Attack";
-                }
-            }
-
-            return "undefined";
+                0 => "Q",
+                1 => "W",
+                2 => "E",
+                3 => "R",
+                62 => "Passive",
+                var n when (n <= 81 && n >= 64) => "Attack",
+                _ => "undefined"
+            };
         }
 
         public void LevelUp()
@@ -1039,19 +975,12 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             }
         }
 
-        /// <summary>
-        /// Sets the state of the spell to the specified state. Often used when reseting time between spell casts.
-        /// </summary>
-        /// <param name="state"></param>
         public void SetSpellState(SpellState state)
         {
             State = state;
         }
 
-        /// <summary>
-        /// Sets the toggle state of this spell to the specified state. True = usable, false = sealed, unusable.
-        /// </summary>
-        /// <param name="toggle">True/False.</param>
+
         public void SetSpellToggle(bool toggle)
         {
             Toggle = toggle;

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -18,10 +18,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
         // Crucial Vars.
         private readonly Game _game;
         private readonly CSharpScriptEngine _scriptEngine;
+        private readonly NetworkIdManager _networkIdManager;
         private uint _futureProjNetId;
         private ISpellScript _spellScript;
-
-        protected NetworkIdManager NetworkIdManager;
 
         public ICastInfo CastInfo { get; private set; } = new CastInfo();
         public string SpellName { get; }
@@ -38,8 +37,8 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
         {
             _game = game;
             _scriptEngine = game.ScriptEngine;
-            NetworkIdManager = game.NetworkIdManager;
-            _futureProjNetId = NetworkIdManager.GetNewNetId();
+            _networkIdManager = game.NetworkIdManager;
+            _futureProjNetId = _networkIdManager.GetNewNetId();
 
             CastInfo.Owner = owner;
             SpellName = spellName;
@@ -125,7 +124,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 return false;
             }
 
-            CastInfo.SpellNetID = NetworkIdManager.GetNewNetId();
+            CastInfo.SpellNetID = _networkIdManager.GetNewNetId();
 
             CastInfo.AttackSpeedModifier = stats.AttackSpeedMultiplier.Total;
 
@@ -134,7 +133,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 stats.CurrentMana -= SpellData.ManaCost[CastInfo.SpellLevel] * (1 - stats.SpellCostReduction);
             }
 
-            _futureProjNetId = NetworkIdManager.GetNewNetId();
+            _futureProjNetId = _networkIdManager.GetNewNetId();
 
             CastInfo.MissileNetID = _futureProjNetId;
 
@@ -381,7 +380,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 }
             }
 
-            _futureProjNetId = NetworkIdManager.GetNewNetId();
+            _futureProjNetId = _networkIdManager.GetNewNetId();
 
             CastInfo.MissileNetID = _futureProjNetId;
 


### PR DESCRIPTION
Resolve #1075 Fixed the !reloadscripts command.
Resolve #723 implemented Script Hot Reloading.
The new command is !hotreload 1/0, which helps write scripts quickly.

Added reference of GameMaths to the script engine in order to use MathExtensions in scripts.

Also consolidated the method documentations for Spell.cs and Buff.cs that were strewn across the classes and their interfaces.

