### PR TITLE
Resolve #1103 -- Removed Max Player Cap

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -125,11 +125,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             var playerTeam = "";
             var teamSize = GetTeamSize();
 
-            if (teamSize > 6) //???
-            {
-                teamSize = 6;
-            }
-
             if (config.Players.ContainsKey(playerIndex))
             {
                 var p = config.Players[playerIndex];
@@ -141,6 +136,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 {TeamId.TEAM_BLUE, config.MapSpawns.Blue},
                 {TeamId.TEAM_PURPLE, config.MapSpawns.Purple}
             };
+
+            if (teamSize > config.MapSpawns.Blue.Count || teamSize > config.MapSpawns.Purple.Count)
+            {
+                var spawns1 = spawnsByTeam[Team];
+                return spawns1[0].GetCoordsForPlayer(0);
+            }
 
             var spawns = spawnsByTeam[Team];
             return spawns[teamSize - 1].GetCoordsForPlayer((int)_playerTeamSpecialId);


### PR DESCRIPTION
Removed player cap in order to be possible to host matches with more than 12 players.
No Bugs noticed on some short test sessions.
I've tested 16 (8x8), 24 (12x12) and 48 players (24x24) without problems.

Resolve #1103