### PR TITLE
Resolve #1100 -- [QOL] Animations

### DIFF
--- a/GameServerCore/Domain/GameObjects/IGameObject.cs
+++ b/GameServerCore/Domain/GameObjects/IGameObject.cs
@@ -132,8 +132,20 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="startTime">Time in the animation to start at.</param>
         /// TODO: Verify if this description is correct, if not, correct it.
         /// <param name="speedScale">How much the speed of the GameObject should affect the animation.</param>
-        /// TODO: Implement AnimationFlags enum for this and fill it in.
-        /// <param name="flags">Animation flags. Possible values and functions unknown.</param>
-        void PlayAnimation(string animName, float timeScale = 1.0f, float startTime = 0, float speedScale = 0, byte flags = 0);
+        /// <param name="flags">Animation flags. Refer to AnimationFlags enum.</param>
+        void PlayAnimation(string animName, float timeScale = 1.0f, float startTime = 0, float speedScale = 0, AnimationFlags flags = 0);
+        /// <summary>
+        /// Forces the GameObject's current animations to pause/unpause.
+        /// </summary>
+        /// <param name="pause">Whether or not to pause/unpause animations.</param>
+        void PauseAnimation(bool pause);
+        /// <summary>
+        /// Forces this GameObject to stop playing the specified animation (or optionally all animations) with the given parameters.
+        /// </summary>
+        /// <param name="animation">Internal name of the animation to stop playing. Set blank/null if stopAll is true.</param>
+        /// <param name="stopAll">Whether or not to stop all animations. Only works if animation is empty/null.</param>
+        /// <param name="fade">Whether or not the animation should fade before stopping.</param>
+        /// <param name="ignoreLock">Whether or not locked animations should still be stopped.</param>
+        void StopAnimation(string animation, bool stopAll = false, bool fade = false, bool ignoreLock = true);
     }
 }

--- a/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
@@ -106,7 +106,12 @@ namespace GameServerCore.Domain.GameObjects.Spell
         void LevelUp();
         string GetStringForSlot();
         float GetCooldown();
-        void SetCooldown(float newCd);
+        /// <summary>
+        /// Sets the cooldown of this spell.
+        /// </summary>
+        /// <param name="newCd">Cooldown to set.</param>
+        /// <param name="ignoreCDR">Whether or not to ignore cooldown reduction.</param>
+        void SetCooldown(float newCd, bool ignoreCDR = false);
         void LowerCooldown(float lowerValue);
         void ResetSpellDelay();
         void SetLevel(byte toLevel);

--- a/GameServerCore/Enums/AnimationFlags.cs
+++ b/GameServerCore/Enums/AnimationFlags.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace GameServerCore.Enums
+{
+    /// <summary>
+    /// Enum of all animation flags that can be applied to an animation. Used for packets.
+    /// *NOTE*: Descriptions may not be accurate as the flags have yet to be fully explored.
+    /// </summary>
+    /// TODO: Finish this.
+    [Flags]
+    public enum AnimationFlags : byte
+    {
+        /// <summary>
+        /// Seems to prevent animations of the same name from playing until the first one with this flag is finished.
+        /// Also seems to override automatic animations such as RUN.
+        /// </summary>
+        UniqueOverride = 1 << 0,
+        /// <summary>
+        /// Unknown.
+        /// </summary>
+        Unknown2 = 1 << 1,
+        /// <summary>
+        /// Seems to override automatic animations such as RUN.
+        /// </summary>
+        Override = 1 << 2,
+        /// <summary>
+        /// Seems to lock animations at the end of an animation.
+        /// </summary>
+        Lock = 1 << 3,
+        /// <summary>
+        /// Unknown.
+        /// </summary>
+        Unknown5 = 1 << 4,
+        /// <summary>
+        /// Unknown.
+        /// </summary>
+        Unknown6 = 1 << 5,
+        /// <summary>
+        /// Unknown.
+        /// </summary>
+        Unknown7 = 1 << 6,
+        /// <summary>
+        /// Unknown.
+        /// </summary>
+        Unknown8 = 1 << 7
+    }
+}

