### PR TITLE
Progress #1059, Progress #1061 -- [QOL] SpellCast Fix & Particles

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab.cs
@@ -1,0 +1,36 @@
+﻿using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Domain.GameObjects.Spell;
+
+namespace RocketGrab
+{
+    internal class RocketGrab : IBuffGameScript
+    {
+        public BuffType BuffType => BuffType.INTERNAL;
+        public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
+        public int MaxStacks => 1;
+        public bool IsHidden => false;
+
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
+
+        IParticle grab;
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            grab = AddParticleTarget(unit, "FistReturn_mis.troy", ownerSpell.CastInfo.Owner, 1, "head", "R_hand", lifetime: buff.Duration);
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            RemoveParticle(grab);
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}
+

--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
@@ -1,0 +1,45 @@
+﻿using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Domain.GameObjects.Spell;
+
+namespace RocketGrab2
+{
+    internal class RocketGrab2 : IBuffGameScript
+    {
+        public BuffType BuffType => BuffType.STUN;
+        public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
+        public int MaxStacks => 1;
+        public bool IsHidden => false;
+
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            unit.Stats.SetActionState(ActionState.CAN_ATTACK, false);
+            unit.Stats.SetActionState(ActionState.CAN_CAST, false);
+            unit.Stats.SetActionState(ActionState.CAN_MOVE, false);
+
+            ForceMovement(unit, "RUN", buff.SourceUnit.Position, 1800f, 0, 5.0f, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            unit.Stats.SetActionState(ActionState.CAN_ATTACK, true);
+            unit.Stats.SetActionState(ActionState.CAN_CAST, true);
+            unit.Stats.SetActionState(ActionState.CAN_MOVE, true);
+
+            if (unit is IChampion)
+            {
+                buff.SourceUnit.SetTargetUnit(unit, true);
+            }
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}
+

--- a/Content/LeagueSandbox-Scripts/Champions/Blitzcrank/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Blitzcrank/Q.cs
@@ -5,6 +5,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
 
 namespace Spells
 {
@@ -24,42 +25,91 @@ namespace Spells
         {
         }
 
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+            FaceDirection(end, owner);
+        }
+
         public void OnSpellCast(ISpell spell)
         {
-            //spell.CastInfo.Owner.SpellAnimation("SPELL1");
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+            var endPos = GetPointFromUnit(spell.CastInfo.Owner, 925);
+            SpellCast(spell.CastInfo.Owner, 0, SpellSlotType.ExtraSlots, endPos, endPos, false, Vector2.Zero);
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+
+    public class RocketGrabMissile : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata => new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            MissileParameters = new MissileParameters
+            {
+                Type = MissileType.Circle
+            }
+            // TODO
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+            ApiEventManager.OnSpellHit.AddListener(this, new System.Collections.Generic.KeyValuePair<ISpell, IObjAiBase>(spell, spell.CastInfo.Owner), TargetExecute, false);
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
         }
 
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
         }
 
-        public void OnSpellPostCast(ISpell spell)
+        public void OnSpellCast(ISpell spell)
         {
-            var current = new Vector2(spell.CastInfo.Owner.Position.X, spell.CastInfo.Owner.Position.Y);
-            var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
-            var to = Vector2.Normalize(spellPos - current);
-            var range = to * 925;
-            var trueCoords = current + range;
-            //spell.AddProjectile("RocketGrabMissile", current, current, trueCoords);
+            // Prevent flash during cast.
+            SealSpellSlot(spell.CastInfo.Owner, SpellSlotType.SummonerSpellSlots, 0, SpellbookType.SPELLBOOK_SUMMONER, true);
+            SealSpellSlot(spell.CastInfo.Owner, SpellSlotType.SummonerSpellSlots, 1, SpellbookType.SPELLBOOK_SUMMONER, true);
         }
 
-        public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, ISpellMissile missile)
+        public void OnSpellPostCast(ISpell spell)
         {
+            SealSpellSlot(spell.CastInfo.Owner, SpellSlotType.SummonerSpellSlots, 0, SpellbookType.SPELLBOOK_SUMMONER, false);
+            SealSpellSlot(spell.CastInfo.Owner, SpellSlotType.SummonerSpellSlots, 1, SpellbookType.SPELLBOOK_SUMMONER, false);
+        }
+
+        public void TargetExecute(ISpell spell, IAttackableUnit target, ISpellMissile missile)
+        {
+            var owner = spell.CastInfo.Owner;
             var ap = owner.Stats.AbilityPower.Total;
-            var damage = 25 + spell.CastInfo.SpellLevel * 55 + ap;
+            var damage = 80 + ((spell.CastInfo.SpellLevel - 1) * 55) + ap;
             target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
-            if (!target.IsDead)
-            {
-                AddParticleTarget(owner, "Blitzcrank_Grapplin_tar.troy", target, 1, "L_HAND");
-                var current = new Vector2(owner.Position.X, owner.Position.Y);
-                var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
-                var to = Vector2.Normalize(spellPos - current);
-                var range = to * 50;
-                var trueCoords = current + range;
-                ForceMovement(target, "RUN", trueCoords, spell.SpellData.MissileSpeed, 0, 0, 0, movementOrdersFacing: ForceMovementOrdersFacing.KEEP_CURRENT_FACING);
-            }
 
             missile.SetToRemove();
+
+            var dist = System.Math.Abs(Vector2.Distance(target.Position, owner.Position));
+            var time = dist / 1350f;
+            // Grab particle
+            AddBuff("RocketGrab", time, 1, spell, target, owner);
+            // SetStatus & auto attack
+            AddBuff("RocketGrab2", 0.6f, 1, spell, target, owner);
         }
 
         public void OnSpellChannel(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/Ezreal/E.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Ezreal/E.cs
@@ -5,6 +5,8 @@ using GameServerCore.Enums;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
+using LeagueSandbox.GameServer.API;
+using System.Collections.Generic;
 
 namespace Spells
 {
@@ -12,8 +14,11 @@ namespace Spells
     {
         public ISpellScriptMetadata ScriptMetadata => new SpellScriptMetadata()
         {
-            TriggersSpellCasts = true
-            // TODO
+            CastingBreaksStealth = true,
+            DoesntBreakShields = true,
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            NotSingleTargetSpell = true
         };
 
         public void OnActivate(IObjAiBase owner, ISpell spell)
@@ -35,52 +40,82 @@ namespace Spells
         public void OnSpellPostCast(ISpell spell)
         {
             var owner = spell.CastInfo.Owner;
-            var current = new Vector2(owner.Position.X, owner.Position.Y);
-            var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
-            var to = spellPos - current;
-            Vector2 trueCoords;
+            var startPos = owner.Position;
+            var trueCoords = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
+
+            var to = trueCoords - startPos;
             if (to.Length() > 475)
             {
-                to = Vector2.Normalize(to);
-                var range = to * 475;
-                trueCoords = current + range;
-            }
-            else
-            {
-                trueCoords = spellPos;
+                trueCoords = GetPointFromUnit(owner, 475f);
             }
 
-            AddParticle(owner, "Ezreal_arcaneshift_cas.troy", owner.Position);
-            TeleportTo(owner, trueCoords.X, trueCoords.Y);
+            var target = GetClosestUnitInRange(owner, 750f, true);
+
+            if (target != null)
+            {
+                if (!(target is IBaseTurret))
+                {
+                    FaceDirection(target.Position, owner, true);
+                    SpellCast(owner, 1, SpellSlotType.ExtraSlots, true, target, trueCoords);
+                }
+            }
+
+            AddParticle(owner, "Ezreal_arcaneshift_cas.troy", startPos);
             AddParticleTarget(owner, "Ezreal_arcaneshift_flash.troy", owner);
-            IAttackableUnit target2 = null;
-            var units = GetUnitsInRange(current, 700, true);
-            float sqrDistance = 700 * 700;
-            foreach (var value in units)
-            {
-                if (owner.Team != value.Team && value is IObjAiBase)
-                {
-                    if (Vector2.DistanceSquared(trueCoords, value.Position) <=
-                        sqrDistance)
-                    {
-                        target2 = value;
-                        sqrDistance = Vector2.DistanceSquared(trueCoords, value.Position);
-                    }
-                }
-            }
 
-            if (target2 != null)
-            {
-                if (!(target2 is IBaseTurret))
-                {
-                    //spell.AddProjectileTarget("EzrealArcaneShiftMissile", new Vector3(trueCoords.X, owner.GetHeight() + 150.0f, trueCoords.Y), target2, overrideCastPosition: true);
-                }
-            }
+            TeleportTo(owner, trueCoords.X, trueCoords.Y);
         }
 
-        public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, ISpellMissile missile)
+        public void OnSpellChannel(ISpell spell)
         {
-            target.TakeDamage(owner, 25f + spell.CastInfo.SpellLevel * 50f + owner.Stats.AbilityPower.Total * 0.75f,
+        }
+
+        public void OnSpellChannelCancel(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+    public class EzrealArcaneShiftMissile : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata => new SpellScriptMetadata()
+        {
+            MissileParameters = new MissileParameters
+            {
+                Type = MissileType.Target
+            }
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+            ApiEventManager.OnSpellHit.AddListener(this, new KeyValuePair<ISpell, IObjAiBase>(spell, owner), TargetExecute, false);
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+
+        public void TargetExecute(ISpell spell, IAttackableUnit target, ISpellMissile missile)
+        {
+            target.TakeDamage(spell.CastInfo.Owner, 75f + ((spell.CastInfo.SpellLevel - 1) * 50f) + spell.CastInfo.Owner.Stats.AbilityPower.Total * 0.75f,
                 DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
             missile.SetToRemove();
         }

--- a/Content/LeagueSandbox-Scripts/Champions/Ezreal/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Ezreal/Q.cs
@@ -110,12 +110,13 @@ namespace Spells
             var ap = owner.Stats.AbilityPower.Total * spell.SpellData.MagicDamageCoefficient;
             var damage = 15 + spell.CastInfo.SpellLevel * 20 + ad + ap;
             target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
+
             for (byte i = 0; i < 4; i++)
             {
                 owner.Spells[i].LowerCooldown(1);
             }
 
-            AddParticleTarget(spell.CastInfo.Owner, "Ezreal_mysticshot_tar.troy", target);
+            AddParticleTarget(target, "Ezreal_mysticshot_tar.troy", target);
             missile.SetToRemove();
 
             // SpellBuffAdd EzrealRisingSpellForce

--- a/GameServerCore/Domain/GameObjects/IParticle.cs
+++ b/GameServerCore/Domain/GameObjects/IParticle.cs
@@ -8,9 +8,9 @@ namespace GameServerCore.Domain.GameObjects
     public interface IParticle : IGameObject
     {
         /// <summary>
-        /// Object which spawned or caused the particle to be instanced
+        /// Primary bind object.
         /// </summary>
-        IGameObject Owner { get; }
+        public IGameObject BindObject { get; }
         /// <summary>
         /// Client-sided, internal name of the particle used in networking, usually always ends in .troy
         /// </summary>
@@ -27,6 +27,10 @@ namespace GameServerCore.Domain.GameObjects
         /// Client-sided, internal name of the bone that this particle should be attached to for networking
         /// </summary>
         string BoneName { get; }
+        /// <summary>
+        /// Client-sided, internal name of the bone that this particle should be attached to on the target, for networking.
+        /// </summary>
+        string TargetBoneName { get; }
         /// <summary>
         /// Scale of the particle used in networking
         /// </summary>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -735,13 +735,6 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="timeOut">Time until voting becomes unavailable.</param>
         void NotifyTeamSurrenderVote(IChampion starter, bool open, bool votedYes, byte yesVotes, byte noVotes, byte maxVotes, float timeOut);
         /// <summary>
-        /// Sends a packet to all players with vision of the specified unit detailing that the unit has teleported to the specified position.
-        /// </summary>
-        /// <param name="o">GameObject that teleported.</param>
-        /// <param name="pos">2D top-down position that the unit teleported to.</param>
-        /// TODO: Take into account any movements (waypoints) that should carry over after the teleport.
-        void NotifyTeleport(IGameObject o, Vector2 pos);
-        /// <summary>
         /// Sends a packet to all players detailing that their screen's tint is shifting to the specified color.
         /// </summary>
         /// <param name="team">TeamID to apply the tint to.</param>
@@ -815,7 +808,8 @@ namespace GameServerCore.Packets.Interfaces
         /// Sends a packet to all players that have vision of the specified unit that it has made a movement.
         /// </summary>
         /// <param name="u">AttackableUnit that is moving.</param>
-        void NotifyWaypointGroup(IAttackableUnit u);
+        /// <param name="useTeleportID">Whether or not to teleport the unit to its current position in its path.</param>
+        void NotifyWaypointGroup(IAttackableUnit u, bool useTeleportID = true);
         /// <summary>
         /// Sends a packet to all players that have vision of the specified unit.
         /// The packet details a group of waypoints with speed parameters which determine what kind of movement will be done to reach the waypoints, or optionally a GameObject.

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -142,7 +142,6 @@ namespace LeagueSandbox.GameServer.API
             }
 
             unit.TeleportTo(x, y);
-            unit.StopMovement();
         }
 
         public static void FaceDirection(Vector2 location, IGameObject target, bool isInstant = false, float turnTime = 0.08333f)
@@ -422,7 +421,8 @@ namespace LeagueSandbox.GameServer.API
         {
             var units = _game.ObjectManager.GetUnitsInRange(target.Position, range, isAlive);
             var orderedUnits = units.OrderBy(unit => Vector2.DistanceSquared(target.Position, unit.Position));
-            if (orderedUnits.First() == target)
+
+            if (orderedUnits.First() == target && orderedUnits.Count() > 1)
             {
                 return orderedUnits.ElementAt(1);
             }

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -273,18 +273,19 @@ namespace LeagueSandbox.GameServer.API
         /// <summary>
         /// Creates a new particle with the specified parameters.
         /// </summary>
-        /// <param name="obj">GameObject that should own this particle.</param>
+        /// <param name="bindObj">GameObject that the particle should bind to.</param>
         /// <param name="particle">Internal name of the particle.</param>
         /// <param name="position">Position to spawn at.</param>
         /// <param name="size">Scale.</param>
-        /// <param name="bone">Bone the particle should be attached to.</param>
+        /// <param name="bone">Bone on the owner the particle should be attached to.</param>
+        /// <param name="targetBone">Bone on the target the particle should be attached to.</param>
         /// <param name="direction">3D direction the particle should face.</param>
         /// <param name="lifetime">Time in seconds the particle should last.</param>
         /// <param name="reqVision">Whether or not the particle can be obstructed by terrain.</param>
         /// <returns>New particle instance.</returns>
-        public static IParticle AddParticle(IGameObject obj, string particle, Vector2 position, float size = 1.0f, string bone = "", Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true)
+        public static IParticle AddParticle(IGameObject bindObj, string particle, Vector2 position, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true)
         {
-            var p = new Particle(_game, obj, position, particle, size, bone, 0, direction, lifetime, reqVision);
+            var p = new Particle(_game, bindObj, position, particle, size, bone, targetBone, 0, direction, lifetime, reqVision);
             return p;
         }
 
@@ -292,18 +293,19 @@ namespace LeagueSandbox.GameServer.API
         /// Creates a new particle with the specified parameters.
         /// This particle will be attached to a target.
         /// </summary>
-        /// <param name="obj">GameObject that should own this particle.</param>
+        /// <param name="bindObj">GameObject that the particle should bind to (prioritized over target).</param>
         /// <param name="particle">Internal name of the particle.</param>
-        /// <param name="target">GameObject to attach this particle to.</param>
+        /// <param name="target">GameObject that the particle should bind to after the bindObj.</param>
         /// <param name="size">Scale.</param>
-        /// <param name="bone">Bone the particle should be attached to.</param>
+        /// <param name="bone">Bone on the owner the particle should be attached to.</param>
+        /// <param name="targetBone">Bone on the target the particle should be attached to.</param>
         /// <param name="direction">3D direction the particle should face.</param>
         /// <param name="lifetime">Time in seconds the particle should last.</param>
         /// <param name="reqVision">Whether or not the particle can be obstructed by terrain.</param>
         /// <returns>New particle instance.</returns>
-        public static IParticle AddParticleTarget(IGameObject obj, string particle, IGameObject target, float size = 1.0f, string bone = "", Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true)
+        public static IParticle AddParticleTarget(IGameObject bindObj, string particle, IGameObject target, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true)
         {
-            var p = new Particle(_game, obj, target, particle, size, bone, 0, direction, lifetime, reqVision);
+            var p = new Particle(_game, bindObj, target, particle, size, bone, targetBone, 0, direction, lifetime, reqVision);
             return p;
         }
 
@@ -553,7 +555,7 @@ namespace LeagueSandbox.GameServer.API
         public static void SealSpellSlot(IObjAiBase target, SpellSlotType slotType, int slot, SpellbookType spellbookType, bool seal)
         {
             if (spellbookType == SpellbookType.SPELLBOOK_UNKNOWN
-                || spellbookType == SpellbookType.SPELLBOOK_SUMMONER && (slotType != SpellSlotType.SpellSlots)
+                || spellbookType == SpellbookType.SPELLBOOK_SUMMONER && (slotType != SpellSlotType.SummonerSpellSlots)
                 || (spellbookType == SpellbookType.SPELLBOOK_CHAMPION
                     && ((slotType == SpellSlotType.SpellSlots && (slot < 0 || slot > 3))
                         || (slotType == SpellSlotType.InventorySlots && (slot < 0 || slot > 6))
@@ -573,9 +575,11 @@ namespace LeagueSandbox.GameServer.API
                     slot += (int)SpellSlotType.ExtraSlots;
                 }
             }
-            else
+
+            if (spellbookType == SpellbookType.SPELLBOOK_SUMMONER)
             {
-                slot += (int)SpellSlotType.SummonerSpellSlots;
+                target.Stats.SetSummonerSpellEnabled((byte)slot, !seal);
+                return;
             }
 
             target.Stats.SetSpellEnabled((byte)slot, !seal);

--- a/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
+++ b/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
@@ -182,7 +182,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                 }
             }
 
-            var circleparticle = new Particle(_game, _userChampion, _userChampion.Position, "DebugCircle_green.troy", circlesize, "", 0, default, 0.1f, false, false);
+            var circleparticle = new Particle(_game, _userChampion, _userChampion.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, 0.1f, false, false);
             _circleParticles.Add(_userChampion.NetId, circleparticle);
             _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
@@ -221,7 +221,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                         _arrowParticlesList.Add(_userChampion.NetId, new List<Particle>());
                     }
 
-                    var arrowparticle = new Particle(_game, _userChampion, wpTarget, "DebugArrow_green.troy", 0.5f, "", 0, direction, 0.1f, false, false);
+                    var arrowparticle = new Particle(_game, _userChampion, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, 0.1f, false, false);
                     _arrowParticlesList[_userChampion.NetId].Add(arrowparticle);
 
                     _game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
@@ -279,7 +279,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                     }
                 }
 
-                var circleparticle = new Particle(_game, champion, champion.Position, "DebugCircle_green.troy", circlesize, "", 0, default, 0.1f, false, false);
+                var circleparticle = new Particle(_game, champion, champion.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, 0.1f, false, false);
                 _circleParticles.Add(champion.NetId, circleparticle);
                 _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
@@ -318,7 +318,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                             _arrowParticlesList.Add(champion.NetId, new List<Particle>());
                         }
 
-                        var arrowparticle = new Particle(_game, champion, wpTarget, "DebugArrow_green.troy", 0.5f, "", 0, direction, 0.1f, false, false);
+                        var arrowparticle = new Particle(_game, champion, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, 0.1f, false, false);
                         _arrowParticlesList[champion.NetId].Add(arrowparticle);
 
                         _game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
@@ -376,7 +376,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                         }
                     }
 
-                    var circleparticle = new Particle(_game, missile, missile.Position, "DebugCircle_green.troy", circlesize, "", 0, default, 0.1f, false, false);
+                    var circleparticle = new Particle(_game, missile, missile.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, 0.1f, false, false);
                     _circleParticles.Add(missile.NetId, circleparticle);
                     _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
@@ -410,13 +410,12 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                             var to = Vector2.Normalize(new Vector2(wpTarget.X, wpTarget.Y) - current);
 
                             var direction = new Vector3(to.X, 0, to.Y);
-                            var arrowparticle = new Particle(_game, missile, wpTarget, "DebugArrow_green.troy", 0.5f, "", 0, direction, 0.1f, false, false);
+                            var arrowparticle = new Particle(_game, missile, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowparticle);
 
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
                         }
