### PR TITLE
Resolve #1079 -- RemoveAllListeners in ApiEventManager

### DIFF
--- a/GameServerLib/API/ApiEventManager.cs
+++ b/GameServerLib/API/ApiEventManager.cs
@@ -77,9 +77,11 @@ namespace LeagueSandbox.GameServer.API
         {
             OnHitUnit.RemoveListener(owner);
             OnLaunchAttack.RemoveListener(owner);
+            OnLaunchMissile.RemoveListener(owner);
             OnPreAttack.RemoveListener(owner);
             OnSpellCast.RemoveListener(owner);
             OnSpellChannel.RemoveListener(owner);
+            OnSpellChannelCancel.RemoveListener(owner);
             OnSpellHit.RemoveListener(owner);
             OnSpellPostCast.RemoveListener(owner);
             OnSpellPostChannel.RemoveListener(owner);


### PR DESCRIPTION
References #1079 
Added
```
        OnSpellChannelCancel.RemoveListener(owner);
        OnLaunchMissile.RemoveListener(owner);
```

All listeners are now cleanly removed.

Resolve #1079