### PR TITLE
Resolve #1052, Resolve #970 -- Optimize LaneMinion

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
@@ -101,23 +101,28 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             IAttackableUnit nextTarget = null;
             var nextTargetPriority = 14;
-            var objects = _game.ObjectManager.GetObjects();
+            // TODO: Verify if we still need to order this by distance (if it is ordered by time created).
+            var nearestObjects = _game.Map.CollisionHandler.QuadDynamic.GetNearestObjects(this);
             //Find target closest to max attack range.
-            foreach (var it in objects.OrderBy(x => Vector2.DistanceSquared(Position, x.Value.Position) - (Stats.Range.Total * Stats.Range.Total)))
+            foreach (var it in nearestObjects)
             {
-                if (!(it.Value is IAttackableUnit u) ||
+                if (!(it is IAttackableUnit u) ||
                     u.IsDead ||
                     u.Team == Team ||
                     Vector2.DistanceSquared(Position, u.Position) > DETECT_RANGE * DETECT_RANGE ||
                     !_game.ObjectManager.TeamHasVisionOn(Team, u))
+                {
                     continue;
+                }
+
                 var priority = (int)ClassifyTarget(u);  // get the priority.
                 if (priority < nextTargetPriority) // if the priority is lower than the target we checked previously
                 {
-                    nextTarget = u;                // make him a potential target.
+                    nextTarget = u;                // make it a potential target.
                     nextTargetPriority = priority;
                 }
             }
+
             if (nextTarget != null) // If we have a target
             {
                 // Set the new target and refresh waypoints
@@ -125,8 +130,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
                 return true;
             }
-            _game.PacketNotifier.NotifyNPC_InstantStop_Attack(this, false);
-            IsAttacking = false;
+
             return false;
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
@@ -101,10 +101,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             IAttackableUnit nextTarget = null;
             var nextTargetPriority = 14;
-            // TODO: Verify if we still need to order this by distance (if it is ordered by time created).
             var nearestObjects = _game.Map.CollisionHandler.QuadDynamic.GetNearestObjects(this);
             //Find target closest to max attack range.
-            foreach (var it in nearestObjects)
+            foreach (var it in nearestObjects.OrderBy(x => Vector2.DistanceSquared(Position, x.Position) - (Stats.Range.Total * Stats.Range.Total)))
             {
                 if (!(it is IAttackableUnit u) ||
                     u.IsDead ||

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -456,7 +456,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public bool RecalculateAttackPosition()
         {
             // If we are already where we should be, which means we are in attack range, then keep our current position.
-            if (TargetUnit != null && !TargetUnit.IsDead && Vector2.DistanceSquared(Position, TargetUnit.Position) <= Stats.Range.Total * Stats.Range.Total)
+            if (TargetUnit == null || TargetUnit.IsDead || Vector2.DistanceSquared(Position, TargetUnit.Position) <= Stats.Range.Total * Stats.Range.Total)
             {
                 return false;
             }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -455,65 +455,38 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// TODO: Re-implement this for LaneMinions and add a patience or distance threshold so they don't follow forever.
         public bool RecalculateAttackPosition()
         {
-            // If we are already where we should be, which means we are in attack range and not colliding, then keep our current position.
-            if (TargetUnit != null && !TargetUnit.IsDead && Vector2.DistanceSquared(Position, TargetUnit.Position) > CollisionRadius * CollisionRadius
-                && Vector2.DistanceSquared(Position, TargetUnit.Position) <= Stats.Range.Total * Stats.Range.Total)
+            // If we are already where we should be, which means we are in attack range, then keep our current position.
+            if (TargetUnit != null && !TargetUnit.IsDead && Vector2.DistanceSquared(Position, TargetUnit.Position) <= Stats.Range.Total * Stats.Range.Total)
             {
                 return false;
             }
-            var objects = _game.ObjectManager.GetObjects();
-            List<CirclePoly> usedPositions = new List<CirclePoly>();
+
+            var nearestObjects = _game.Map.CollisionHandler.QuadDynamic.GetNearestObjects(this);
             var isCurrentlyOverlapping = false;
 
-            var thisCollisionCircle = new CirclePoly(TargetUnit?.Position ?? Position, CollisionRadius + 10);
-
-            foreach (var gameObject in objects)
+            foreach (var gameObject in nearestObjects)
             {
-                var unit = gameObject.Value as IAttackableUnit;
+                var unit = gameObject as IAttackableUnit;
                 if (unit == null ||
                     unit.NetId == NetId ||
                     unit.IsDead ||
-                    unit.Team != Team ||
                     Vector2.DistanceSquared(Position, TargetUnit.Position) > DETECT_RANGE * DETECT_RANGE
                 )
                 {
                     continue;
                 }
-                var targetCollisionCircle = new CirclePoly(unit.Position, unit.CollisionRadius + 10);
-                if (targetCollisionCircle.CheckForOverLaps(thisCollisionCircle))
-                {
-                    isCurrentlyOverlapping = true;
-                }
-                usedPositions.Add(targetCollisionCircle);
-            }
-            if (isCurrentlyOverlapping)
-            {
-                // TODO: Optimize this, preferably without things like CirclePoly.
-                var targetCircle = new CirclePoly(TargetUnit.Position, Stats.Range.Total, 72);
-                //Find optimal position...
-                foreach (var point in targetCircle.Points.OrderBy(x => Vector2.DistanceSquared(Position, x)))
-                {
-                    if (!_game.Map.NavigationGrid.IsVisible(point))
-                    {
-                        continue;
-                    }
-                    var positionUsed = false;
-                    foreach (var circlePoly in usedPositions)
-                    {
-                        if (circlePoly.CheckForOverLaps(new CirclePoly(point, CollisionRadius + 10, 20)))
-                        {
-                            positionUsed = true;
-                        }
-                    }
 
-                    if (positionUsed)
-                    {
-                        continue;
-                    }
-                    SetWaypoints(new List<Vector2> { Position, point });
+                var closestPoint = GameServerCore.Extensions.GetClosestCircleEdgePoint(Position, gameObject.Position, gameObject.CollisionRadius);
+
+                // If this unit is colliding with gameObject
+                if (GameServerCore.Extensions.IsVectorWithinRange(closestPoint, Position, CollisionRadius))
+                {
+                    var exitPoint = GameServerCore.Extensions.GetCircleEscapePoint(Position, CollisionRadius + 1, gameObject.Position, gameObject.CollisionRadius);
+                    SetWaypoints(new List<Vector2> { Position, exitPoint });
                     return true;
                 }
             }
+
             return false;
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -462,7 +462,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
 
             var nearestObjects = _game.Map.CollisionHandler.QuadDynamic.GetNearestObjects(this);
-            var isCurrentlyOverlapping = false;
 
             foreach (var gameObject in nearestObjects)
             {


### PR DESCRIPTION
This fixes issues with CPU usage regarding LaneMinions.

Resolve #1052, #970

* ObjAiBase:
  * RecalculateAttackPosition no longer uses CirclePoly.
* Minion:
  * Switched to using QuadTree's GetNearestObjects.

New method tested with 10 minutes of continuous lane minion stacking on both teams. At the end of 10 minutes (~300 alive minions in total), the maximum ping was 60ms with minor hangups when taking actions.
The previous method with 5 minutes of continuous lane minion stacking on one team (~70 alive minions in total) had a maximum ping of 300 (highly flucuating) with major hangups when taking actions.