### PR TITLE
Progress #1055 -- Added disconnected check to allow players to reconnect

### DIFF
--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -352,7 +352,7 @@ namespace PacketDefinitions420
                 return false;
             }
             
-            if(_peers.ContainsKey(request.PlayerID))
+            if(_peers.ContainsKey(request.PlayerID) && !_playerManager.GetPeerInfo(request.PlayerID).IsDisconnected)
             {
                 Debug.WriteLine($"Player {request.PlayerID} is already connected. Request from {peer.Address.ToString()}.");
                 return false;


### PR DESCRIPTION
Disconnected players can now reconnect. There are still problems with sending packets (either explicitly or by broadcasting) to disconnected peers and also the re-notification of player spawned for all the other players. Tested and works fine with 1 player (skills are still unusable due to #400)

Progress #1055