-
-                        if (missile.CastInfo.Targets[0].Unit == null)
+                        else if (missile is ISpellCircleMissile skillshot)
                         {
                             if (!_arrowParticlesList.ContainsKey(missile.NetId))
                             {
@@ -425,37 +424,33 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
                             var current = new Vector2(missile.CastInfo.SpellCastLaunchPosition.X, missile.CastInfo.SpellCastLaunchPosition.Z);
 
-                            var wpTarget = missile.GetTargetPosition();
+                            var wpTarget = skillshot.Destination;
 
-                            // Makes the arrow point to the target
-                            var to = Vector2.Normalize(new Vector2(wpTarget.X, wpTarget.Y) - current);
+                            // Points the arrow towards the target
+                            var dirTangent = Extensions.Rotate(new Vector2(missile.Direction.X, missile.Direction.Z), 90.0f) * missile.CollisionRadius;
+                            var dirTangent2 = Extensions.Rotate(new Vector2(missile.Direction.X, missile.Direction.Z), 270.0f) * missile.CollisionRadius;
 
-                            var direction = new Vector3(to.X, 0, to.Y);
-
-                            var dirTangent = Extensions.Rotate(new Vector2(direction.X, direction.Z), 90.0f) * missile.CollisionRadius;
-                            var dirTangent2 = Extensions.Rotate(new Vector2(direction.X, direction.Z), 270.0f) * missile.CollisionRadius;
-
-                            var arrowParticleStart = new Particle(_game, missile, current, "DebugArrow_green.troy", 0.5f, "", 0, direction, 0.1f, false, false);
+                            var arrowParticleStart = new Particle(_game, missile, current, "DebugArrow_green.troy", 0.5f, "", "", 0, missile.Direction, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleStart);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart, userId);
 
-                            var arrowParticleEnd = new Particle(_game, missile, wpTarget, "DebugArrow_green.troy", 0.5f, "", 0, direction, 0.1f, false, false);
+                            var arrowParticleEnd = new Particle(_game, missile, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, missile.Direction, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleEnd);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd, userId);
 
