### PR TITLE
Resolve #1107 -- Implement Cone SectorType

### DIFF
--- a/Content/LeagueSandbox-Scripts/Champions/Anivia/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Anivia/R.cs
@@ -58,7 +58,7 @@ namespace Spells
 
                 DamageSector = spell.CreateSpellSector(new SectorParameters
                 {
-                    Radius = 400f,
+                    HalfLength = 400f,
                     Tickrate = 2,
                     CanHitSameTargetConsecutively = true,
                     OverrideFlags = SpellDataFlags.AffectEnemies | SpellDataFlags.AffectNeutral | SpellDataFlags.AffectMinions | SpellDataFlags.AffectHeroes,
@@ -67,7 +67,7 @@ namespace Spells
 
                 SlowSector = spell.CreateSpellSector(new SectorParameters
                 {
-                    Radius = 400f,
+                    HalfLength = 400f,
                     Tickrate = 4,
                     CanHitSameTargetConsecutively = true,
                     OverrideFlags = SpellDataFlags.AffectEnemies | SpellDataFlags.AffectNeutral | SpellDataFlags.AffectMinions | SpellDataFlags.AffectHeroes,

--- a/GameServerCore/Domain/GameObjects/Spell/Sector/ISectorParameters.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/Sector/ISectorParameters.cs
@@ -8,14 +8,29 @@ namespace GameServerCore.Domain.GameObjects.Spell.Sector
     public interface ISectorParameters
     {
         /// <summary>
-        /// Area around the sector to check for collisions.
+        /// Half the distance from the center of the sector to the maximum Y-value.
+        /// If this is larger than HalfWidth, it will be used as the area around the sector to check for collisions.
         /// </summary>
-        float Radius { get; set; }
+        float HalfLength { get; set; }
         /// <summary>
-        /// Maximum amount of time this spell sector should last before being automatically removed.
+        /// Half the distance from the center of the sector to the maximum X-value.
+        /// If this is larger than HalfLength, it will be used as the area around the sector to check for collisions.
+        /// </summary>
+        float HalfWidth { get; set; }
+        /// <summary>
+        /// If the Type is Cone, this will filter collisions that are in front of the sector and are within this angle from the sector's center.
+        /// Should be a value from 0->360
+        /// </summary>
+        float ConeAngle { get; set; }
+        /// <summary>
+        /// Maximum amount of time this spell sector should last (in seconds) before being automatically removed.
         /// Setting to -1 will cause the spell sector to last until manually removed.
         /// </summary>
         float Lifetime { get; set; }
+        /// <summary>
+        /// Whether or not the sector should only tick once before being removed.
+        /// </summary>
+        bool SingleTick { get; set; }
         /// <summary>
         /// How many times a second the spell sector should check for hitbox collisions.
         /// </summary>

--- a/GameServerCore/Enums/IMissileType.cs
+++ b/GameServerCore/Enums/IMissileType.cs
@@ -3,7 +3,7 @@
     public enum MissileType : int
     {
         /// <summary>
-        /// Unused. If a ProjectileGameScript is implemented which controls flight path, use this (possibly rename to "Custom").
+        /// Unused. If a MissileGameScript is implemented which controls flight path, use this (possibly rename to "Custom").
         /// </summary>
         None = 0x0,
         /// <summary>

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSector.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSector.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Numerics;
 using GameServerCore;
 using GameServerCore.Domain.GameObjects;
@@ -53,7 +54,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             ISpell originSpell,
             ICastInfo castInfo,
             uint netId = 0
-        ) : base(game, new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z), (int)parameters.Radius, 0, netId)
+        ) : base(game, new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z), Math.Max(parameters.HalfLength, parameters.HalfWidth), 0, netId)
         {
             _timeSinceCreation = 0.0f;
             _lastTickTime = 0.0f;
@@ -85,7 +86,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
 
             _lastTickTime += diff;
 
-            if ((Parameters.Lifetime >= 0 && Parameters.Lifetime <= _timeSinceCreation))
+            if ((Parameters.Lifetime >= 0 && (Parameters.Lifetime * 1000.0f) <= _timeSinceCreation))
             {
                 SetToRemove();
                 return;
@@ -130,7 +131,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             // OnCollision has already checked the affectRadius around the sector, so now we filter the area.
             if (collider is IAttackableUnit unit)
             {
-                if (FilterCollisions(unit) && IsValidTarget(unit))
+                if (IsValidTarget(unit) && FilterCollisions(unit))
                 {
                     _unitsToHit.Add(unit);
                 }
@@ -233,6 +234,11 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
                     HitUnit(_unitsToHit[i]);
                     _unitsToHit.RemoveAt(i);
                 }
+            }
+
+            if (Parameters.SingleTick)
+            {
+                SetToRemove();
             }
         }
 

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSectorCone.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSectorCone.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using GameServerCore;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using GameServerCore.Domain.GameObjects.Spell.Sector;
+using GameServerCore.Enums;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+
+namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
+{
+    /// <summary>
+    /// Base class for all spell sectors. Functionally acts as a circular spell hitbox.
+    /// Base functionality can be overriden to fit a specific shape.
+    /// </summary>
+    internal class SpellSectorCone : SpellSector, ISpellSector
+    {
+        public SpellSectorCone(
+            Game game,
+            ISectorParameters parameters,
+            ISpell originSpell,
+            ICastInfo castInfo,
+            uint netId = 0
+        ) : base(game, parameters, originSpell, castInfo, netId)
+        {
+            Position = new Vector2(castInfo.SpellCastLaunchPosition.X, castInfo.SpellCastLaunchPosition.Z);
+
+            var goingTo = new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z) - Position;
+            var dirTemp = Vector2.Normalize(goingTo);
+
+            // usually doesn't happen
+            if (float.IsNaN(dirTemp.X) || float.IsNaN(dirTemp.Y))
+            {
+                if (float.IsNaN(BindObject.Direction.X) || float.IsNaN(BindObject.Direction.Y))
+                {
+                    dirTemp = new Vector2(1, 0);
+                }
+                else
+                {
+                    dirTemp = new Vector2(BindObject.Direction.X, BindObject.Direction.Z);
+                }
+
+                var endPos = Position + (dirTemp * SpellOrigin.GetCurrentCastRange());
+                CastInfo.TargetPositionEnd = new Vector3(endPos.X, 0, endPos.Y);
+            }
+
+            Direction = new Vector3(dirTemp.X, 0, dirTemp.Y);
+
+            VisionRadius = SpellOrigin.SpellData.MissilePerceptionBubbleRadius;
+
+            Team = CastInfo.Owner.Team;
+        }
+
+        public override void Move(float diff)
+        {
+            // Change direction to the bind object's facing direction.
+            Direction = BindObject.Direction;
+
+            // Then move.
+            base.Move(diff);
+        }
+
+        /// <summary>
+        /// Filter function which checks if the given collider is within the bounds of a hitbox.
+        /// </summary>
+        /// <param name="collider">Object to check.</param>
+        /// <returns>True/False.</returns>
+        protected override bool FilterCollisions(IGameObject collider)
+        {
+            if (Parameters.ConeAngle <= 0)
+            {
+                return false;
+            }
+
+            // Here we simply check if the angle from the sector position to the collider's left and right bounds is greater than the ConeAngle.
+
+            // Get the current direction of the sector
+            var angleDir = Extensions.UnitVectorToAngle(new Vector2(Direction.X, Direction.Z));
+            // Get the left and round bounds of the collider (from the sector's perspective)
+            var colliderBounds = Extensions.CastRayCircle(Position, collider.Position, collider.CollisionRadius);
+
+            // True if the angle from the sector to either the left or right bounds is within the ConeAngle.
+            return MathF.Abs(Position.AngleTo(colliderBounds[0], Position) - angleDir) <= Parameters.ConeAngle
+                || MathF.Abs(Position.AngleTo(colliderBounds[1], Position) - angleDir) <= Parameters.ConeAngle;
+        }
+    }
+}

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -876,7 +876,13 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 }
                 case SectorType.Cone:
                 {
-                    // TODO
+                    s = new SpellSectorCone(
+                        _game,
+                        parameters,
+                        this,
+                        CastInfo,
+                        netId
+                    );
                     break;
                 }
                 case SectorType.Polygon:

--- a/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
@@ -100,14 +100,29 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
     public class SectorParameters : ISectorParameters
     {
         /// <summary>
-        /// Area around the sector to check for collisions.
+        /// Half the distance from the center of the sector to the maximum Y-value.
+        /// If this is larger than HalfWidth, it will be used as the area around the sector to check for collisions.
         /// </summary>
-        public float Radius { get; set; } = 0f;
+        public float HalfLength { get; set; } = 0f;
         /// <summary>
-        /// Maximum amount of time this spell sector should last before being automatically removed.
+        /// Half the distance from the center of the sector to the maximum X-value.
+        /// If this is larger than HalfLength, it will be used as the area around the sector to check for collisions.
+        /// </summary>
+        public float HalfWidth { get; set; } = 0f;
+        /// <summary>
+        /// If the Type is Cone, this will filter collisions that are in front of the sector and are within this angle from the sector's center.
+        /// Should be a value from 0->360
+        /// </summary>
+        public float ConeAngle { get; set; } = 0f;
+        /// <summary>
+        /// Maximum amount of time this spell sector should last (in seconds) before being automatically removed.
         /// Setting to -1 will cause the spell sector to last until manually removed.
         /// </summary>
         public float Lifetime { get; set; } = -1f;
+        /// <summary>
+        /// Whether or not the sector should only tick once before being removed (Lifetime must be greater than a single tick).
+        /// </summary>
+        public bool SingleTick { get; set; } = false;
         /// <summary>
         /// How many times a second the spell sector should check for hitbox collisions.
         /// </summary>


### PR DESCRIPTION
* Spell:
  * Utilized SpellSectorCone in CreateSpellSector.
* SpellSector:
  * Replaced Radius parameter with HalfLength and HalfWidth.
  * Added ConeAngle parameter.
  * Added SingleTick parameter.
  * Lifetime is now in seconds.
  * FilterCollisions now only occurs if the collider passes IsValidTarget.
  * Implemented SpellSectorCone for the Cone SectorType.
* Scripting:
  * Re-implemented Annie W as an example.
* Extensions:
  * Added AngleTo, UnitVectorToAngle, and CastRayCircle functions.
  * Removed AngleBetween function.