### PR TITLE
[Scripting] Item Actives

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Items/DeathfireGraspSpell.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Items/DeathfireGraspSpell.cs
@@ -5,9 +5,9 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 
-namespace Deathfire_Grasp
+namespace DeathfireGraspSpell
 {
-    internal class Deathfire_Grasp : IBuffGameScript
+    internal class DeathfireGraspSpell : IBuffGameScript
     {
         public BuffType BuffType => BuffType.COMBAT_DEHANCER;
         public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
@@ -16,20 +16,17 @@ namespace Deathfire_Grasp
 
         public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
-        IParticle target;
         IParticle debuff;
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            target = AddParticleTarget(ownerSpell.CastInfo.Owner, "deathFireGrasp_tar.troy", target);
-            debuff = AddParticleTarget(ownerSpell.CastInfo.Owner, "obj_DeathfireGrasp_debuff.troy", target);
+            debuff = AddParticleTarget(ownerSpell.CastInfo.Owner, "obj_DeathfireGrasp_debuff.troy", unit);
 
-            // TODO: Implement damage amp. stat modifier
+            // TODO: Implement damage amp. stat modifier or OnTakeDamage listener
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            RemoveParticle(target);
             RemoveParticle(debuff);
         }
 

--- a/Content/LeagueSandbox-Scripts/Items/DeathfireGrasp.cs
+++ b/Content/LeagueSandbox-Scripts/Items/DeathfireGrasp.cs
@@ -5,6 +5,8 @@ using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Enums;
 using System.Numerics;
+using LeagueSandbox.GameServer.API;
+using System.Collections.Generic;
 
 namespace Spells
 {
@@ -25,8 +27,7 @@ namespace Spells
 
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
-            //spell.AddProjectileTarget("DeathfireGraspSpell", spell.CastInfo.SpellCastLaunchPosition, target);
-            AddBuff("Deathfire Grasp", 4.0f, 1, spell, target, owner);
+            SpellCastItem(owner, "DeathfireGraspSpell", true, target, Vector2.Zero);
         }
 
         public void OnSpellCast(ISpell spell)
@@ -37,10 +38,60 @@ namespace Spells
         {
         }
 
-        public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, ISpellMissile missile)
+        public void OnSpellChannel(ISpell spell)
         {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+
+    public class DeathfireGraspSpell : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            MissileParameters = new MissileParameters
+            {
+                Type = MissileType.Target
+            }
+            // TODO
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+            ApiEventManager.OnSpellHit.AddListener(this, new KeyValuePair<ISpell, IObjAiBase>(spell, owner), TargetExecute, true);
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+
+        public void TargetExecute(ISpell spell, IAttackableUnit target, ISpellMissile missile)
+        {
+            AddBuff("DeathfireGraspSpell", 4.0f, 1, spell, target, spell.CastInfo.Owner);
             var damage = target.Stats.HealthPoints.Total * 0.15f;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_DEFAULT, false);
+            target.TakeDamage(spell.CastInfo.Owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_DEFAULT, false);
             missile.SetToRemove();
         }
 

--- a/GameServerCore/Enums/SpellSlotType.cs
+++ b/GameServerCore/Enums/SpellSlotType.cs
@@ -3,7 +3,17 @@
     public enum SpellSlotType
     {
         SpellSlots,
-        InventorySlots,
-        ExtraSlots
+        SummonerSpellSlots = 4,
+        InventorySlots = 6,
+        BluePillSlot = 13,
+        TempItemSlot = 14,
+        RuneSlots = 15,
+        ExtraSlots = 45,
+        RespawnSpellSlot = 61,
+        UseSpellSlot = 62,
+        PassiveSpellSlot = 63,
+        BasicAttackNormalSlots = 64,
+        // TODO: Verify if we need this
+        BasicAttackCriticalSlots = 73
     }
 }

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -553,11 +553,11 @@ namespace LeagueSandbox.GameServer.API
         public static void SealSpellSlot(IObjAiBase target, SpellSlotType slotType, int slot, SpellbookType spellbookType, bool seal)
         {
             if (spellbookType == SpellbookType.SPELLBOOK_UNKNOWN
-                || (spellbookType == SpellbookType.SPELLBOOK_SUMMONER && (slotType != SpellSlotType.SpellSlots)
+                || spellbookType == SpellbookType.SPELLBOOK_SUMMONER && (slotType != SpellSlotType.SpellSlots)
                 || (spellbookType == SpellbookType.SPELLBOOK_CHAMPION
-                    && ((slotType == SpellSlotType.SpellSlots && slot < 0 || slot > 3)
-                        || (slotType == SpellSlotType.InventorySlots && slot < 0 && slot > 6)
-                        || (slotType == SpellSlotType.ExtraSlots && slot < 0 && slot > 15)))))
+                    && ((slotType == SpellSlotType.SpellSlots && (slot < 0 || slot > 3))
+                        || (slotType == SpellSlotType.InventorySlots && (slot < 0 || slot > 6))
+                        || (slotType == SpellSlotType.ExtraSlots && (slot < 0 || slot > 15)))))
             {
                 return;
             }
