### PR TITLE
Resolve #1109 -- Player ID update

### DIFF
--- a/GameServerLib/Config.cs
+++ b/GameServerLib/Config.cs
@@ -58,8 +58,7 @@ namespace LeagueSandbox.GameServer
             foreach (var player in playerConfigurations)
             {
                 var playerConfig = new PlayerConfig(player);
-                var playerNum = Players.Count + 1;
-                Players.Add($"player{playerNum}", playerConfig);
+                Players.Add($"player{playerConfig.PlayerID}", playerConfig);
             }
 
             // Read cost/cd info

--- a/GameServerLib/Packets/PacketHandlers/HandleSync.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSync.cs
@@ -35,7 +35,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             }
             else
             {
-                _logger.Debug("Accepted client version (" + req.Version + ") from client="+req.ClientId);
+                _logger.Debug("Accepted client version (" + req.Version + ") from player="+userId);
             }
 
             foreach (var player in _playerManager.GetPlayers())

--- a/GameServerLib/Packets/PacketHandlers/HandleSync.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSync.cs
@@ -35,7 +35,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             }
             else
             {
-                _logger.Debug("Accepted client version (" + req.Version + ") from player="+userId);
+                _logger.Debug("Accepted client version (" + req.Version + ") from client = " + req.ClientId + " & PlayerID = " + userId);
             }
 
             foreach (var player in _playerManager.GetPlayers())

--- a/GameServerLib/Players/PlayerManager.cs
+++ b/GameServerLib/Players/PlayerManager.cs
@@ -15,7 +15,6 @@ namespace LeagueSandbox.GameServer.Players
         private Game _game;
 
         private List<Tuple<uint, ClientInfo>> _players = new List<Tuple<uint, ClientInfo>>();
-        private long _currentId = 1;
         private Dictionary<TeamId, uint> _userIdsPerTeam = new Dictionary<TeamId, uint>
         {
             { TeamId.TEAM_BLUE, 0 },
@@ -54,9 +53,8 @@ namespace LeagueSandbox.GameServer.Players
                 p.Value.Skin,
                 p.Value.Name,
                 summonerSkills,
-                _currentId // same as StartClient.bat
+                p.Value.PlayerID // same as StartClient.bat
             );
-            _currentId++;
             var c = new Champion(_game, p.Value.Champion, (uint)player.PlayerId, _userIdsPerTeam[teamId]++, p.Value.Runes, player, 0, teamId);
 
             var pos = c.GetSpawnPosition();


### PR DESCRIPTION
-Fixed an issue that would cause so player ID numbers HAD to be sequential (1,2,3,4,5...), now it can be any sequence(2, 5, 7, 14). (Credits to Lizardy, who helped me figure this out)

-Changed so the console shows the player ID that just connected, instead of just counting progressively/additively by the clients.

Resolve #1109