-                            var arrowParticleEnd2Temp = new Particle(_game, missile, new Vector2(wpTarget.X + dirTangent.X, wpTarget.Y + dirTangent.Y), "Global_Indicator_Line_Beam.troy", 0.0f, "", 0, direction, 0.1f, false, false);
+                            var arrowParticleEnd2Temp = new Particle(_game, missile, new Vector2(wpTarget.X + dirTangent.X, wpTarget.Y + dirTangent.Y), "Global_Indicator_Line_Beam.troy", 0.0f, "", "", 0, missile.Direction, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleEnd2Temp);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd2Temp, userId);
 
-                            var arrowParticleStart2 = new Particle(_game, arrowParticleEnd2Temp, new Vector2(current.X + dirTangent.X, current.Y + dirTangent.Y), "Global_Indicator_Line_Beam.troy", 1.0f, "", 0, direction, 0.1f, false, false);
+                            var arrowParticleStart2 = new Particle(_game, arrowParticleEnd2Temp, new Vector2(current.X + dirTangent.X, current.Y + dirTangent.Y), "Global_Indicator_Line_Beam.troy", 1.0f, "", "", 0, missile.Direction, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleStart2);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart2, userId);
 
-                            var arrowParticleEnd3Temp = new Particle(_game, missile, new Vector2(wpTarget.X + dirTangent2.X, wpTarget.Y + dirTangent2.Y), "Global_Indicator_Line_Beam.troy", 0.0f, "", 0, direction, 0.1f, false, false);
+                            var arrowParticleEnd3Temp = new Particle(_game, missile, new Vector2(wpTarget.X + dirTangent2.X, wpTarget.Y + dirTangent2.Y), "Global_Indicator_Line_Beam.troy", 0.0f, "", "", 0, missile.Direction, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleEnd3Temp);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd3Temp, userId);
 