@@ -566,16 +566,16 @@ namespace LeagueSandbox.GameServer.API
             {
                 if (slotType == SpellSlotType.InventorySlots)
                 {
-                    slot += 6;
+                    slot += (int)SpellSlotType.InventorySlots;
                 }
                 if (slotType == SpellSlotType.ExtraSlots)
                 {
-                    slot += 45;
+                    slot += (int)SpellSlotType.ExtraSlots;
                 }
             }
             else
             {
-                slot += 4;
+                slot += (int)SpellSlotType.SummonerSpellSlots;
             }
 
             target.Stats.SetSpellEnabled((byte)slot, !seal);
@@ -583,21 +583,26 @@ namespace LeagueSandbox.GameServer.API
 
         public static void SpellCast(IObjAiBase caster, int slot, SpellSlotType slotType, Vector2 pos, Vector2 endPos, bool fireWithoutCasting, Vector2 overrideCastPos, List<ICastTarget> targets = null, bool isForceCastingOrChanneling = false, int overrideForceLevel = -1, bool updateAutoAttackTimer = false, bool useAutoAttackSpell = false)
         {
-            if ((slotType == SpellSlotType.SpellSlots && slot < 0 || slot > 3)
-                || (slotType == SpellSlotType.InventorySlots && slot < 0 && slot > 6)
-                || (slotType == SpellSlotType.ExtraSlots && slot < 0 && slot > 15))
+            if ((slotType == SpellSlotType.SpellSlots && (slot < 0 || slot > 3))
+                || (slotType == SpellSlotType.InventorySlots && (slot < 0 || slot > 6))
+                || (slotType == SpellSlotType.ExtraSlots && (slot < 0 || slot > 15)))
             {
                 return;
             }
 
             if (slotType == SpellSlotType.InventorySlots)
             {
-                slot += 4;
+                slot += (int)SpellSlotType.InventorySlots;
+            }
+
+            if (slotType == SpellSlotType.TempItemSlot)
+            {
+                slot = (int)SpellSlotType.TempItemSlot;
             }
 
             if (slotType == SpellSlotType.ExtraSlots)
             {
-                slot += 45;
+                slot += (int)SpellSlotType.ExtraSlots;
             }
 
             ISpell spell = caster.GetSpell((byte)slot);
@@ -657,6 +662,25 @@ namespace LeagueSandbox.GameServer.API
             ICastTarget castTarget = new CastTarget(target, CastTarget.GetHitResult(target, useAutoAttackSpell, caster.IsNextAutoCrit));
 
             SpellCast(caster, slot, slotType, target.Position, target.Position, fireWithoutCasting, overrideCastPos, new List<ICastTarget> { castTarget }, isForceCastingOrChanneling, overrideForceLevel, updateAutoAttackTimer, useAutoAttackSpell);
+        }
+
+        public static void SpellCast(IObjAiBase caster, int slot, SpellSlotType slotType, Vector2 pos, Vector2 endPos, bool fireWithoutCasting, Vector2 overrideCastPos, bool isForceCastingOrChanneling = false, int overrideForceLevel = -1, bool updateAutoAttackTimer = false, bool useAutoAttackSpell = false)
+        {
+            SpellCast(caster, slot, slotType, pos, endPos, fireWithoutCasting, overrideCastPos, null, isForceCastingOrChanneling, overrideForceLevel, updateAutoAttackTimer, useAutoAttackSpell);
+        }
+
+        public static void SpellCastItem(IObjAiBase caster, string itemSpellName, bool fireWithoutCasting, IAttackableUnit target, Vector2 overrideCastPos, bool isForceCastingOrChanneling = false, int overrideForceLevel = -1, bool updateAutoAttackTimer = false, bool useAutoAttackSpell = false)
+        {
+            // Apply the spell to the TempItemSlot.
+            caster.SetSpell(itemSpellName, (byte)SpellSlotType.TempItemSlot, true);
+            SpellCast(caster, 0, SpellSlotType.TempItemSlot, fireWithoutCasting, target, overrideCastPos, isForceCastingOrChanneling, overrideForceLevel, updateAutoAttackTimer, useAutoAttackSpell);
+        }
+
+        public static void SpellCastItem(IObjAiBase caster, string itemSpellName, Vector2 pos, Vector2 endPos, bool fireWithoutCasting, Vector2 overrideCastPos, bool isForceCastingOrChanneling = false, int overrideForceLevel = -1, bool updateAutoAttackTimer = false, bool useAutoAttackSpell = false)
+        {
+            // Apply the spell to the TempItemSlot.
+            caster.SetSpell(itemSpellName, (byte)SpellSlotType.TempItemSlot, true);
+            SpellCast(caster, 0, SpellSlotType.TempItemSlot, pos, endPos, fireWithoutCasting, overrideCastPos, isForceCastingOrChanneling, overrideForceLevel, updateAutoAttackTimer, useAutoAttackSpell);
         }
 
         public static void StopChanneling(IObjAiBase target, ChannelingStopCondition stopCondition, ChannelingStopSource stopSource)

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -664,11 +664,6 @@ namespace LeagueSandbox.GameServer.API
             SpellCast(caster, slot, slotType, target.Position, target.Position, fireWithoutCasting, overrideCastPos, new List<ICastTarget> { castTarget }, isForceCastingOrChanneling, overrideForceLevel, updateAutoAttackTimer, useAutoAttackSpell);
         }
 