--- a/GameServerCore/Enums/ChangeSlotSpellDataType.cs
+++ b/GameServerCore/Enums/ChangeSlotSpellDataType.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GameServerCore.Enums
+{
+    public enum ChangeSlotSpellDataType : byte
+    {
+        TargetingType = 0x1,
+        SpellName = 0x2,
+        Range = 0x3,
+        MaxGrowthRange = 0x4,
+        RangeDisplay = 0x5,
+        IconIndex = 0x6,
+        OffsetTarget = 0x7,
+    }
+}

--- a/GameServerCore/GameServerCore.csproj
+++ b/GameServerCore/GameServerCore.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="UltimateQuadTree" Version="1.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\LeaguePackets\LeaguePackets\LeaguePackets.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/GameServerCore/GameServerCore.csproj
+++ b/GameServerCore/GameServerCore.csproj
@@ -12,8 +12,4 @@
     <PackageReference Include="UltimateQuadTree" Version="1.0.3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\LeaguePackets\LeaguePackets\LeaguePackets.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -10,6 +10,7 @@ using GameServerCore.NetInfo;
 using GameServerCore.Enums;
 using GameServerCore.Packets.Enums;
 using GameServerCore.Packets.PacketDefinitions.Requests;
+using LeaguePackets.Game.Common;
 
 namespace GameServerCore.Packets.Interfaces
 {
@@ -153,6 +154,22 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// <param name="c">Champion that respawned.</param>
         void NotifyChampionRespawn(IChampion c);
+        /// <summary>
+        /// Sends a packet to the specified user detailing that the specified owner unit's spell in the specified slot has been changed.
+        /// </summary>
+        /// <param name="userId">User to send the packet to.</param>
+        /// <param name="owner">Unit that owns the spell being changed.</param>
+        /// <param name="slot">Slot of the spell being changed.</param>
+        /// <param name="changeType">Type of change being made.</param>
+        /// <param name="isSummonerSpell">Whether or not the spell being changed is a summoner spell.</param>
+        /// <param name="targetingType">New targeting type to set.</param>
+        /// <param name="newName">New internal name of a spell to set.</param>
+        /// <param name="newRange">New cast range for the spell to set.</param>
+        /// <param name="newMaxCastRange">New max cast range for the spell to set.</param>
+        /// <param name="newDisplayRange">New max display range for the spell to set.</param>
+        /// <param name="newIconIndex">New index of an icon for the spell to set.</param>
+        /// <param name="offsetTargets">New target netids for the spell to set.</param>
+        void NotifyChangeSlotSpellData(int userId, IObjAiBase owner, byte slot, ChangeSlotSpellDataType changeType, bool isSummonerSpell = false, TargetingType targetingType = TargetingType.Invalid, string newName = "", float newRange = 0, float newMaxCastRange = 0, float newDisplayRange = 0, byte newIconIndex = 0x0, List<uint> offsetTargets = null);
         /// <summary>
         /// Sends a packet to all players with vision of a specified ObjAiBase explaining that their specified spell's cooldown has been set.
         /// </summary>
@@ -595,12 +612,27 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="obj">GameObject that is playing the animation.</param>
         /// <param name="animation">Internal name of the animation to play.</param>
         /// TODO: Implement AnimationFlags enum for this and fill it in.
-        /// <param name="flags">Animation flags. Possible values and functions unknown.</param>
+        /// <param name="flags">Animation flags. Refer to AnimationFlags enum.</param>
         /// <param name="timeScale">How fast the animation should play. Default 1x speed.</param>
         /// <param name="startTime">Time in the animation to start at.</param>
         /// TODO: Verify if this description is correct, if not, correct it.
         /// <param name="speedScale">How much the speed of the GameObject should affect the animation.</param>
-        void NotifyS2C_PlayAnimation(IGameObject obj, string animation, byte flags = 0, float timeScale = 1.0f, float startTime = 0.0f, float speedScale = 1.0f);
+        void NotifyS2C_PlayAnimation(IGameObject obj, string animation, AnimationFlags flags = 0, float timeScale = 1.0f, float startTime = 0.0f, float speedScale = 1.0f);
+        /// <summary>
+        /// Sends a packet to all players detailing that the specified object's current animations have been paused/unpaused.
+        /// </summary>
+        /// <param name="obj">GameObject that is playing the animation.</param>
+        /// <param name="pause">Whether or not to pause/unpause animations.</param>
+        void NotifyS2C_PauseAnimation(IGameObject obj, bool pause);
+        /// <summary>
+        /// Sends a packet to all players detailing that the specified object has stopped playing an animation.
+        /// </summary>
+        /// <param name="obj">GameObject that is playing the animation.</param>
+        /// <param name="animation">Internal name of the animation to stop.</param>
+        /// <param name="stopAll">Whether or not to stop all animations. Only works if animation is empty/null.</param>
+        /// <param name="fade">Whether or not the animation should fade before stopping.</param>
+        /// <param name="ignoreLock">Whether or not locked animations should still be stopped.</param>
+        void NotifyS2C_StopAnimation(IGameObject obj, string animation, bool stopAll = false, bool fade = false, bool ignoreLock = true);
         /// <summary>
         /// Sends a packet to all players with vision of the specified unit detailing that its animation states have changed to the specified animation pairs.
         /// Replaces the unit's normal animation behaviors with the given animation pairs. Structure of the animationPairs is expected to follow the same structure from before the replacement.
@@ -741,7 +773,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="enable">Whether or not to fade in the tint.</param>
         /// <param name="speed">Amount of time that should pass before tint is fully applied.</param>
         /// <param name="color">Color of the tint.</param>
-        void NotifyTint(TeamId team, bool enable, float speed, Color color);
+        void NotifyTint(TeamId team, bool enable, float speed, Content.Color color);
         /// <summary>
         /// Sends a packet to the specified player detailing that the specified LaneTurret has spawned.
         /// </summary>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
-using GameServerCore.Content;
 using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
@@ -10,7 +9,6 @@ using GameServerCore.NetInfo;
 using GameServerCore.Enums;
 using GameServerCore.Packets.Enums;
 using GameServerCore.Packets.PacketDefinitions.Requests;
-using LeaguePackets.Game.Common;
 
 namespace GameServerCore.Packets.Interfaces
 {

--- a/GameServerLib/API/ApiEventManager.cs
+++ b/GameServerLib/API/ApiEventManager.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using GameServerCore.Domain.GameObjects;
+﻿using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Enums;
 using LeagueSandbox.GameServer.Logging;
 using log4net;
+using System;
+using System.Collections.Generic;
 
 /*
  * Possible Events:
@@ -285,13 +285,20 @@ namespace LeagueSandbox.GameServer.API
         }
         public void Publish(ISpell spell)
         {
-            _listeners.ForEach((listener) =>
+            var count = _listeners.Count;
+
+            if (count == 0)
             {
-                if (listener.Item2 == spell)
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == spell)
                 {
-                    listener.Item3(spell);
+                    _listeners[i].Item3(spell);
                 }
-            });
+            }
         }
     }
 
@@ -313,13 +320,20 @@ namespace LeagueSandbox.GameServer.API
         }
         public void Publish(ISpell spell)
         {
-            _listeners.ForEach((listener) =>
+            var count = _listeners.Count;
+
+            if (count == 0)
             {
-                if (listener.Item2 == spell)
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == spell)
                 {
-                    listener.Item3(spell);
+                    _listeners[i].Item3(spell);
                 }
-            });
+            }
         }
     }
 
@@ -341,13 +355,20 @@ namespace LeagueSandbox.GameServer.API
         }
         public void Publish(ISpell spell)
         {
-            _listeners.ForEach((listener) =>
+            var count = _listeners.Count;
+
+            if (count == 0)
             {
-                if (listener.Item2 == spell)
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == spell)
                 {
-                    listener.Item3(spell);
+                    _listeners[i].Item3(spell);
                 }
-            });
+            }
         }
     }
 
@@ -408,13 +429,20 @@ namespace LeagueSandbox.GameServer.API
         }
         public void Publish(ISpell spell)
         {
-            _listeners.ForEach((listener) =>
+            var count = _listeners.Count;
+
+            if (count == 0)
             {
-                if (listener.Item2 == spell)
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == spell)
                 {
-                    listener.Item3(spell);
+                    _listeners[i].Item3(spell);
                 }
-            });
+            }
         }
     }
 
@@ -436,13 +464,20 @@ namespace LeagueSandbox.GameServer.API
         }
         public void Publish(ISpell spell)
         {
-            _listeners.ForEach((listener) =>
+            var count = _listeners.Count;
+
+            if (count == 0)
             {
-                if (listener.Item2 == spell)
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == spell)
                 {
-                    listener.Item3(spell);
+                    _listeners[i].Item3(spell);
                 }
-            });
+            }
         }
     }
 

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -525,19 +525,41 @@ namespace LeagueSandbox.GameServer.API
         }
 
         /// <summary>
-        /// Forces the given unit or object to perform the given animation.
+        /// Forces the given object to perform the given animation.
         /// </summary>
-        /// <param name="unit">Unit or object that will play the animation.</param>
+        /// <param name="obj">Object that will play the animation.</param>
         /// <param name="animName">Internal name of an animation to play.</param>
         /// <param name="timeScale">How fast the animation should play. Default 1x speed.</param>
         /// <param name="startTime">Time in the animation to start at.</param>
         /// TODO: Verify if this description is correct, if not, correct it.
         /// <param name="speedScale">How much the speed of the GameObject should affect the animation.</param>
         /// TODO: Implement AnimationFlags enum for this and fill it in.
-        /// <param name="flags">Animation flags. Possible values and functions unknown.</param>
-        public static void PlayAnimation(IGameObject unit, string animName, float timeScale = 1.0f, float startTime = 0, float speedScale = 0, byte flags = 0)
+        /// <param name="flags">Animation flags. Refer to AnimationFlags enum.</param>
+        public static void PlayAnimation(IGameObject obj, string animName, float timeScale = 1.0f, float startTime = 0, float speedScale = 0, AnimationFlags flags = 0)
         {
-            unit.PlayAnimation(animName, timeScale, startTime, speedScale, flags);
+            obj.PlayAnimation(animName, timeScale, startTime, speedScale, flags);
+        }
+
+        /// <summary>
+        /// Forces the given object's current animations to pause/unpause.
+        /// </summary>
+        /// <param name="pause">Whether or not to pause/unpause animations.</param>
+        public static void PauseAnimation(IGameObject obj, bool pause)
+        {
+            obj.PauseAnimation(pause);
+        }
+
+        /// <summary>
+        /// Forces the given object to stop performing the given animation (or optionally all animations).
+        /// </summary>
+        /// <param name="obj">Object who's animations will be stopped.</param>
+        /// <param name="animation">Internal name of the animation to stop playing. Set blank/null if stopAll is true.</param>
+        /// <param name="stopAll">Whether or not to stop all animations. Only works if animation is empty/null.</param>
+        /// <param name="fade">Whether or not the animation should fade before stopping.</param>
+        /// <param name="ignoreLock">Whether or not locked animations should still be stopped.</param>
+        public static void StopAnimation(IGameObject obj, string animation, bool stopAll = false, bool fade = false, bool ignoreLock = true)
+        {
+            obj.StopAnimation(animation, stopAll, fade, ignoreLock);
         }
 
         public static void SealSpellSlot(IObjAiBase target, SpellSlotType slotType, int slot, SpellbookType spellbookType, bool seal)

--- a/GameServerLib/Chatbox/Commands/CooldownReductionCommand.cs
+++ b/GameServerLib/Chatbox/Commands/CooldownReductionCommand.cs
@@ -1,0 +1,32 @@
+﻿using GameServerCore;
+
+namespace LeagueSandbox.GameServer.Chatbox.Commands
+{
+    public class CooldownReductionCommand : ChatCommandBase
+    {
+        private readonly IPlayerManager _playerManager;
+
+        public override string Command => "cdr";
+        public override string Syntax => $"{Command} bonusCdr";
+
+        public CooldownReductionCommand(ChatCommandManager chatCommandManager, Game game)
+            : base(chatCommandManager, game)
+        {
+            _playerManager = game.PlayerManager;
+        }
+
+        public override void Execute(int userId, bool hasReceivedArguments, string arguments = "")
+        {
+            var split = arguments.ToLower().Split(' ');
+            if (split.Length < 2)
+            {
+                ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.SYNTAXERROR);
+                ShowSyntax();
+            }
+            else if (float.TryParse(split[1], out var cdr))
+            {
+                _playerManager.GetPeerInfo(userId).Champion.Stats.CooldownReduction.FlatBonus += (cdr / 100f);
+            }
+        }
+    }
+}

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -790,7 +790,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             if (this is IChampion champion)
             {
-                _game.PacketNotifier.NotifyS2C_SetSpellData((int)_game.PlayerManager.GetClientInfoByChampion(champion).PlayerId, NetId, name, slot);
+                int userId = (int)_game.PlayerManager.GetClientInfoByChampion(champion).PlayerId;
+                _game.PacketNotifier.NotifyS2C_SetSpellData(userId, NetId, name, slot);
             }
 
             return newSpell;

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -277,11 +277,31 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="startTime">Time in the animation to start at.</param>
         /// TODO: Verify if this description is correct, if not, correct it.
         /// <param name="speedScale">How much the speed of the GameObject should affect the animation.</param>
-        /// TODO: Implement AnimationFlags enum for this and fill it in.
-        /// <param name="flags">Animation flags. Possible values and functions unknown.</param>
-        public void PlayAnimation(string animName, float timeScale = 1.0f, float startTime = 0, float speedScale = 0, byte flags = 0)
+        /// <param name="flags">Animation flags. Refer to AnimationFlags enum.</param>
+        public void PlayAnimation(string animName, float timeScale = 1.0f, float startTime = 0, float speedScale = 0, AnimationFlags flags = 0)
         {
             _game.PacketNotifier.NotifyS2C_PlayAnimation(this, animName, flags, timeScale, startTime, speedScale);
+        }
+
+        /// <summary>
+        /// Forces this GameObject's current animations to pause/unpause.
+        /// </summary>
+        /// <param name="pause">Whether or not to pause/unpause animations.</param>
+        public void PauseAnimation(bool pause)
+        {
+            _game.PacketNotifier.NotifyS2C_PauseAnimation(this, pause);
+        }
+
+        /// <summary>
+        /// Forces this GameObject to stop playing the specified animation (or optionally all animations) with the given parameters.
+        /// </summary>
+        /// <param name="animation">Internal name of the animation to stop playing. Set blank/null if stopAll is true.</param>
+        /// <param name="stopAll">Whether or not to stop all animations. Only works if animation is empty/null.</param>
+        /// <param name="fade">Whether or not the animation should fade before stopping.</param>
+        /// <param name="ignoreLock">Whether or not locked animations should still be stopped.</param>
+        public void StopAnimation(string animation, bool stopAll = false, bool fade = false, bool ignoreLock = true)
+        {
+            _game.PacketNotifier.NotifyS2C_StopAnimation(this, animation, stopAll, fade, ignoreLock);
         }
     }
 }

--- a/GameServerLib/GameObjects/Stats/ReplicationHero.cs
+++ b/GameServerLib/GameObjects/Stats/ReplicationHero.cs
@@ -47,7 +47,8 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             // UpdateFloat(Stats.MagicResist.PercentBonus, 1, 18); //mPercentMagicReduction
             UpdateFloat(Stats.AttackSpeedMultiplier.Total, 1, 19); //mAttackSpeedMod
             UpdateFloat(Stats.Range.FlatBonus, 1, 20); //mFlatCastRangeMod
-            UpdateFloat(Stats.CooldownReduction.Total, 1, 21); //mPercentCooldownMod
+            // TODO: Find out why a negative value is required for ability cooldowns to display properly.
+            UpdateFloat(-Stats.CooldownReduction.Total, 1, 21); //mPercentCooldownMod
             // UpdateFloat(Stats.PassiveCooldownEndTime, 1, 22); //mPassiveCooldownEndTime
             // UpdateFloat(Stats.PassiveCooldownTotalTime, 1, 23); //mPassiveCooldownTotalTime
             UpdateFloat(Stats.ArmorPenetration.FlatBonus, 1, 24); //mFlatArmorPenetration

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -2107,17 +2107,17 @@ namespace PacketDefinitions420
         /// <param name="obj">GameObject that is playing the animation.</param>
         /// <param name="animation">Internal name of the animation to play.</param>
         /// TODO: Implement AnimationFlags enum for this and fill it in.
-        /// <param name="flags">Animation flags. Possible values and functions unknown.</param>
+        /// <param name="flags">Animation flags. Refer to AnimationFlags enum.</param>
         /// <param name="timeScale">How fast the animation should play. Default 1x speed.</param>
         /// <param name="startTime">Time in the animation to start at.</param>
         /// TODO: Verify if this description is correct, if not, correct it.
         /// <param name="speedScale">How much the speed of the GameObject should affect the animation.</param>
-        public void NotifyS2C_PlayAnimation(IGameObject obj, string animation, byte flags = 0, float timeScale = 1.0f, float startTime = 0.0f, float speedScale = 1.0f)
+        public void NotifyS2C_PlayAnimation(IGameObject obj, string animation, AnimationFlags flags = 0, float timeScale = 1.0f, float startTime = 0.0f, float speedScale = 1.0f)
         {
             var animPacket = new S2C_PlayAnimation
             {
                 SenderNetID = obj.NetId,
-                AnimationFlags = flags, // TODO: figure out what these do, and probably make an enum for it
+                AnimationFlags = (byte)flags,
                 ScaleTime = timeScale,
                 StartProgress = startTime,
                 SpeedRatio = speedScale,
@@ -2125,6 +2125,44 @@ namespace PacketDefinitions420
             };
 
             _packetHandlerManager.BroadcastPacketVision(obj, animPacket.GetBytes(), Channel.CHL_S2C);
+        }
+
+        /// <summary>
+        /// Sends a packet to all players detailing that the specified object's current animations have been paused/unpaused.
+        /// </summary>
+        /// <param name="obj">GameObject that is playing the animation.</param>
+        /// <param name="pause">Whether or not to pause/unpause animations.</param>
+        public void NotifyS2C_PauseAnimation(IGameObject obj, bool pause)
+        {
+            var animPacket = new S2C_PauseAnimation
+            {
+                SenderNetID = obj.NetId,
+                Pause = pause
+            };
+
+            _packetHandlerManager.BroadcastPacket(animPacket.GetBytes(), Channel.CHL_S2C);
+        }
+
+        /// <summary>
+        /// Sends a packet to all players detailing that the specified object has stopped playing an animation.
+        /// </summary>
+        /// <param name="obj">GameObject that is playing the animation.</param>
+        /// <param name="animation">Internal name of the animation to stop.</param>
+        /// <param name="stopAll">Whether or not to stop all animations. Only works if animation is empty/null.</param>
+        /// <param name="fade">Whether or not the animation should fade before stopping.</param>
+        /// <param name="ignoreLock">Whether or not locked animations should still be stopped.</param>
+        public void NotifyS2C_StopAnimation(IGameObject obj, string animation, bool stopAll = false, bool fade = false, bool ignoreLock = true)
+        {
+            var animPacket = new S2C_StopAnimation
+            {
+                SenderNetID = obj.NetId,
+                Fade = fade,
+                IgnoreLock = ignoreLock,
+                StopAll = stopAll,
+                AnimationName = animation
+            };
+
+            _packetHandlerManager.BroadcastPacket(animPacket.GetBytes(), Channel.CHL_S2C);
         }
 
         /// <summary>
@@ -2168,7 +2206,7 @@ namespace PacketDefinitions420
             {
                 SenderNetID = netId,
                 ObjectNetID = netId,
-                HashedSpellName = HashStringNorm(spellName),
+                HashedSpellName = HashString(spellName),
                 SpellSlot = slot
             };
 

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -440,7 +440,7 @@ namespace PacketDefinitions420
         /// <param name="newDisplayRange">New max display range for the spell to set.</param>
         /// <param name="newIconIndex">New index of an icon for the spell to set.</param>
         /// <param name="offsetTargets">New target netids for the spell to set.</param>
-        public void NotifyChangeSlotSpellData(int userId, IObjAiBase owner, byte slot, ChangeSlotSpellDataType changeType, bool isSummonerSpell = false, TargetingType targetingType = TargetingType.Invalid, string newName = "", float newRange = 0, float newMaxCastRange = 0, float newDisplayRange = 0, byte newIconIndex = 0x0, List<uint> offsetTargets = null)
+        public void NotifyChangeSlotSpellData(int userId, IObjAiBase owner, byte slot, GameServerCore.Enums.ChangeSlotSpellDataType changeType, bool isSummonerSpell = false, TargetingType targetingType = TargetingType.Invalid, string newName = "", float newRange = 0, float newMaxCastRange = 0, float newDisplayRange = 0, byte newIconIndex = 0x0, List<uint> offsetTargets = null)
         {
             ChangeSpellData spellData = new ChangeSpellDataUnknown()
             {
@@ -450,7 +450,7 @@ namespace PacketDefinitions420
 
             switch(changeType)
             {
-                case ChangeSlotSpellDataType.TargetingType:
+                case GameServerCore.Enums.ChangeSlotSpellDataType.TargetingType:
                 {
                     if (targetingType != TargetingType.Invalid)
                     {
@@ -463,7 +463,7 @@ namespace PacketDefinitions420
                     }
                     break;
                 }
-                case ChangeSlotSpellDataType.SpellName:
+                case GameServerCore.Enums.ChangeSlotSpellDataType.SpellName:
                 {
                     spellData = new ChangeSpellDataSpellName()
                     {
@@ -473,7 +473,7 @@ namespace PacketDefinitions420
                     };
                     break;
                 }
-                case ChangeSlotSpellDataType.Range:
+                case GameServerCore.Enums.ChangeSlotSpellDataType.Range:
                 {
                     spellData = new ChangeSpellDataRange()
                     {
@@ -483,7 +483,7 @@ namespace PacketDefinitions420
                     };
                     break;
                 }
-                case ChangeSlotSpellDataType.MaxGrowthRange:
+                case GameServerCore.Enums.ChangeSlotSpellDataType.MaxGrowthRange:
                 {
                     spellData = new ChangeSpellDataMaxGrowthRange()
                     {
@@ -493,7 +493,7 @@ namespace PacketDefinitions420
                     };
                     break;
                 }
-                case ChangeSlotSpellDataType.RangeDisplay:
+                case GameServerCore.Enums.ChangeSlotSpellDataType.RangeDisplay:
                 {
                     spellData = new ChangeSpellDataRangeDisplay()
                     {
@@ -503,7 +503,7 @@ namespace PacketDefinitions420
                     };
                     break;
                 }
-                case ChangeSlotSpellDataType.IconIndex:
+                case GameServerCore.Enums.ChangeSlotSpellDataType.IconIndex:
                 {
                     spellData = new ChangeSpellDataIconIndex()
                     {
@@ -513,7 +513,7 @@ namespace PacketDefinitions420
                     };
                     break;
                 }
-                case ChangeSlotSpellDataType.OffsetTarget:
+                case GameServerCore.Enums.ChangeSlotSpellDataType.OffsetTarget:
                 {
                     if (offsetTargets != null)
                     {


### PR DESCRIPTION
* Replication:
  * Fixed an issue related to cooldown reduction causing incorrect cooldown time to show when hovering over spells.
* GameObject:
  * PlayAnimation uses AnimationFlags.
  * Added Pause and Stop animation functions.
* Spell:
  * OnSpellPostCast now occurs after attack launch and cooldown start.
  * SetCooldown (optionally) takes into account cooldown reduction.
  * SpellLevel now sends SetSpellLevel packet to clients.
* Scripting:
  * Added Play and Stop animation functions.
  * All event listeners use a reverse for loop to reduce chances of the list being modified during the loop, which would result in an error/crash.
* Chat Commands:
  * Added CooldownReductionCommand.
* Packets:
  * Implemented Pause and Stop animation packets.
  * PlayAnimation now uses AnimationFlags enum.
  * Fixed SetSpellData not using the correct Hash function.
* Enums:
  * Added AnimationFlags enum (incomplete).


Resolve #1100