-                            var arrowParticleStart3 = new Particle(_game, arrowParticleEnd3Temp, new Vector2(current.X + dirTangent2.X, current.Y + dirTangent2.Y), "Global_Indicator_Line_Beam.troy", 1.0f, "", 0, direction, 0.1f, false, false);
+                            var arrowParticleStart3 = new Particle(_game, arrowParticleEnd3Temp, new Vector2(current.X + dirTangent2.X, current.Y + dirTangent2.Y), "Global_Indicator_Line_Beam.troy", 1.0f, "", "", 0, missile.Direction, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleStart3);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart3, userId);
                         }

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -994,6 +994,21 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             return false;
         }
 
+        public override void TeleportTo(float x, float y)
+        {
+            var position = new Vector2(x, y);
+
+            if (!_game.Map.NavigationGrid.IsWalkable(x, y, CollisionRadius))
+            {
+                position = _game.Map.NavigationGrid.GetClosestTerrainExit(new Vector2(x, y), CollisionRadius + 1.0f);
+            }
+
+            // TODO: Verify if we should move this to ApiFunctionManager as an optional parameter.
+            SetWaypoints(new List<Vector2> { Position, position });
+
+            SetPosition(position);
+        }
+
         /// <summary>
         /// Moves this unit to its specified waypoints, updating its position along the way.
         /// </summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -1241,12 +1241,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             };
             DashElapsedTime = 0;
 