-        public static void SpellCast(IObjAiBase caster, int slot, SpellSlotType slotType, Vector2 pos, Vector2 endPos, bool fireWithoutCasting, Vector2 overrideCastPos, bool isForceCastingOrChanneling = false, int overrideForceLevel = -1, bool updateAutoAttackTimer = false, bool useAutoAttackSpell = false)
-        {
-            SpellCast(caster, slot, slotType, pos, endPos, fireWithoutCasting, overrideCastPos, null, isForceCastingOrChanneling, overrideForceLevel, updateAutoAttackTimer, useAutoAttackSpell);
-        }
-
         public static void SpellCastItem(IObjAiBase caster, string itemSpellName, bool fireWithoutCasting, IAttackableUnit target, Vector2 overrideCastPos, bool isForceCastingOrChanneling = false, int overrideForceLevel = -1, bool updateAutoAttackTimer = false, bool useAutoAttackSpell = false)
         {
             // Apply the spell to the TempItemSlot.
@@ -680,7 +675,7 @@ namespace LeagueSandbox.GameServer.API
         {
             // Apply the spell to the TempItemSlot.
             caster.SetSpell(itemSpellName, (byte)SpellSlotType.TempItemSlot, true);
-            SpellCast(caster, 0, SpellSlotType.TempItemSlot, pos, endPos, fireWithoutCasting, overrideCastPos, isForceCastingOrChanneling, overrideForceLevel, updateAutoAttackTimer, useAutoAttackSpell);
+            SpellCast(caster, 0, SpellSlotType.TempItemSlot, pos, endPos, fireWithoutCasting, overrideCastPos, null, isForceCastingOrChanneling, overrideForceLevel, updateAutoAttackTimer, useAutoAttackSpell);
         }
 
         public static void StopChanneling(IObjAiBase target, ChannelingStopCondition stopCondition, ChannelingStopSource stopSource)

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -56,18 +56,16 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             Stats.IsGeneratingGold = false;
 
             //TODO: automaticaly rise spell levels with CharData.SpellLevelsUp
+            
+            Spells[(int)SpellSlotType.SummonerSpellSlots] = new Spell.Spell(game, this, clientInfo.SummonerSkills[0], (int)SpellSlotType.SummonerSpellSlots);
+            Spells[(int)SpellSlotType.SummonerSpellSlots].LevelUp();
+            Spells[(int)SpellSlotType.SummonerSpellSlots + 1] = new Spell.Spell(game, this, clientInfo.SummonerSkills[1], (int)SpellSlotType.SummonerSpellSlots + 1);
+            Spells[(int)SpellSlotType.SummonerSpellSlots + 1].LevelUp();
 
-            Spells[4] = new Spell.Spell(game, this, clientInfo.SummonerSkills[0], 4);
-            Spells[5] = new Spell.Spell(game, this, clientInfo.SummonerSkills[1], 5);
-
-            Spells[13] = new Spell.Spell(game, this, "Recall", 13);
-
-            Spells[4].LevelUp();
-            Spells[5].LevelUp();
+            Spells[(int)SpellSlotType.BluePillSlot] = new Spell.Spell(game, this, "Recall", (int)SpellSlotType.BluePillSlot);
+            Stats.SetSpellEnabled((byte)SpellSlotType.BluePillSlot, true);
 
             Replication = new ReplicationHero(this);
-
-            Stats.SetSpellEnabled(13, true);
         }
 
         private string GetPlayerIndex()

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -133,49 +133,51 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     }
                 }
 