-            // TODO: Verify if this should be a parameter
-            Stats.SetActionState(ActionState.CAN_ATTACK, false);
-            Stats.SetActionState(ActionState.CAN_NOT_ATTACK, true);
-            Stats.SetActionState(ActionState.CAN_MOVE, false);
-            Stats.SetActionState(ActionState.CAN_NOT_MOVE, true);
-
             if (animation != null && animation != "")
             {
                 var animPairs = new Dictionary<string, string> { { "RUN", animation } };
@@ -1272,10 +1266,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         {
             if (MovementParameters != null && state == false)
             {
-                Stats.SetActionState(ActionState.CAN_ATTACK, true);
-                Stats.SetActionState(ActionState.CAN_NOT_ATTACK, false);
-                Stats.SetActionState(ActionState.CAN_MOVE, true);
-                Stats.SetActionState(ActionState.CAN_NOT_MOVE, false);
                 MovementParameters = null;
                 DashElapsedTime = 0;
 

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -255,19 +255,18 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="y">Y coordinate to set.</param>
         public virtual void TeleportTo(float x, float y)
         {
+            var position = new Vector2(x, y);
+
             if (!_game.Map.NavigationGrid.IsWalkable(x, y, CollisionRadius))
             {
-                var walkableSpot = _game.Map.NavigationGrid.GetClosestTerrainExit(new Vector2(x, y), CollisionRadius + 1.0f);
-                SetPosition(walkableSpot);
+                position = _game.Map.NavigationGrid.GetClosestTerrainExit(new Vector2(x, y), CollisionRadius + 1.0f);
             }
-            else
-            {
-                SetPosition(x, y);
-            }
+
+            SetPosition(position);
 
             // TODO: Verify which one we want to use. WaypointList does not require conversions, however WaypointGroup does (and it has TeleportID functionality).
             //_game.PacketNotifier.NotifyWaypointList(this, new List<Vector2> { Position });
-            _game.PacketNotifier.NotifyTeleport(this, Position);
+            _game.PacketNotifier.NotifyEnterVisibilityClient(this, useTeleportID: true);
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/Particle.cs
+++ b/GameServerLib/GameObjects/Particle.cs
@@ -14,15 +14,15 @@ namespace LeagueSandbox.GameServer.GameObjects
         private float _currentTime;
 
         /// <summary>
-        /// Object which spawned or caused the particle to be instanced
+        /// Primary bind target.
         /// </summary>
-        public IGameObject Owner { get; }
+        public IGameObject BindObject { get; }
         /// <summary>
         /// Client-sided, internal name of the particle used in networking, usually always ends in .troy
         /// </summary>
         public string Name { get; }
         /// <summary>
-        /// GameObject this particle is currently attached to. Null when not attached to anything.
+        /// Secondary bind target. Null when not attached to anything.
         /// </summary>
         public IGameObject TargetObject { get; }
         /// <summary>
@@ -30,9 +30,13 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// </summary>
         public Vector2 TargetPosition { get; private set; }
         /// <summary>
-        /// Client-sided, internal name of the bone that this particle should be attached to for networking
+        /// Client-sided, internal name of the bone that this particle should be attached to on the owner, for networking.
         /// </summary>
         public string BoneName { get; }
+        /// <summary>
+        /// Client-sided, internal name of the bone that this particle should be attached to on the target, for networking.
+        /// </summary>
+        public string TargetBoneName { get; }
         /// <summary>
         /// Scale of the particle used in networking
         /// </summary>
@@ -53,8 +57,8 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// This particle will spawn and stay on the specified GameObject target.
         /// </summary>
         /// <param name="game">Game instance.</param>
-        /// <param name="owner">Owner of this Particle instance.</param>
-        /// <param name="t">GameObject this particle should be attached to. Leave null if target is position.</param>
+        /// <param name="bindObj">Primary bind target.</param>
+        /// <param name="target">Secondary bind target.</param>
         /// <param name="particleName">Name used by League of Legends interally (ex: DebugCircle.troy).</param>
         /// <param name="scale">Scale of the Particle.</param>
         /// <param name="boneName">Name used by League of Legends internally where the Particle should be attached. Only useful when the target is a GameObject.</param>
@@ -63,14 +67,15 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="lifetime">Number of seconds the Particle should exist.</param>
         /// <param name="reqVision">Whether or not the Particle is affected by vision checks.</param>
         /// <param name="autoSend">Whether or not to automatically send the Particle packet to clients.</param>
-        public Particle(Game game, IGameObject owner, IGameObject t, string particleName, float scale = 1.0f, string boneName = "", uint netId = 0, Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true, bool autoSend = true)
-               : base(game, t.Position, 0, 0, netId, owner.Team)
+        public Particle(Game game, IGameObject bindObj, IGameObject target, string particleName, float scale = 1.0f, string boneName = "", string targetBoneName = "", uint netId = 0, Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true, bool autoSend = true)
+               : base(game, target.Position, 0, 0, netId, bindObj.Team)
         {
-            Owner = owner;
-            TargetObject = t;
+            BindObject = bindObj;
+            TargetObject = target;
             TargetPosition = TargetObject.Position;
             Name = particleName;
             BoneName = boneName;
+            TargetBoneName = targetBoneName;
             Scale = scale;
             Direction = direction;
             Lifetime = lifetime;
@@ -89,7 +94,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// This particle will spawn and stay at the specified position.
         /// </summary>
         /// <param name="game">Game instance.</param>
-        /// <param name="owner">Owner of this Particle instance.</param>
+        /// <param name="bindObj">GameObject that the particle should be bound to.</param>
         /// <param name="targetPos">Target position of this particle.</param>
         /// <param name="particleName">Name used by League of Legends interally (ex: DebugCircle.troy).</param>
         /// <param name="scale">Scale of the Particle.</param>
@@ -99,14 +104,15 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="lifetime">Number of seconds the Particle should exist.</param>
         /// <param name="reqVision">Whether or not the Particle is affected by vision checks.</param>
         /// <param name="autoSend">Whether or not to automatically send the Particle packet to clients.</param>
-        public Particle(Game game, IGameObject owner, Vector2 targetPos, string particleName, float scale = 1.0f, string boneName = "", uint netId = 0, Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true, bool autoSend = true)
-               : base(game, targetPos, 0, 0, netId, owner.Team)
+        public Particle(Game game, IGameObject bindObj, Vector2 targetPos, string particleName, float scale = 1.0f, string boneName = "", string targetBoneName = "", uint netId = 0, Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true, bool autoSend = true)
+               : base(game, targetPos, 0, 0, netId, bindObj.Team)
         {
-            Owner = owner;
+            BindObject = bindObj;
             TargetObject = null;
             TargetPosition = targetPos;
             Name = particleName;
             BoneName = boneName;
+            TargetBoneName = targetBoneName;
             Scale = scale;
             Direction = direction;
             Lifetime = lifetime;

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -244,6 +244,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                     if (!SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
                     {
                         CastInfo.Owner.StopMovement();
+
+                        // TODO: Verify if we should move this outside of this TriggersSpellCasts if statement.
+                        CastInfo.Owner.UpdateMoveOrder(OrderType.CastSpell, true);
                     }
 
                     var goingTo = end - CastInfo.Owner.Position;
@@ -255,12 +258,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
 
                     var dirTemp = Vector2.Normalize(goingTo);
                     CastInfo.Owner.FaceDirection(new Vector3(dirTemp.X, 0, dirTemp.Y), false);
-                }
-
-                // TODO: Verify if we should move this into the above if statement.
-                if (!SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
-                {
-                    CastInfo.Owner.UpdateMoveOrder(OrderType.CastSpell, true);
                 }
             }
 
@@ -447,6 +444,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                     if (!SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
                     {
                         CastInfo.Owner.StopMovement();
+
+                        // TODO: Verify if we should move this outside of this TriggersSpellCasts if statement.
+                        CastInfo.Owner.UpdateMoveOrder(OrderType.CastSpell, true);
                     }
 
                     var goingTo = end - CastInfo.Owner.Position;
@@ -458,12 +458,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
 
                     var dirTemp = Vector2.Normalize(goingTo);
                     CastInfo.Owner.FaceDirection(new Vector3(dirTemp.X, 0, dirTemp.Y), false);
-                }
-
-                // TODO: Verify if we should move this into the above if statement.
-                if (!SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
-                {
-                    CastInfo.Owner.UpdateMoveOrder(OrderType.CastSpell, true);
                 }
             }
 

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -257,6 +257,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                     CastInfo.Owner.FaceDirection(new Vector3(dirTemp.X, 0, dirTemp.Y), false);
                 }
 
+                // TODO: Verify if we should move this into the above if statement.
                 if (!SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
                 {
                     CastInfo.Owner.UpdateMoveOrder(OrderType.CastSpell, true);
@@ -459,6 +460,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                     CastInfo.Owner.FaceDirection(new Vector3(dirTemp.X, 0, dirTemp.Y), false);
                 }
 
+                // TODO: Verify if we should move this into the above if statement.
                 if (!SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
                 {
                     CastInfo.Owner.UpdateMoveOrder(OrderType.CastSpell, true);
@@ -621,6 +623,24 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
 
         public void FinishCasting()
         {
+            // Updates move order before script PostCast so teleports are sent to clients correctly (not sent if MoveOrder == CastSpell).
+            if (SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
+            {
+                if (!CastInfo.Owner.IsPathEnded())
+                {
+                    CastInfo.Owner.UpdateMoveOrder(OrderType.MoveTo, true);
+                }
+                if (CastInfo.Owner.TargetUnit != null)
+                {
+                    CastInfo.Owner.UpdateMoveOrder(OrderType.AttackTo, true);
+                }
+            }
+            else
+            {
+                // TODO: Verify
+                CastInfo.Owner.UpdateMoveOrder(OrderType.Hold, true);
+            }
+
             if (_spellScript.ScriptMetadata.TriggersSpellCasts)
             {
                 ApiEventManager.OnSpellPostCast.Publish(this);
@@ -699,23 +719,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 {
                     CreateSpellLineMissile();
                 }
-            }
-
-            if (SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
-            {
-                if (!CastInfo.Owner.IsPathEnded())
-                {
-                    CastInfo.Owner.UpdateMoveOrder(OrderType.MoveTo, true);
-                }
-                if (CastInfo.Owner.TargetUnit != null)
-                {
-                    CastInfo.Owner.UpdateMoveOrder(OrderType.AttackTo, true);
-                }
-            }
-            else
-            {
-                // TODO: Verify
-                CastInfo.Owner.UpdateMoveOrder(OrderType.Hold, true);
             }
 
             if (CastInfo.Owner.SpellToCast != null)

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -180,7 +180,8 @@ namespace LeagueSandbox.GameServer
                 {
                     // TODO: Verify which one we want to use. WaypointList does not require conversions, however WaypointGroup does (and it has TeleportID functionality).
                     //_game.PacketNotifier.NotifyWaypointList(u);
-                    _game.PacketNotifier.NotifyWaypointGroup(u);
+                    // TODO: Verify if we want to use TeleportID.
+                    _game.PacketNotifier.NotifyWaypointGroup(u, false);
                     u.ClearMovementUpdated();
                 }
             }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -543,17 +543,17 @@ namespace PacketDefinitions420
         /// <param name="u">ObjAiBase who owns the spell going on cooldown.</param>
         /// <param name="slotId">Slot of the spell.</param>
         /// <param name="currentCd">Amount of time the spell has already been on cooldown (if applicable).</param>
-        /// <param name="totalCd">Amount of time that the spell should have be in cooldown before going off cooldown.</param>
+        /// <param name="totalCd">Maximum amount of time the spell's cooldown can be.</param>
         public void NotifyCHAR_SetCooldown(IObjAiBase u, byte slotId, float currentCd, float totalCd)
         {
             var cdPacket = new CHAR_SetCooldown
             {
                 SenderNetID = u.NetId,
                 Slot = slotId,
-                PlayVOWhenCooldownReady = true, // TODO: Unhardcode
+                PlayVOWhenCooldownReady = false, // TODO: Unhardcode
                 IsSummonerSpell = false, // TODO: Unhardcode
                 Cooldown = currentCd,
-                MaxCooldownForDisplay = totalCd
+                MaxCooldownForDisplay = 0 // TODO: Verify (packet loses functionality otherwise)
             };
             if (u is IChampion && (slotId == 4 || slotId == 5))
             {
@@ -877,11 +877,11 @@ namespace PacketDefinitions420
         public void NotifyFXCreateGroup(IParticle particle, int userId = 0)
         {
             var fxPacket = new FX_Create_Group();
-            fxPacket.SenderNetID = particle.Owner.NetId;
+            fxPacket.SenderNetID = particle.BindObject.NetId;
 
             var fxDataList = new List<FXCreateData>();
 
-            var ownerPos = particle.Owner.GetPosition3D();
+            var bindPos = particle.BindObject.GetPosition3D();
             var targetHeight = _navGrid.GetHeightAtLocation(particle.TargetPosition.X, particle.TargetPosition.Y);
             var higherValue = Math.Max(targetHeight, particle.GetHeight());
 
@@ -889,7 +889,7 @@ namespace PacketDefinitions420
             var fxData1 = new FXCreateData
             {
                 NetAssignedNetID = particle.NetId,
-                CasterNetID = particle.Owner.NetId,
+                CasterNetID = particle.BindObject.NetId,
                 KeywordNetID = 0, // Not sure what this is
 
                 PositionX = (short)((particle.Position.X - _navGrid.MapWidth / 2) / 2),
@@ -898,9 +898,9 @@ namespace PacketDefinitions420
 
                 TargetPositionY = targetHeight,
 
-                OwnerPositionX = (short)((ownerPos.X - _navGrid.MapWidth / 2) / 2),
-                OwnerPositionY = ownerPos.Y,
-                OwnerPositionZ = (short)((ownerPos.Z - _navGrid.MapHeight / 2) / 2),
+                OwnerPositionX = (short)((bindPos.X - _navGrid.MapWidth / 2) / 2),
+                OwnerPositionY = bindPos.Y,
+                OwnerPositionZ = (short)((bindPos.Z - _navGrid.MapHeight / 2) / 2),
 
                 TimeSpent = particle.GetTimeAlive(),
                 ScriptScale = particle.Scale
@@ -908,8 +908,8 @@ namespace PacketDefinitions420
 
             if (particle.TargetObject == null) // Non-object target (usually a position)
             {
-                fxData1.TargetNetID = particle.Owner.NetId; // Probably not correct, but it works
-                fxData1.BindNetID = 0; // Not sure what this is
+                fxData1.TargetNetID = particle.BindObject.NetId; // Probably not correct, but it works
+                fxData1.BindNetID = 0;
 
                 fxData1.TargetPositionX = (short)((particle.TargetPosition.X - _navGrid.MapWidth / 2) / 2);
                 fxData1.TargetPositionZ = (short)((particle.TargetPosition.Y - _navGrid.MapHeight / 2) / 2);
@@ -917,7 +917,7 @@ namespace PacketDefinitions420
             else
             {
                 fxData1.TargetNetID = particle.TargetObject.NetId;
-                fxData1.BindNetID = particle.TargetObject.NetId; // Not sure what this is
+                fxData1.BindNetID = particle.BindObject.NetId;
 
                 fxData1.TargetPositionX = (short)particle.TargetObject.Position.X;
                 fxData1.TargetPositionZ = (short)particle.TargetObject.Position.Y;
@@ -942,14 +942,14 @@ namespace PacketDefinitions420
                 EffectNameHash = HashString(particle.Name),
                 //TODO: un-hardcode flags
                 Flags = 0x20, // Taken from SpawnParticle packet
-                TargetBoneNameHash = 0,
+                TargetBoneNameHash = HashString(particle.TargetBoneName),
                 // TODO: Verify if the above is the same as below (most likely relate to bone of origin and bone of end point)
                 BoneNameHash = HashString(particle.BoneName),
 
                 FXCreateData = fxDataList
             };
 
-            if (particle.Owner is IObjAiBase o)
+            if (particle.BindObject is IObjAiBase o)
             {
                 fxGroupData1.PackageHash = o.GetObjHash();
             }


### PR DESCRIPTION
* GameObject:
  * Cleaned up TeleportTo, and it now uses EnterVisibilityClient instead of Teleport (they are equivalent in terms of movement).
* AttackableUnit:
  * Added override for TeleportTo which uses SetWaypoints to ensure the teleport.
  * Removed action state setting in DashToLocation.
* Spell:
  * CastSpell packet now occurs before OnSpellCast.
  * Removed useless checks for channeling spell data in Cast.
  * Cast (both manual and auto versions) properly face the direction of the end position.
* Particle:
  * Changed Owner to BindObject as it reflects functionality more accurately.
  * Added TargetBoneName for multi-bind particles (like Blitzcrank Q fist).
* Packets:
  * SetCooldown now properly sets cooldown client-side.
  * FXCreateGroup supports TargetBoneName.
  * Removed useless Teleport.
  * Added useTeleportID parameter to WaypointGroup.
  * MissileReplication uses p.GetPosition3D() for Position variable instead of SpellCastLaunchPosition.
* Scripting:
  * Re-implemented Blitzcrank Q (along with buff scripts) & Ezreal R (dmg reduc credited to cabeca)
  * Re-implemented Ezreal E as a demonstration of the teleport fix.
  * SealSpellSlot now properly supports sealing off Summoner spells.
  * Removed StopMovement from TeleportTo.
* Chat Commands:
  * Fixed DebugMode for projectiles not properly showing path.

Progress #1059, Progress #1061