-                // SummonerSpellSlots
-                // 4 - 5
+                Spells[(int)SpellSlotType.SummonerSpellSlots] = new Spell.Spell(game, this, "BaseSpell", (int)SpellSlotType.SummonerSpellSlots);
+                Spells[(int)SpellSlotType.SummonerSpellSlots + 1] = new Spell.Spell(game, this, "BaseSpell", (int)SpellSlotType.SummonerSpellSlots + 1);
 
                 // InventorySlots
                 // 6 - 12 (12 = TrinketSlot)
-                for (byte i = 6; i < 13; i++)
+                for (byte i = (int)SpellSlotType.InventorySlots; i < (int)SpellSlotType.BluePillSlot; i++)
                 {
                     Spells[i] = new Spell.Spell(game, this, "BaseSpell", i);
                 }
 
-                // BluePillSlot
-                // 13
-
-                // TempItemSlot
-                // 14
+                Spells[(int)SpellSlotType.BluePillSlot] = new Spell.Spell(game, this, "BaseSpell", (int)SpellSlotType.BluePillSlot);
+                Spells[(int)SpellSlotType.TempItemSlot] = new Spell.Spell(game, this, "BaseSpell", (int)SpellSlotType.TempItemSlot);
 
                 // RuneSlots
                 // 15 - 44
+                for (short i = (int)SpellSlotType.RuneSlots; i < (int)SpellSlotType.ExtraSlots; i++)
+                {
+                    Spells[(byte)i] = new Spell.Spell(game, this, "BaseSpell", (byte)i);
+                }
 
                 // ExtraSpells
                 // 45 - 60
                 for (short i = 0; i < CharData.ExtraSpells.Length; i++)
                 {
+                    var extraSpellName = "BaseSpell";
                     if (!string.IsNullOrEmpty(CharData.ExtraSpells[i]))
                     {
-                        var spellSlot = i + 45;
-                        Spells[(byte)(spellSlot)] = new Spell.Spell(game, this, CharData.ExtraSpells[i], (byte)(spellSlot));
-                        Spells[(byte)(spellSlot)].LevelUp();
+                        extraSpellName = CharData.ExtraSpells[i];
                     }
+
+                    var slot = i + (int)SpellSlotType.ExtraSlots;
+                    Spells[(byte)slot] = new Spell.Spell(game, this, extraSpellName, (byte)slot);
+                    Spells[(byte)slot].LevelUp();
                 }
 
-                // RespawnSpellSlot
-                // 61
+                Spells[(int)SpellSlotType.RespawnSpellSlot] = new Spell.Spell(game, this, "BaseSpell", (int)SpellSlotType.RespawnSpellSlot);
+                Spells[(int)SpellSlotType.UseSpellSlot] = new Spell.Spell(game, this, "BaseSpell", (int)SpellSlotType.UseSpellSlot);
 
-                // UseSpellSlot
-                // 62
-
-                // PassiveSpellSlot
-                // 63
+                var passiveSpellName = "BaseSpell";
                 if (!string.IsNullOrEmpty(CharData.Passive.PassiveAbilityName))
                 {
-                    Spells[63] = new Spell.Spell(game, this, CharData.Passive.PassiveAbilityName, 63);
+                    passiveSpellName = CharData.Passive.PassiveAbilityName;
                 }
+
+                Spells[(int)SpellSlotType.PassiveSpellSlot] = new Spell.Spell(game, this, passiveSpellName, (int)SpellSlotType.PassiveSpellSlot);
 
                 // BasicAttackNormalSlots & BasicAttackCriticalSlots
                 // 64 - 72 & 73 - 81
@@ -183,7 +185,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 {
                     if (!string.IsNullOrEmpty(CharData.AttackNames[i]))
                     {
-                        Spells[(byte)(i + 64)] = new Spell.Spell(game, this, CharData.AttackNames[i], (byte)(i + 64));
+                        int slot = i + (int)SpellSlotType.BasicAttackNormalSlots;
+                        Spells[(byte)slot] = new Spell.Spell(game, this, CharData.AttackNames[i], (byte)slot);
                     }
                 }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -344,7 +344,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 
                     break;
                 case DamageType.DAMAGE_TYPE_MAGICAL:
-                    defense = Stats.MagicPenetration.Total;
+                    defense = Stats.MagicResist.Total;
                     defense = (1 - attackerStats.MagicPenetration.PercentBonus) * defense -
                               attackerStats.MagicPenetration.FlatBonus;
                     break;


### PR DESCRIPTION
* Scripting:
  * Added SpellCastItem (location and targeted) for items which require manual casted missile spells.
  * Re-implemented DeathfireGrasp as an example.
  * Added location targeted SpellCast.
* Enums:
  * Expanded SpellSlotType and added start index for each.
* ObjAiBase & Champion:
  * Used SpellSlotType in place of spell slot magic numbers.
  
Resolve #1087, #1085, #1084