### PR TITLE
Resolve #1113 -- Implement SpellSectorPolygon & Particle Refactor

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Aatrox/AatroxR.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Aatrox/AatroxR.cs
@@ -36,7 +36,7 @@ namespace AatroxR
                 {
                     pmodelname = "Aatrox_Skin02_RModel.troy";
                 }
-                pmodel = AddParticleTarget(c, pmodelname, c);
+                pmodel = AddParticleTarget(c, c, pmodelname, c);
                 pmodel.SetToRemove();
 
                 StatsModifier.AttackSpeed.PercentBonus = (0.4f + (0.1f * (ownerSpell.CastInfo.SpellLevel - 1))) * buff.StackCount; // StackCount included here as an example

--- a/Content/LeagueSandbox-Scripts/Buffs/Anivia/GlacialStorm.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Anivia/GlacialStorm.cs
@@ -41,13 +41,13 @@ namespace GlacialStorm
 
             if (owner.Team == TeamId.TEAM_BLUE)
             {
-                red = AddParticle(owner, "cryo_storm_red_team.troy", spellPos, lifetime: buff.Duration, reqVision: false, teamOnly: TeamId.TEAM_PURPLE);
-                green = AddParticle(owner, "cryo_storm_green_team.troy", spellPos, lifetime: buff.Duration, reqVision: false, teamOnly: TeamId.TEAM_BLUE);
+                red = AddParticle(owner, null, "cryo_storm_red_team.troy", spellPos, lifetime: buff.Duration, reqVision: false, teamOnly: TeamId.TEAM_PURPLE);
+                green = AddParticle(owner, null, "cryo_storm_green_team.troy", spellPos, lifetime: buff.Duration, reqVision: false, teamOnly: TeamId.TEAM_BLUE);
             }
             else
             {
-                red = AddParticle(owner, "cryo_storm_red_team.troy", spellPos, lifetime: buff.Duration, reqVision: false, teamOnly: TeamId.TEAM_BLUE);
-                green = AddParticle(owner, "cryo_storm_green_team.troy", spellPos, lifetime: buff.Duration, reqVision: false, teamOnly: TeamId.TEAM_PURPLE);
+                red = AddParticle(owner, null, "cryo_storm_red_team.troy", spellPos, lifetime: buff.Duration, reqVision: false, teamOnly: TeamId.TEAM_BLUE);
+                green = AddParticle(owner, null, "cryo_storm_green_team.troy", spellPos, lifetime: buff.Duration, reqVision: false, teamOnly: TeamId.TEAM_PURPLE);
             }
         }
 

--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/Overdrive.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/Overdrive.cs
@@ -3,6 +3,7 @@ using GameServerCore.Domain.GameObjects;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
 namespace Overdrive
 {
@@ -15,7 +16,7 @@ namespace Overdrive
 
         public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
-        //IParticle p;
+        IParticle p;
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
@@ -23,12 +24,12 @@ namespace Overdrive
             StatsModifier.MoveSpeed.PercentBonus = StatsModifier.MoveSpeed.PercentBonus + (12f + ownerSpell.CastInfo.SpellLevel * 4) / 100f;
             StatsModifier.AttackSpeed.PercentBonus = StatsModifier.AttackSpeed.PercentBonus + (22f + 8f * ownerSpell.CastInfo.SpellLevel) / 100f;
             unit.AddStatModifier(StatsModifier);
-
+            p = AddParticleTarget(ownerSpell.CastInfo.Owner, unit, "Overdrive_buf.troy", unit, buff.Duration);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            //RemoveParticle(p);
+            RemoveParticle(p);
         }
 
         public void OnUpdate(float diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab.cs
@@ -20,7 +20,7 @@ namespace RocketGrab
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            grab = AddParticleTarget(unit, "FistReturn_mis.troy", ownerSpell.CastInfo.Owner, 1, "head", "R_hand", lifetime: buff.Duration);
+            grab = AddParticleTarget(ownerSpell.CastInfo.Owner, unit, "FistReturn_mis.troy", ownerSpell.CastInfo.Owner, buff.Duration, 1, "head", "R_hand");
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Buffs/Gangplank/GangplankE.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Gangplank/GangplankE.cs
@@ -21,6 +21,7 @@ namespace GangplankE
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
+            var owner = ownerSpell.CastInfo.Owner;
             StatsModifier.AttackSpeed.PercentBonus = StatsModifier.AttackSpeed.PercentBonus + (10f + 20f * ownerSpell.CastInfo.SpellLevel) / 100f;
             StatsModifier.MoveSpeed.PercentBonus = StatsModifier.MoveSpeed.PercentBonus + (10f + 5f * ownerSpell.CastInfo.SpellLevel) / 100f;
             StatsModifier.AttackDamage.PercentBonus = StatsModifier.AttackDamage.PercentBonus + (10f + 10f * ownerSpell.CastInfo.SpellLevel) / 100f;
@@ -28,9 +29,9 @@ namespace GangplankE
 
             //_hudvisual = AddBuffHUDVisual("RaiseMorale", time, 1, unit);
 
-            Particles.Add(AddParticleTarget(ownerSpell.CastInfo.Owner, "pirate_raiseMorale_cas.troy", unit, 1));
-            Particles.Add(AddParticleTarget(ownerSpell.CastInfo.Owner, "pirate_raiseMorale_mis.troy", unit, 1));
-            Particles.Add(AddParticleTarget(ownerSpell.CastInfo.Owner, "pirate_raiseMorale_tar.troy", unit, 1));
+            Particles.Add(AddParticleTarget(owner, null, "pirate_raiseMorale_cas.troy", unit));
+            Particles.Add(AddParticleTarget(owner, null, "pirate_raiseMorale_mis.troy", unit));
+            Particles.Add(AddParticleTarget(owner, null, "pirate_raiseMorale_tar.troy", unit));
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Recall.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Recall.cs
@@ -29,7 +29,7 @@ namespace Recall
             ApiEventManager.OnTakeDamage.AddListener(this, unit, OnTakeDamage, true);
             ApiEventManager.OnUnitUpdateMoveOrder.AddListener(this, champion, OnUpdateMoveOrder, true);
 
-            _createdParticle = AddParticleTarget(champion, "TeleportHome.troy", champion, lifetime: buff.Duration);
+            _createdParticle = AddParticleTarget(champion, champion, "TeleportHome.troy", champion, lifetime: buff.Duration);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Stun.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Stun.cs
@@ -19,7 +19,7 @@ namespace Stun
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            stun = AddParticleTarget(ownerSpell.CastInfo.Owner, "Global_Stun.troy", unit, buff.Duration, "head");
+            stun = AddParticleTarget(ownerSpell.CastInfo.Owner, null, "Global_Stun.troy", unit, buff.Duration, bone: "head");
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Buffs/Graves/Quickdraw.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Graves/Quickdraw.cs
@@ -24,7 +24,8 @@ namespace Quickdraw
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            activate = AddParticleTarget(ownerSpell.CastInfo.Owner, "Graves_Move_OnBuffActivate.troy", unit);
+            var owner = ownerSpell.CastInfo.Owner;
+            activate = AddParticleTarget(owner, unit, "Graves_Move_OnBuffActivate.troy", unit);
             StatsModifier.AttackSpeed.PercentBonus = 0.2f + (0.1f * ownerSpell.CastInfo.SpellLevel);
             unit.AddStatModifier(StatsModifier);
         }

--- a/Content/LeagueSandbox-Scripts/Buffs/Items/DeathfireGraspSpell.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Items/DeathfireGraspSpell.cs
@@ -20,7 +20,8 @@ namespace DeathfireGraspSpell
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            debuff = AddParticleTarget(ownerSpell.CastInfo.Owner, "obj_DeathfireGrasp_debuff.troy", unit);
+            var owner = ownerSpell.CastInfo.Owner;
+            debuff = AddParticleTarget(owner, unit, "obj_DeathfireGrasp_debuff.troy", unit);
 
             // TODO: Implement damage amp. stat modifier or OnTakeDamage listener
         }

--- a/Content/LeagueSandbox-Scripts/Buffs/Items/RegenerationPotion.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Items/RegenerationPotion.cs
@@ -20,9 +20,10 @@ namespace RegenerationPotion
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
+            var caster = ownerSpell.CastInfo.Owner;
             StatsModifier.HealthRegeneration.FlatBonus = 10f;
             unit.AddStatModifier(StatsModifier);
-            potion = AddParticleTarget(ownerSpell.CastInfo.Owner, "GLOBAL_Item_HealthPotion.troy", unit, 1, "Buffbone_Glb_Ground_Loc", lifetime: buff.Duration);
+            potion = AddParticleTarget(caster, unit, "GLOBAL_Item_HealthPotion.troy", unit, buff.Duration, bone: "Buffbone_Glb_Ground_Loc");
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Buffs/Items/YoumuusGhostblade.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Items/YoumuusGhostblade.cs
@@ -2,6 +2,7 @@
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects.Stats;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Scripting.CSharp;
 
 namespace YoumuusGhostblade
@@ -15,8 +16,11 @@ namespace YoumuusGhostblade
 
         public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
+        IParticle p;
+
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
+            p = AddParticleTarget(ownerSpell.CastInfo.Owner, unit, "spectral_fury_activate_speed.troy", unit, buff.Duration, size: 2);
             StatsModifier.MoveSpeed.PercentBonus = 0.2f;
             StatsModifier.AttackSpeed.PercentBonus = 0.4f;
             unit.AddStatModifier(StatsModifier);
@@ -24,6 +28,7 @@ namespace YoumuusGhostblade
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
+            RemoveParticle(p);
         }
 
         public void OnUpdate(float diff)

--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkSonicWave.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkSonicWave.cs
@@ -43,7 +43,7 @@ namespace BlindMonkSonicWave
                 var ad = owner.Stats.AttackDamage.Total * 1.0f;
                 var damage = 50 + (originSpell.CastInfo.SpellLevel * 30) + ad + (0.08f * (target.Stats.HealthPoints.Total - target.Stats.CurrentHealth));
                 target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_REACTIVE, false);
-                AddParticleTarget(owner, "GlobalHit_Yellow_tar.troy", target, 1);
+                AddParticleTarget(owner, owner, "GlobalHit_Yellow_tar.troy", target);
 
                 thisBuff.DeactivateBuff();
             }

--- a/Content/LeagueSandbox-Scripts/Buffs/Leona/LeonaShieldOfDaybreak.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Leona/LeonaShieldOfDaybreak.cs
@@ -24,7 +24,7 @@ namespace LeonaShieldOfDaybreak
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             thisBuff = buff;
-            pbuff = AddParticleTarget(unit, "Leona_ShieldOfDaybreak_cas.troy", unit, 1, "BUFFBONE_CSTM_SHIELD_TOP", lifetime: buff.Duration);
+            pbuff = AddParticleTarget(ownerSpell.CastInfo.Owner, unit, "Leona_ShieldOfDaybreak_cas.troy", unit, buff.Duration, bone: "BUFFBONE_CSTM_SHIELD_TOP");
 
             StatsModifier.Range.FlatBonus = 30.0f;
 

--- a/Content/LeagueSandbox-Scripts/Buffs/Lulu/LuluR.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Lulu/LuluR.cs
@@ -26,8 +26,9 @@ namespace LuluR
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
+            var owner = ownerSpell.CastInfo.Owner;
             OwnerSpell = ownerSpell;
-            cast = AddParticleTarget(ownerSpell.CastInfo.Owner, "Lulu_R_cas.troy", unit, 1);
+            cast = AddParticleTarget(owner, unit, "Lulu_R_cas.troy", unit);
 
             StatsModifier.Size.PercentBonus = StatsModifier.Size.PercentBonus + 1;
             _healthBefore = unit.Stats.CurrentHealth;
@@ -40,7 +41,7 @@ namespace LuluR
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             RemoveParticle(cast);
-            AddParticleTarget(OwnerSpell.CastInfo.Owner, "Lulu_R_expire.troy", unit, 1);
+            AddParticleTarget(OwnerSpell.CastInfo.Owner, unit, "Lulu_R_expire.troy", unit);
             _healthNow = unit.Stats.CurrentHealth - _healthBonus;
             _meantimeDamage = _healthBefore - _healthNow;
             var bonusDamage = _healthBonus - _meantimeDamage;

--- a/Content/LeagueSandbox-Scripts/Buffs/Lulu/LuluW/LuluWBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Lulu/LuluW/LuluWBuff.cs
@@ -21,8 +21,9 @@ namespace LuluWBuff
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            buff1 = AddParticleTarget(ownerSpell.CastInfo.Owner, "Lulu_W_buf_01.troy", unit, 1);
-            buff2 = AddParticleTarget(ownerSpell.CastInfo.Owner, "Lulu_W_buf_02.troy", unit, 1);
+            var caster = ownerSpell.CastInfo.Owner;
+            buff1 = AddParticleTarget(caster, unit, "Lulu_W_buf_01.troy", unit);
+            buff2 = AddParticleTarget(caster, unit, "Lulu_W_buf_02.troy", unit);
 
             var ap = ownerSpell.CastInfo.Owner.Stats.AbilityPower.Total * 0.001;
             StatsModifier.MoveSpeed.PercentBonus = StatsModifier.MoveSpeed.PercentBonus + 0.3f + (float)ap;

--- a/Content/LeagueSandbox-Scripts/Buffs/MasterYi/Highlander.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/MasterYi/Highlander.cs
@@ -20,7 +20,8 @@ namespace Highlander
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            highlander = AddParticleTarget(ownerSpell.CastInfo.Owner, "Highlander_buf.troy", unit, 1);
+            var owner = ownerSpell.CastInfo.Owner;
+            highlander = AddParticleTarget(owner, unit, "Highlander_buf.troy", unit);
 
             StatsModifier.MoveSpeed.PercentBonus = StatsModifier.MoveSpeed.PercentBonus + (15f + ownerSpell.CastInfo.SpellLevel * 10) / 100f;
             StatsModifier.AttackSpeed.PercentBonus = StatsModifier.AttackSpeed.PercentBonus + (5f + ownerSpell.CastInfo.SpellLevel * 25) / 100f;

--- a/Content/LeagueSandbox-Scripts/Buffs/Sivir/SivirW.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Sivir/SivirW.cs
@@ -25,7 +25,7 @@ namespace SivirW
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             thisBuff = buff;
-            pbuff = AddParticleTarget(unit, "Sivir_Base_W_Buff.troy", unit, 1, "BUFFBONE_CSTM_WEAPON_1", lifetime: buff.Duration);
+            pbuff = AddParticleTarget(ownerSpell.CastInfo.Owner, unit, "Sivir_Base_W_Buff.troy", unit, buff.Duration, bone: "BUFFBONE_CSTM_WEAPON_1");
 
             if (unit is IObjAiBase ai)
             {

--- a/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerDot.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerDot.cs
@@ -28,7 +28,7 @@ namespace SummonerDot
             Owner = ownerSpell.CastInfo.Owner;
             Target = unit;
             damage = 10 + Owner.Stats.Level * 4;
-            ignite = AddParticleTarget(Owner, "Global_SS_Ignite.troy", unit, 1, "C_BUFFBONE_GLB_CHEST_LOC", lifetime: buff.Duration);
+            ignite = AddParticleTarget(Owner, unit, "Global_SS_Ignite.troy", unit, buff.Duration, bone: "C_BUFFBONE_GLB_CHEST_LOC");
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoE.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoE.cs
@@ -20,10 +20,11 @@ namespace YasuoE
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
+            var owner = ownerSpell.CastInfo.Owner;
             var time = 0.6f - ownerSpell.CastInfo.SpellLevel * 0.1f;
             var damage = 50f + ownerSpell.CastInfo.SpellLevel * 20f + unit.Stats.AbilityPower.Total * 0.6f;
-            AddParticleTarget(ownerSpell.CastInfo.Owner, "Yasuo_Base_E_Dash.troy", unit);
-            AddParticleTarget(ownerSpell.CastInfo.Owner, "Yasuo_Base_E_dash_hit.troy", target);
+            AddParticleTarget(owner, unit, "Yasuo_Base_E_Dash.troy", unit);
+            AddParticleTarget(owner, target, "Yasuo_Base_E_dash_hit.troy", target);
             var to = Vector2.Normalize(target.Position - unit.Position);
             ForceMovement(unit, "Spell3", new Vector2(target.Position.X + to.X * 175f, target.Position.Y + to.Y * 175f), 750f + unit.Stats.MoveSpeed.Total * 0.6f, 0, 0, 0);
             target.TakeDamage(unit, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);

--- a/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoEBlock.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoEBlock.cs
@@ -19,7 +19,8 @@ namespace YasuoEBlock
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            timer = AddParticleTarget(ownerSpell.CastInfo.Owner, "Yasuo_base_E_timer1.troy", unit);
+            var owner = ownerSpell.CastInfo.Owner;
+            timer = AddParticleTarget(owner, unit, "Yasuo_base_E_timer1.troy", unit);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoQ2.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoQ2.cs
@@ -22,11 +22,12 @@ namespace YasuoQ02
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
+            var caster = ownerSpell.CastInfo.Owner;
             ((IChampion)unit).SetSpell("YasuoQ3W", 0, true);
-            p1 = AddParticleTarget((IChampion)unit, "Yasuo_Base_Q3_Indicator_Ring.troy", unit);
-            p2 = AddParticleTarget((IChampion)unit, "Yasuo_Base_Q3_Indicator_Ring_alt.troy", unit);
-            p3 = AddParticleTarget((IChampion)unit, "Yasuo_Base_Q_wind_ready_buff.troy", unit);
-            p4 = AddParticleTarget((IChampion)unit, "Yasuo_Base_Q_strike_build_up_test.troy", unit);
+            p1 = AddParticleTarget(caster, (IChampion)unit, "Yasuo_Base_Q3_Indicator_Ring.troy", unit);
+            p2 = AddParticleTarget(caster, (IChampion)unit, "Yasuo_Base_Q3_Indicator_Ring_alt.troy", unit);
+            p3 = AddParticleTarget(caster, (IChampion)unit, "Yasuo_Base_Q_wind_ready_buff.troy", unit);
+            p4 = AddParticleTarget(caster, (IChampion)unit, "Yasuo_Base_Q_strike_build_up_test.troy", unit);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Champions/Aatrox/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Aatrox/R.cs
@@ -50,7 +50,8 @@ namespace Spells
 
         public void OnSpellCast(ISpell spell)
         {
-            AddParticleTarget(spell.CastInfo.Owner, pcastname, spell.CastInfo.Owner);
+            var owner = spell.CastInfo.Owner;
+            AddParticleTarget(owner, owner, pcastname, owner);
         }
 
         public void OnSpellPostCast(ISpell spell)
@@ -65,7 +66,7 @@ namespace Spells
                     if (units[i].Team != c.Team && !(units[i] is IObjBuilding || units[i] is IBaseTurret))
                     {
                         units[i].TakeDamage(c, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
-                        AddParticleTarget(c, phitname, units[i]);
+                        AddParticleTarget(c, units[i], phitname, units[i]);
                     }
                 }
 

--- a/Content/LeagueSandbox-Scripts/Champions/Akali/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Akali/Q.cs
@@ -46,7 +46,7 @@ namespace Spells
             var ap = owner.Stats.AbilityPower.Total * 0.4f;
             var damage = 15 + spell.CastInfo.SpellLevel * 20 + ap;
             target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
-            AddParticleTarget(owner, "akali_markOftheAssasin_marker_tar_02.troy", target, 1, "");
+            AddParticleTarget(owner, target, "akali_markOftheAssasin_marker_tar_02.troy", target);
             missile.SetToRemove();
         }
 

--- a/Content/LeagueSandbox-Scripts/Champions/Akali/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Akali/R.cs
@@ -35,16 +35,18 @@ namespace Spells
 
         public void OnSpellPostCast(ISpell spell)
         {
-            var current = new Vector2(spell.CastInfo.Owner.Position.X, spell.CastInfo.Owner.Position.Y);
-            var to = Vector2.Normalize(new Vector2(spell.CastInfo.Targets[0].Unit.Position.X, spell.CastInfo.Targets[0].Unit.Position.Y) - current);
+            var owner = spell.CastInfo.Owner;
+            var target = spell.CastInfo.Targets[0].Unit;
+            var current = new Vector2(owner.Position.X, owner.Position.Y);
+            var to = Vector2.Normalize(new Vector2(target.Position.X, target.Position.Y) - current);
             var range = to * 800;
 
             var trueCoords = current + range;
 
             //TODO: Dash to the correct location (in front of the enemy IChampion) instead of far behind or inside them
-            ForceMovement(spell.CastInfo.Owner, spell.CastInfo.Targets[0].Unit, "Spell4", 2200, 0, 0, 0, 20000);
+            ForceMovement(owner, target, "Spell4", 2200, 0, 0, 0, 20000);
             //ForceMovement(spell.CastInfo.Owner, "Spell4", trueCoords, 2200, 0, 0, 0);
-            AddParticleTarget(spell.CastInfo.Owner, "akali_shadowDance_tar.troy", spell.CastInfo.Targets[0].Unit, 1, "");
+            AddParticleTarget(owner, target, "akali_shadowDance_tar.troy", target);
         }
 
         public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, ISpellMissile missile)

--- a/Content/LeagueSandbox-Scripts/Champions/Akali/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Akali/W.cs
@@ -34,13 +34,13 @@ namespace Spells
         public void OnSpellPostCast(ISpell spell)
         {
             var owner = spell.CastInfo.Owner;
-            var smokeBomb = AddParticle(owner, "akali_smoke_bomb_tar.troy", owner.Position);
+            var smokeBomb = AddParticle(owner, null, "akali_smoke_bomb_tar.troy", owner.Position);
             /*
              * TODO: Display green border (akali_smoke_bomb_tar_team_green.troy) for the own team,
              * display red border (akali_smoke_bomb_tar_team_red.troy) for the enemy team
              * Currently only displaying the green border for everyone
             */
-            var smokeBombBorder = AddParticle(owner, "akali_smoke_bomb_tar_team_green.troy", owner.Position);
+            var smokeBombBorder = AddParticle(owner, null, "akali_smoke_bomb_tar_team_green.troy", owner.Position);
             //TODO: Add invisibility
 
             CreateTimer(8.0f, () =>

--- a/Content/LeagueSandbox-Scripts/Champions/Annie/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Annie/Q.cs
@@ -38,11 +38,11 @@ namespace Spells
 
             if (ownerSkinID == 5)
             {
-                AddParticleTarget(owner, "DisintegrateHit_tar_frost.troy", target, lifetime: 1.0f);
+                AddParticleTarget(owner, target, "DisintegrateHit_tar_frost.troy", target);
             }
             else
             {
-                AddParticleTarget(owner, "DisintegrateHit_tar.troy", target, lifetime: 1.0f);
+                AddParticleTarget(owner, target, "DisintegrateHit_tar.troy", target);
             }
         }
 

--- a/Content/LeagueSandbox-Scripts/Champions/Annie/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Annie/W.cs
@@ -52,8 +52,8 @@ namespace Spells
                 Type = SectorType.Cone
             });
 
-            AddParticle(owner, "IIncinerate_buf.troy", GetPointFromUnit(owner, 625f));
-            AddParticleTarget(owner, "Incinerate_cas.troy", owner);
+            AddParticle(owner, null, "IIncinerate_buf.troy", GetPointFromUnit(owner, 625f));
+            AddParticleTarget(owner, owner, "Incinerate_cas.troy", owner);
         }
 
         public void TargetExecute(ISpell spell, IAttackableUnit target, ISpellSector sector)

--- a/Content/LeagueSandbox-Scripts/Champions/Blitzcrank/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Blitzcrank/W.cs
@@ -24,12 +24,7 @@ namespace Spells
 
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
-            var p = AddParticleTarget(owner, "Overdrive_buf.troy", target, 1);
             AddBuff("Overdrive", 8.0f, 1, spell, owner, owner);
-            CreateTimer(8.0f, () =>
-            {
-                RemoveParticle(p);
-            });
         }
 
         public void OnSpellCast(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/Caitlyn/E.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Caitlyn/E.cs
@@ -57,8 +57,8 @@ namespace Spells
             target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
             var slowDuration = new[] { 0, 1, 1.25f, 1.5f, 1.75f, 2 }[spell.CastInfo.SpellLevel];
             AddBuff("Slow", slowDuration, 1, spell, target, owner);
-            AddParticleTarget(owner, "caitlyn_entrapment_tar.troy", target);
-            AddParticleTarget(owner, "caitlyn_entrapment_slow.troy", target);
+            AddParticleTarget(owner, target, "caitlyn_entrapment_tar.troy", target);
+            AddParticleTarget(owner, target, "caitlyn_entrapment_slow.troy", target);
 
             missile.SetToRemove();
         }

--- a/Content/LeagueSandbox-Scripts/Champions/Ezreal/E.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Ezreal/E.cs
@@ -61,8 +61,8 @@ namespace Spells
                 }
             }
 
-            AddParticle(owner, "Ezreal_arcaneshift_cas.troy", startPos);
-            AddParticleTarget(owner, "Ezreal_arcaneshift_flash.troy", owner);
+            AddParticle(owner, null, "Ezreal_arcaneshift_cas.troy", startPos);
+            AddParticleTarget(owner, owner, "Ezreal_arcaneshift_flash.troy", owner);
 
             TeleportTo(owner, trueCoords.X, trueCoords.Y);
         }

--- a/Content/LeagueSandbox-Scripts/Champions/Ezreal/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Ezreal/Q.cs
@@ -33,7 +33,8 @@ namespace Spells
 
         public void OnSpellCast(ISpell spell)
         {
-            AddParticleTarget(spell.CastInfo.Owner, "ezreal_bow.troy", spell.CastInfo.Owner, 1, "L_HAND", lifetime: 1.0f);
+            var owner = spell.CastInfo.Owner;
+            AddParticleTarget(owner, owner, "ezreal_bow.troy", owner, bone: "L_HAND");
         }
 
         public void OnSpellPostCast(ISpell spell)
@@ -117,7 +118,7 @@ namespace Spells
                 owner.Spells[i].LowerCooldown(1);
             }
 
-            AddParticleTarget(target, "Ezreal_mysticshot_tar.troy", target);
+            AddParticleTarget(owner, target, "Ezreal_mysticshot_tar.troy", target);
             missile.SetToRemove();
 
             // SpellBuffAdd EzrealRisingSpellForce

--- a/Content/LeagueSandbox-Scripts/Champions/Ezreal/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Ezreal/R.cs
@@ -39,7 +39,8 @@ namespace Spells
 
         public void OnSpellCast(ISpell spell)
         {
-            AddParticleTarget(spell.CastInfo.Owner, "Ezreal_bow_huge.troy", spell.CastInfo.Owner, 1, "L_HAND", lifetime: 1.0f);
+            var owner = spell.CastInfo.Owner;
+            AddParticleTarget(owner, owner, "Ezreal_bow_huge.troy", owner, bone: "L_HAND");
         }
 
         public void OnSpellPostCast(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/Ezreal/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Ezreal/W.cs
@@ -31,7 +31,8 @@ namespace Spells
 
         public void OnSpellCast(ISpell spell)
         {
-            AddParticleTarget(spell.CastInfo.Owner, "ezreal_bow_yellow.troy", spell.CastInfo.Owner, 1, "L_HAND");
+            var owner = spell.CastInfo.Owner;
+            AddParticleTarget(owner, owner,  "ezreal_bow_yellow.troy", owner, bone: "L_HAND");
         }
 
         public void OnSpellPostCast(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/Garen/E.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Garen/E.cs
@@ -29,7 +29,7 @@ namespace Spells
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
             //owner.SpellAnimation("SPELL3");
-            var p = AddParticleTarget(owner, "Garen_Base_E_Spin.troy", owner, lifetime: 3.0f);
+            var p = AddParticleTarget(owner, owner, "Garen_Base_E_Spin.troy", owner, lifetime: 3.0f);
             AddBuff("GarenE", 3.0f, 1, spell, owner, owner);
             CreateTimer(3.0f, () =>
             {

--- a/Content/LeagueSandbox-Scripts/Champions/Garen/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Garen/R.cs
@@ -36,16 +36,16 @@ namespace Spells
         {
             var owner = spell.CastInfo.Owner;
             var target = spell.CastInfo.Targets[0].Unit;
-            AddParticleTarget(owner, "Garen_Base_R_Tar_Impact.troy", target, 1);
-            AddParticleTarget(owner, "Garen_Base_R_Sword_Tar.troy", target, 1);
+            AddParticleTarget(owner, target, "Garen_Base_R_Tar_Impact.troy", target);
+            AddParticleTarget(owner, target, "Garen_Base_R_Sword_Tar.troy", target);
             var missinghealth = target.Stats.HealthPoints.Total - target.Stats.CurrentHealth;
             var damageperc = missinghealth * new[] { 0.28f, 0.33f, 0.40f }[spell.CastInfo.SpellLevel - 1];
             var damage = spell.CastInfo.SpellLevel * 175 + damageperc;
             target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
             if (target.IsDead)
             {
-                AddParticleTarget(owner, "Garen_Base_R_Champ_Kill.troy", target, 1);
-                AddParticleTarget(owner, "Garen_Base_R_Champ_Death.troy", target, 1);
+                AddParticleTarget(owner, target, "Garen_Base_R_Champ_Kill.troy", target);
+                AddParticleTarget(owner, target, "Garen_Base_R_Champ_Death.troy", target);
             }
         }
 

--- a/Content/LeagueSandbox-Scripts/Champions/Global/SummonerExhaust.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Global/SummonerExhaust.cs
@@ -27,7 +27,7 @@ namespace Spells
         {
             if (target != null)
             {
-                AddParticleTarget(owner, "Global_SS_Exhaust.troy", target);
+                AddParticleTarget(owner, target, "Global_SS_Exhaust.troy", target);
                 AddBuff("SummonerExhaustDebuff", 2.5f, 1, spell, target, owner);
             }
         }

--- a/Content/LeagueSandbox-Scripts/Champions/Global/SummonerFlash.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Global/SummonerFlash.cs
@@ -42,9 +42,9 @@ namespace Spells
 
             owner.FaceDirection(new Vector3(to.X, 0.0f, to.Y));
 
-            AddParticle(owner, "global_ss_flash.troy", owner.Position);
+            AddParticle(owner, null, "global_ss_flash.troy", owner.Position);
             TeleportTo(owner, trueCoords.X, trueCoords.Y);
-            AddParticleTarget(owner, "global_ss_flash_02.troy", owner);
+            AddParticleTarget(owner, owner, "global_ss_flash_02.troy", owner);
         }
 
         public void OnSpellCast(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/Global/SummonerHaste.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Global/SummonerHaste.cs
@@ -26,8 +26,8 @@ namespace Spells
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
             AddBuff("SummonerHasteBuff", 10.0f, 1, spell, owner, owner);
-            var p1 = AddParticleTarget(owner, "Global_SS_Ghost.troy", target);
-            var p2 = AddParticleTarget(owner, "Global_SS_Ghost_cas.troy", target);
+            var p1 = AddParticleTarget(owner, target, "Global_SS_Ghost.troy", target);
+            var p2 = AddParticleTarget(owner, target, "Global_SS_Ghost_cas.troy", target);
             CreateTimer(10.0f, () =>
             {
                 RemoveParticle(p1);

--- a/Content/LeagueSandbox-Scripts/Champions/Global/SummonerHeal.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Global/SummonerHeal.cs
@@ -74,8 +74,8 @@ namespace Spells
             target.Stats.CurrentHealth = Math.Min(newHealth, target.Stats.HealthPoints.Total);
             AddBuff("HealSpeed", 1.0f, 1, spell, target, owner);
             AddBuff("HealCheck", 35.0f, 1, spell, target, owner);
-            AddParticleTarget(owner, "global_ss_heal_02.troy", target);
-            AddParticleTarget(owner, "global_ss_heal_speedboost.troy", target);
+            AddParticleTarget(owner, target, "global_ss_heal_02.troy", target);
+            AddParticleTarget(owner, target, "global_ss_heal_speedboost.troy", target);
         }
 
         public void OnSpellCast(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/Global/SummonerMana.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Global/SummonerMana.cs
@@ -44,7 +44,7 @@ namespace Spells
                 target.Stats.CurrentMana = newMp;
             else
                 target.Stats.CurrentMana = maxMp;
-            AddParticleTarget(target, "global_ss_clarity_02.troy", target);
+            AddParticleTarget(target, target, "global_ss_clarity_02.troy", target);
         }
 
         public void OnSpellCast(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/Global/SummonerRevive.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Global/SummonerRevive.cs
@@ -32,7 +32,7 @@ namespace Spells
 
             (owner as IChampion).Respawn();
             AddBuff("SummonerReviveSpeedBoost", 12.0f, 1, spell, owner, owner);
-            AddParticleTarget(owner, "Global_SS_Revive.troy", owner);
+            AddParticleTarget(owner, owner, "Global_SS_Revive.troy", owner);
         }
 
         public void OnSpellCast(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/Global/SummonerSmite.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Global/SummonerSmite.cs
@@ -26,7 +26,7 @@ namespace Spells
 
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
-            AddParticleTarget(owner, "Global_SS_Smite.troy", target, 1);
+            AddParticleTarget(owner, target, "Global_SS_Smite.troy", target);
             var damage = new float[] {390, 410, 430, 450, 480, 510, 540, 570, 600, 640, 680, 420,
                 760, 800, 850, 900, 950, 1000}[owner.Stats.Level - 1];
             target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_SPELL, false);

--- a/Content/LeagueSandbox-Scripts/Champions/Karthus/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Karthus/Q.cs
@@ -33,23 +33,25 @@ namespace Spells
 
         public void OnSpellCast(ISpell spell)
         {
-            var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
-            AddParticleTarget(spell.CastInfo.Owner, "Karthus_Base_Q_Hand_Glow.troy", spell.CastInfo.Owner, 1, "R_Hand");
-            AddParticle(spell.CastInfo.Owner, "Karthus_Base_Q_Point.troy", spellPos);
-            AddParticle(spell.CastInfo.Owner, "Karthus_Base_Q_Ring.troy", spellPos);
-            AddParticle(spell.CastInfo.Owner, "Karthus_Base_Q_Skull_Child.troy", spellPos);
+            var owner = spell.CastInfo.Owner;
+             var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
+            AddParticleTarget(owner, owner, "Karthus_Base_Q_Hand_Glow.troy", owner, bone: "R_Hand");
+            AddParticle(owner, null, "Karthus_Base_Q_Point.troy", spellPos);
+            AddParticle(owner, null, "Karthus_Base_Q_Ring.troy", spellPos);
+            AddParticle(owner, null, "Karthus_Base_Q_Skull_Child.troy", spellPos);
         }
 
         public void OnSpellPostCast(ISpell spell)
         {
+            var owner = spell.CastInfo.Owner;
             var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
-            IGameObject m = AddParticle(spell.CastInfo.Owner, "Karthus_Base_Q_Explosion.troy", spellPos);
+            IGameObject m = AddParticle(owner, null, "Karthus_Base_Q_Explosion.troy", spellPos);
             var affectedUnits = GetUnitsInRange(m.Position, 150, true);
             var ap = spell.CastInfo.Owner.Stats.AbilityPower.Total;
             var damage = 20f + spell.CastInfo.SpellLevel * 20f + ap * 0.3f;
             if (affectedUnits.Count == 0)
             {
-                AddParticle(spell.CastInfo.Owner, "Karthus_Base_Q_Hit_Miss.troy", spellPos);
+                AddParticle(owner, null, "Karthus_Base_Q_Hit_Miss.troy", spellPos);
             }
             foreach (var unit in affectedUnits
             .Where(x => x.Team == CustomConvert.GetEnemyTeam(spell.CastInfo.Owner.Team)))
@@ -59,18 +61,18 @@ namespace Spells
                     if (affectedUnits.Count == 1)
                     {
                         damage *= 2;
-                        AddParticle(spell.CastInfo.Owner, "Karthus_Base_Q_Hit_Single.troy", spellPos);
+                        AddParticle(owner, null, "Karthus_Base_Q_Hit_Single.troy", spellPos);
                         unit.TakeDamage(spell.CastInfo.Owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, true);
                     }
                     if (affectedUnits.Count > 1)
                     {
-                        AddParticle(spell.CastInfo.Owner, "Karthus_Base_Q_Hit_Many.troy", spellPos);
+                        AddParticle(owner, null, "Karthus_Base_Q_Hit_Many.troy", spellPos);
                         unit.TakeDamage(spell.CastInfo.Owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
                     }
                 }
             }
             m.SetToRemove();
-            AddParticle(spell.CastInfo.Owner, "Karthus_Base_Q_Explosion_Sound.troy", spellPos);
+            AddParticle(owner, null, "Karthus_Base_Q_Explosion_Sound.troy", spellPos);
         }
 
         public void OnSpellChannel(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/Karthus/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Karthus/R.cs
@@ -36,7 +36,7 @@ namespace Spells
             foreach (var enemyTarget in GetChampionsInRange(owner.Position, 20000, true)
                 .Where(x => x.Team == CustomConvert.GetEnemyTeam(owner.Team)))
             {
-                AddParticleTarget(owner, "KarthusFallenOne", enemyTarget);
+                AddParticleTarget(owner, enemyTarget, "KarthusFallenOne", enemyTarget);
             }
         }
 

--- a/Content/LeagueSandbox-Scripts/Champions/Kassadin/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Kassadin/Q.cs
@@ -27,7 +27,7 @@ namespace Spells
 
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
-            AddParticleTarget(owner, "Kassadin_Base_cas.troy", owner, 1, "L_HAND");
+            AddParticleTarget(owner, owner, "Kassadin_Base_cas.troy", owner, bone: "L_HAND");
         }
 
         public void OnSpellCast(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/LeeSin/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/LeeSin/Q.cs
@@ -48,8 +48,8 @@ namespace Spells
             var ad = owner.Stats.AttackDamage.Total * 0.9f;
             var damage = 50 + (spell.CastInfo.SpellLevel * 30) + ad;
             target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
-            AddParticleTarget(owner, "blindMonk_Q_resonatingStrike_tar.troy", target, 1, "C_BuffBone_Glb_Center_Loc");
-            AddParticleTarget(owner, "blindMonk_Q_tar.troy", target, 1, "C_BuffBone_Glb_Center_Loc");
+            AddParticleTarget(owner, target, "blindMonk_Q_resonatingStrike_tar.troy", target, bone: "C_BuffBone_Glb_Center_Loc");
+            AddParticleTarget(owner, target, "blindMonk_Q_tar.troy", target, bone: "C_BuffBone_Glb_Center_Loc");
             if (target is IObjAiBase u)
             {
                 AddBuff("BlindMonkSonicWave", 3f, 1, spell, u, owner);

--- a/Content/LeagueSandbox-Scripts/Champions/Leona/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Leona/Q.cs
@@ -76,8 +76,8 @@ namespace Spells
         {
             var owner = spell.CastInfo.Owner;
 
-            AddParticle(owner, "Leona_ShieldOfDaybreak_nova.troy", target.Position);
-            AddParticleTarget(owner, "Leona_ShieldOfDaybreak_tar.troy", target);
+            AddParticle(owner, null, "Leona_ShieldOfDaybreak_nova.troy", target.Position);
+            AddParticleTarget(owner, target, "Leona_ShieldOfDaybreak_tar.troy", target);
 
             var ap = owner.Stats.AbilityPower.Total * 0.3f;
             var damage = 40 + (30 * (spell.CastInfo.SpellLevel - 1)) + ap;

--- a/Content/LeagueSandbox-Scripts/Champions/Lulu/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Lulu/W.cs
@@ -57,7 +57,7 @@ namespace Spells
             var model = champion.Model;
             ChangeModel((owner as IChampion).Skin, target);
 
-            var p = AddParticleTarget(owner, "Lulu_W_polymorph_01.troy", target, 1);
+            var p = AddParticleTarget(owner, owner, "Lulu_W_polymorph_01.troy", target);
             CreateTimer(time, () =>
             {
                 RemoveParticle(p);

--- a/Content/LeagueSandbox-Scripts/Champions/Nidalee/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Nidalee/Q.cs
@@ -68,7 +68,7 @@ namespace Spells
             target.TakeDamage(owner, finaldamage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
             if (!target.IsDead)
             {
-                AddParticleTarget(owner, "Nidalee_Base_Q_Tar.troy", target, 1, "C_BUFFBONE_GLB_CHEST_LOC");
+                AddParticleTarget(owner, target, "Nidalee_Base_Q_Tar.troy", target, bone: "C_BUFFBONE_GLB_CHEST_LOC");
             }
 
             missile.SetToRemove();

--- a/Content/LeagueSandbox-Scripts/Champions/Olaf/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Olaf/Q.cs
@@ -56,7 +56,7 @@ namespace Spells
 
         public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, ISpellMissile missile)
         {
-            AddParticleTarget(owner, "olaf_axeThrow_tar.troy", target, 1);
+            AddParticleTarget(owner, target, "olaf_axeThrow_tar.troy", target);
             var ad = owner.Stats.AttackDamage.Total * 1.1f;
             var ap = owner.Stats.AttackDamage.Total * 0.0f;
             var damage = 15 + spell.CastInfo.SpellLevel * 20 + ad + ap;

--- a/Content/LeagueSandbox-Scripts/Champions/Shaco/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Shaco/W.cs
@@ -54,7 +54,7 @@ namespace Spells
             if (Extensions.IsVectorWithinRange(ownerPos, spellPos, castrange))
             {
                 IMinion m = AddMinion((IChampion)owner, "ShacoBox", "ShacoBox", spellPos);
-                AddParticle(owner, "JackintheboxPoof.troy", spellPos);
+                AddParticle(owner, null, "JackintheboxPoof.troy", spellPos);
 
                 var attackrange = m.Stats.Range.Total;
 

--- a/Content/LeagueSandbox-Scripts/Champions/Sivir/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Sivir/W.cs
@@ -82,9 +82,10 @@ namespace Spells
 
         public void TargetExecute(ISpell spell, IAttackableUnit target, ISpellMissile missile)
         {
-            spell.CastInfo.Owner.AutoAttackHit(target);
-            AddParticleTarget(spell.CastInfo.Owner, "Sivir_Base_W_Tar.troy", target, bone: "C_BUFFBONE_GLB_CHEST_LOC");
-            SpellCast(spell.CastInfo.Owner, 2, SpellSlotType.ExtraSlots, false, target, missile.Position);
+            var owner = spell.CastInfo.Owner;
+            owner.AutoAttackHit(target);
+            AddParticleTarget(owner, target, "Sivir_Base_W_Tar.troy", target, bone: "C_BUFFBONE_GLB_CHEST_LOC");
+            SpellCast(owner, 2, SpellSlotType.ExtraSlots, false, target, missile.Position);
         }
 
         public void OnSpellCast(ISpell spell)
@@ -142,7 +143,7 @@ namespace Spells
 
             var owner = spell.CastInfo.Owner;
 
-            AddParticleTarget(owner, "Sivir_Base_W_Tar.troy", target);
+            AddParticleTarget(owner, target, "Sivir_Base_W_Tar.troy", target);
 
             var damage = owner.Stats.AttackDamage.Total * (0.5f + (0.05f * (spell.CastInfo.SpellLevel - 1)));
 

--- a/Content/LeagueSandbox-Scripts/Champions/Taric/E.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Taric/E.cs
@@ -64,8 +64,8 @@ namespace Spells
 
             AddBuff("TaricEHud", time, 1, spell, target, owner);
             AddBuff("Stun", time, 1, spell, target, owner);
-            AddParticleTarget(owner, "Dazzle_tar.troy", target);
-            var p103 = AddParticleTarget(owner, "Taric_HammerFlare.troy", target, 1);
+            AddParticleTarget(owner, target, "Dazzle_tar.troy", target);
+            var p103 = AddParticleTarget(owner, target, "Taric_HammerFlare.troy", target);
 
             CreateTimer(time, () =>
             {

--- a/Content/LeagueSandbox-Scripts/Champions/Taric/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Taric/Q.cs
@@ -40,8 +40,8 @@ namespace Spells
             var target = spell.CastInfo.Targets[0].Unit;
             if (target.Team == owner.Team)
             {
-                var p1 = AddParticleTarget(owner, "Imbue_glow.troy", target, 1);
-                var p2 = AddParticleTarget(owner, "Imbue_cas.troy", owner, 1);
+                var p1 = AddParticleTarget(owner, target, "Imbue_glow.troy", target);
+                var p2 = AddParticleTarget(owner, owner, "Imbue_cas.troy", owner);
                 CreateTimer(1.75f, () =>
                 {
                     RemoveParticle(p1);
@@ -74,8 +74,8 @@ namespace Spells
 
             var newHealth = target.Stats.CurrentHealth + healthGain;
             target.Stats.CurrentHealth = Math.Min(newHealth, target.Stats.HealthPoints.Total);
-            AddParticleTarget(owner, "global_ss_heal_02.troy", target);
-            AddParticleTarget(owner, "global_ss_heal_speedboost.troy", target);
+            AddParticleTarget(owner, target, "global_ss_heal_02.troy", target);
+            AddParticleTarget(owner, target, "global_ss_heal_speedboost.troy", target);
         }
 
         public void OnSpellChannel(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Champions/Taric/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Taric/R.cs
@@ -37,21 +37,22 @@ namespace Spells
 
         public void OnSpellPostCast(ISpell spell)
         {
-            var p1 = AddParticleTarget(spell.CastInfo.Owner, "TaricHammerSmash_nova.troy", spell.CastInfo.Owner);
-            var p2 = AddParticleTarget(spell.CastInfo.Owner, "TaricHammerSmash_shatter.troy", spell.CastInfo.Owner);
-            var hasbuff = spell.CastInfo.Owner.HasBuff("Radiance");
-            var ap = spell.CastInfo.Owner.Stats.AbilityPower.Total * 0.5f;
+            var owner = spell.CastInfo.Owner;
+            var p1 = AddParticleTarget(owner, owner, "TaricHammerSmash_nova.troy", owner);
+            var p2 = AddParticleTarget(owner, owner, "TaricHammerSmash_shatter.troy", owner);
+            var hasbuff = owner.HasBuff("Radiance");
+            var ap = owner.Stats.AbilityPower.Total * 0.5f;
             var damage = 50 + spell.CastInfo.SpellLevel * 100 + ap;
 
-            foreach (var enemyTarget in GetUnitsInRange(spell.CastInfo.Owner.Position, 375, true)
-                .Where(x => x.Team == CustomConvert.GetEnemyTeam(spell.CastInfo.Owner.Team)))
+            foreach (var enemyTarget in GetUnitsInRange(owner.Position, 375, true)
+                .Where(x => x.Team == CustomConvert.GetEnemyTeam(owner.Team)))
             {
                 if (enemyTarget is IAttackableUnit)
                 {
                     enemyTarget.TakeDamage(spell.CastInfo.Owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
-                    var ep1 = AddParticleTarget(spell.CastInfo.Owner, "Taric_GemStorm_Tar.troy", enemyTarget, 1.25f);
-                    var ep2 = AddParticleTarget(spell.CastInfo.Owner, "Taric_GemStorm_Aura.troy", enemyTarget, 1.25f);
-                    var ep3 = AddParticleTarget(spell.CastInfo.Owner, "Taric_ShoulderFlare.troy", enemyTarget, 1.25f);
+                    var ep1 = AddParticleTarget(owner, owner, "Taric_GemStorm_Tar.troy", enemyTarget, size: 1.25f);
+                    var ep2 = AddParticleTarget(owner, owner, "Taric_GemStorm_Aura.troy", enemyTarget, size: 1.25f);
+                    var ep3 = AddParticleTarget(owner, owner, "Taric_ShoulderFlare.troy", enemyTarget, size: 1.25f);
                     CreateTimer(1f, () =>
                     {
                         RemoveParticle(ep1);
@@ -61,18 +62,18 @@ namespace Spells
                 }
             }
 
-            foreach (var allyTarget in GetUnitsInRange(spell.CastInfo.Owner.Position, 1100, true)
-                .Where(x => x.Team != CustomConvert.GetEnemyTeam(spell.CastInfo.Owner.Team)))
+            foreach (var allyTarget in GetUnitsInRange(owner.Position, 1100, true)
+                .Where(x => x.Team != CustomConvert.GetEnemyTeam(owner.Team)))
             {
-                if (allyTarget is IObjAiBase && spell.CastInfo.Owner != allyTarget && hasbuff == false)
+                if (allyTarget is IObjAiBase && owner != allyTarget && hasbuff == false)
                 {
-                    AddBuff("Radiance_ally", 10.0f, 1, spell, allyTarget, spell.CastInfo.Owner);
+                    AddBuff("Radiance_ally", 10.0f, 1, spell, allyTarget, owner);
                 }
             }
-            if (spell.CastInfo.Owner == spell.CastInfo.Targets[0].Unit && hasbuff == false)
+            if (owner == spell.CastInfo.Targets[0].Unit && hasbuff == false)
             {
-                var p3 = AddParticleTarget(spell.CastInfo.Owner, "taricgemstorm.troy", spell.CastInfo.Owner);
-                AddBuff("Radiance", 10.0f, 1, spell, spell.CastInfo.Owner, spell.CastInfo.Owner);
+                var p3 = AddParticleTarget(owner, owner, "taricgemstorm.troy", owner);
+                AddBuff("Radiance", 10.0f, 1, spell, owner, owner);
                 CreateTimer(10.0f, () =>
                 {
                     RemoveParticle(p3);

--- a/Content/LeagueSandbox-Scripts/Champions/Taric/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Taric/W.cs
@@ -39,20 +39,21 @@ namespace Spells
 
         public void OnSpellPostCast(ISpell spell)
         {
-            var armor = spell.CastInfo.Owner.Stats.Armor.Total;
+            var owner = spell.CastInfo.Owner;
+            var armor = owner.Stats.Armor.Total;
             var damage = spell.CastInfo.SpellLevel * 40 + armor * 0.2f;
             var reduce = spell.CastInfo.SpellLevel * 5 + armor * 0.05f;
-            AddParticleTarget(spell.CastInfo.Owner, "Shatter_nova.troy", spell.CastInfo.Owner, 1);
+            AddParticleTarget(owner, owner, "Shatter_nova.troy", owner);
 
-            foreach (var enemy in GetUnitsInRange(spell.CastInfo.Owner.Position, 375, true)
-                .Where(x => x.Team == CustomConvert.GetEnemyTeam(spell.CastInfo.Owner.Team)))
+            foreach (var enemy in GetUnitsInRange(owner.Position, 375, true)
+                .Where(x => x.Team == CustomConvert.GetEnemyTeam(owner.Team)))
             {
                 var hasbuff = HasBuff((IObjAiBase)enemy, "TaricWDis");
                 if (enemy is IObjAiBase)
                 {
-                    enemy.TakeDamage(spell.CastInfo.Owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
-                    var p2 = AddParticleTarget(spell.CastInfo.Owner, "Shatter_tar.troy", enemy, 1);
-                    AddBuff("TaricWDis", 4.0f, 1, spell, enemy, spell.CastInfo.Owner);
+                    enemy.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+                    var p2 = AddParticleTarget(owner, enemy, "Shatter_tar.troy", enemy);
+                    AddBuff("TaricWDis", 4.0f, 1, spell, enemy, owner);
 
                     if (hasbuff == true)
                     {

--- a/Content/LeagueSandbox-Scripts/Champions/Yasuo/Q1.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Yasuo/Q1.cs
@@ -45,17 +45,18 @@ namespace Spells
 
         public void OnSpellPostCast(ISpell spell)
         {
-            if (HasBuff(spell.CastInfo.Owner, "YasuoE"))
+            var owner = spell.CastInfo.Owner;
+            if (HasBuff(owner, "YasuoE"))
             {
                 //spell.CastInfo.Owner.SpellAnimation("SPELL3b");
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_EQ_cas.troy", spell.CastInfo.Owner);
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_EQ_SwordGlow.troy", spell.CastInfo.Owner, 1, "C_BUFFBONE_GLB_Weapon_1");
+                AddParticleTarget(owner, owner, "Yasuo_Base_EQ_cas.troy", owner);
+                AddParticleTarget(owner, owner, "Yasuo_Base_EQ_SwordGlow.troy", owner, 0, 1, "C_BUFFBONE_GLB_Weapon_1");
                 foreach (var affectEnemys in GetUnitsInRange(spell.CastInfo.Owner.Position, 270f, true))
                 {
                     if (affectEnemys is IAttackableUnit && affectEnemys.Team != spell.CastInfo.Owner.Team)
                     {
                         affectEnemys.TakeDamage(spell.CastInfo.Owner, spell.CastInfo.SpellLevel * 20f + spell.CastInfo.Owner.Stats.AttackDamage.Total, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
-                        AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_Q_hit_tar.troy", affectEnemys);
+                        AddParticleTarget(owner, affectEnemys, "Yasuo_Base_Q_hit_tar.troy", affectEnemys);
                     }
                 }
                 AddBuff("YasuoQ01", 6f, 1, spell, spell.CastInfo.Owner, spell.CastInfo.Owner);
@@ -64,14 +65,14 @@ namespace Spells
             {
                 //spell.CastInfo.Owner.SpellAnimation("SPELL1A");
                 //spell.AddLaser("YasuoQ", trueCoords);
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Q_Hand.troy", spell.CastInfo.Owner);
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_Q1_cast_sound.troy", spell.CastInfo.Owner);
+                AddParticleTarget(owner, owner, "Yasuo_Q_Hand.troy", owner);
+                AddParticleTarget(owner, owner, "Yasuo_Base_Q1_cast_sound.troy", owner);
             }
         }
 
         public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, ISpellMissile missile)
         {
-            AddParticleTarget(owner, "Yasuo_Base_Q_hit_tar.troy", target);
+            AddParticleTarget(owner, target, "Yasuo_Base_Q_hit_tar.troy", target);
             target.TakeDamage(owner, spell.CastInfo.SpellLevel * 20f + owner.Stats.AttackDamage.Total, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
             if (!HasBuff(owner, "YasuoQ01"))
             {

--- a/Content/LeagueSandbox-Scripts/Champions/Yasuo/Q2.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Yasuo/Q2.cs
@@ -45,34 +45,35 @@ namespace Spells
 
         public void OnSpellPostCast(ISpell spell)
         {
-            if (HasBuff(spell.CastInfo.Owner, "YasuoE"))
+            var owner = spell.CastInfo.Owner;
+            if (HasBuff(owner, "YasuoE"))
             {
                 //spell.CastInfo.Owner.SpellAnimation("SPELL3b");
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_EQ_cas.troy", spell.CastInfo.Owner);
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_EQ_SwordGlow.troy", spell.CastInfo.Owner, 1, "C_BUFFBONE_GLB_Weapon_1");
-                foreach (var affectEnemys in GetUnitsInRange(spell.CastInfo.Owner.Position, 270f, true))
+                AddParticleTarget(owner, owner, "Yasuo_Base_EQ_cas.troy", owner);
+                AddParticleTarget(owner, owner, "Yasuo_Base_EQ_SwordGlow.troy", owner, 0, 1, "C_BUFFBONE_GLB_Weapon_1");
+                foreach (var affectEnemys in GetUnitsInRange(owner.Position, 270f, true))
                 {
-                    if (affectEnemys is IAttackableUnit && affectEnemys.Team != spell.CastInfo.Owner.Team)
+                    if (affectEnemys is IAttackableUnit && affectEnemys.Team != owner.Team)
                     {
-                        affectEnemys.TakeDamage(spell.CastInfo.Owner, spell.CastInfo.SpellLevel * 20f + spell.CastInfo.Owner.Stats.AttackDamage.Total, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
-                        AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_Q_hit_tar.troy", affectEnemys);
+                        affectEnemys.TakeDamage(owner, spell.CastInfo.SpellLevel * 20f + owner.Stats.AttackDamage.Total, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
+                        AddParticleTarget(owner, owner, "Yasuo_Base_Q_hit_tar.troy", affectEnemys);
                     }
                 }
-                AddBuff("YasuoQ02", 6f, 1, spell, spell.CastInfo.Owner, spell.CastInfo.Owner);
-                RemoveBuff(spell.CastInfo.Owner, "YasuoQ01");
+                AddBuff("YasuoQ02", 6f, 1, spell, owner, owner);
+                RemoveBuff(owner, "YasuoQ01");
             }
             else
             {
                 //spell.CastInfo.Owner.SpellAnimation("SPELL1B");
                 //spell.AddLaser("YasuoQ", trueCoords);
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Q_Hand.troy", spell.CastInfo.Owner);
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_Q2_cast_sound.troy", spell.CastInfo.Owner);
+                AddParticleTarget(owner, owner, "Yasuo_Q_Hand.troy", owner);
+                AddParticleTarget(owner, owner, "Yasuo_Base_Q2_cast_sound.troy", owner);
             }
         }
 
         public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, ISpellMissile missile)
         {
-            AddParticleTarget(owner, "Yasuo_Base_Q_hit_tar.troy", target);
+            AddParticleTarget(owner, owner, "Yasuo_Base_Q_hit_tar.troy", target);
             target.TakeDamage(owner, spell.CastInfo.SpellLevel * 20f + owner.Stats.AttackDamage.Total,DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
             if (!HasBuff(owner, "YasuoQ02"))
             {

--- a/Content/LeagueSandbox-Scripts/Champions/Yasuo/Q3.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Yasuo/Q3.cs
@@ -45,19 +45,20 @@ namespace Spells
 
         public void OnSpellPostCast(ISpell spell)
         {
+            var owner = spell.CastInfo.Owner;
             if (HasBuff(spell.CastInfo.Owner, "YasuoE"))
             {
                 //spell.CastInfo.Owner.SpellAnimation("SPELL3b");
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_EQ3_cas.troy", spell.CastInfo.Owner);
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_EQ_SwordGlow.troy", spell.CastInfo.Owner, bone: "C_BUFFBONE_GLB_Weapon_1");
+                AddParticleTarget(owner, owner, "Yasuo_Base_EQ3_cas.troy", owner);
+                AddParticleTarget(owner, owner, "Yasuo_Base_EQ_SwordGlow.troy", owner, bone: "C_BUFFBONE_GLB_Weapon_1");
                 foreach (var affectEnemys in GetUnitsInRange(spell.CastInfo.Owner.Position, 270f, true))
                 {
-                    if (affectEnemys is IAttackableUnit && affectEnemys.Team != spell.CastInfo.Owner.Team)
+                    if (affectEnemys is IAttackableUnit && affectEnemys.Team != owner.Team)
                     {
-                        affectEnemys.TakeDamage(spell.CastInfo.Owner, spell.CastInfo.SpellLevel * 20f + spell.CastInfo.Owner.Stats.AttackDamage.Total, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
-                        AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_Q_WindStrike.troy", affectEnemys);
-                        AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_Q_windstrike_02.troy", affectEnemys);
-                        AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_Q_hit_tar.troy", affectEnemys);
+                        affectEnemys.TakeDamage(owner, spell.CastInfo.SpellLevel * 20f + owner.Stats.AttackDamage.Total, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
+                        AddParticleTarget(owner, owner, "Yasuo_Base_Q_WindStrike.troy", affectEnemys);
+                        AddParticleTarget(owner, owner, "Yasuo_Base_Q_windstrike_02.troy", affectEnemys);
+                        AddParticleTarget(owner, owner, "Yasuo_Base_Q_hit_tar.troy", affectEnemys);
                         ForceMovement(affectEnemys, "RUN", new Vector2(affectEnemys.Position.X + 10f, affectEnemys.Position.Y + 10f), 13f, 0, 16.5f, 0, movementOrdersFacing: ForceMovementOrdersFacing.KEEP_CURRENT_FACING);
                     }
                 }
@@ -66,21 +67,21 @@ namespace Spells
             {
                 //spell.AddProjectile("YasuoQ3Mis", spell.CastInfo.Owner.Position, spell.CastInfo.Owner.Position, trueCoords);
                 //spell.CastInfo.Owner.SpellAnimation("SPELL1C");
-                (spell.CastInfo.Owner as IChampion).SetSpell("YasuoQW", 0, true);
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_Q3_Hand.troy", spell.CastInfo.Owner);
-                AddParticleTarget(spell.CastInfo.Owner, "Yasuo_Base_Q3_cast_sound.troy", spell.CastInfo.Owner);
+                (owner as IChampion).SetSpell("YasuoQW", 0, true);
+                AddParticleTarget(owner, owner, "Yasuo_Base_Q3_Hand.troy", owner);
+                AddParticleTarget(owner, owner, "Yasuo_Base_Q3_cast_sound.troy", owner);
             }
-            if (HasBuff(spell.CastInfo.Owner, "YasuoQ02"))
+            if (HasBuff(owner, "YasuoQ02"))
             {
-                RemoveBuff(spell.CastInfo.Owner, "YasuoQ02");
+                RemoveBuff(owner, "YasuoQ02");
             }
         }
 
         public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, ISpellMissile missile)
         {
-            AddParticleTarget(owner, "Yasuo_Base_Q_WindStrike.troy", target);
-            AddParticleTarget(owner, "Yasuo_Base_Q_windstrike_02.troy", target);
-            AddParticleTarget(owner, "Yasuo_Base_Q_hit_tar.troy", target);
+            AddParticleTarget(owner, owner, "Yasuo_Base_Q_WindStrike.troy", target);
+            AddParticleTarget(owner, owner, "Yasuo_Base_Q_windstrike_02.troy", target);
+            AddParticleTarget(owner, owner, "Yasuo_Base_Q_hit_tar.troy", target);
             target.TakeDamage(owner, spell.CastInfo.SpellLevel * 20f + owner.Stats.AttackDamage.Total,DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
             ForceMovement(target, "RUN", new Vector2(target.Position.X + 10f, target.Position.Y + 10f), 13f, 0, 16.5f, 0);
         }

--- a/Content/LeagueSandbox-Scripts/Items/YoumusBlade.cs
+++ b/Content/LeagueSandbox-Scripts/Items/YoumusBlade.cs
@@ -26,11 +26,6 @@ namespace Spells
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
             AddBuff("YoumuusGhostblade", 6.0f, 1, spell, owner, owner);
-            var p = AddParticleTarget(owner, "spectral_fury_activate_speed.troy", owner, 2);
-            CreateTimer(6.0f, () =>
-            {
-                RemoveParticle(p);
-            });
         }
 
         public void OnSpellCast(ISpell spell)

--- a/GameServerCore/Domain/GameObjects/IParticle.cs
+++ b/GameServerCore/Domain/GameObjects/IParticle.cs
@@ -9,9 +9,13 @@ namespace GameServerCore.Domain.GameObjects
     public interface IParticle : IGameObject
     {
         /// <summary>
+        /// Creator of this particle.
+        /// </summary>
+        IGameObject Caster { get; }
+        /// <summary>
         /// Primary bind object.
         /// </summary>
-        public IGameObject BindObject { get; }
+        IGameObject BindObject { get; }
         /// <summary>
         /// Client-sided, internal name of the particle used in networking, usually always ends in .troy
         /// </summary>
@@ -50,6 +54,11 @@ namespace GameServerCore.Domain.GameObjects
         /// The only team that should be able to see this particle.
         /// </summary>
         TeamId SpecificTeam { get; }
+        /// <summary>
+        /// Whether or not the particle should be titled along the ground towards its end position.
+        /// Effectively uses the ground height for the end position.
+        /// </summary>
+        bool FollowsGroundTilt { get; }
 
         /// <summary>
         /// Returns the total game-time passed since the particle was added to ObjectManager

--- a/GameServerCore/Domain/GameObjects/Spell/Sector/ISectorParameters.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/Sector/ISectorParameters.cs
@@ -1,4 +1,5 @@
 ﻿using GameServerCore.Enums;
+using System.Numerics;
 
 namespace GameServerCore.Domain.GameObjects.Spell.Sector
 {
@@ -8,27 +9,41 @@ namespace GameServerCore.Domain.GameObjects.Spell.Sector
     public interface ISectorParameters
     {
         /// <summary>
+        /// Optional object the sector should be bound to. The sector will be attached to this object and will use its facing direction.
+        /// </summary>
+        IGameObject BindObject { get; set; }
+        /// <summary>
         /// Half the distance from the center of the sector to the maximum Y-value.
-        /// If this is larger than HalfWidth, it will be used as the area around the sector to check for collisions.
+        /// If this is larger than Width, it will be used as the area around the sector to check for collisions.
+        /// Scales the distance (in y) between PolygonVertices.
         /// </summary>
         float HalfLength { get; set; }
         /// <summary>
-        /// Half the distance from the center of the sector to the maximum X-value.
+        /// Distance from the center of the sector to the maximum X-value.
         /// If this is larger than HalfLength, it will be used as the area around the sector to check for collisions.
+        /// Scales the distance (in x) between PolygonVertices.
         /// </summary>
-        float HalfWidth { get; set; }
+        float Width { get; set; }
         /// <summary>
         /// If the Type is Cone, this will filter collisions that are in front of the sector and are within this angle from the sector's center.
         /// Should be a value from 0->360
         /// </summary>
         float ConeAngle { get; set; }
         /// <summary>
+        /// If the Type is Polygon, this will represent the vertices of the sector.
+        /// Vertices are relative to the origin (SpellCastLaunchPosition or target position & direction).
+        /// If the distance between points exceeds HalfLength/Width, that distance will be used instead as the collision radius check for the sector.
+        /// Points should be ordered such that each point connects to the next (with the last point connecting to the first point).
+        /// Due to HalfLength and Width scaling the distance between vertices, it is recommended that points be arranged with x and y values between 0 and 1.
+        /// </summary>
+        Vector2[] PolygonVertices { get; set; }
+        /// <summary>
         /// Maximum amount of time this spell sector should last (in seconds) before being automatically removed.
         /// Setting to -1 will cause the spell sector to last until manually removed.
         /// </summary>
         float Lifetime { get; set; }
         /// <summary>
-        /// Whether or not the sector should only tick once before being removed.
+        /// Whether or not the sector should only tick once before being removed (Lifetime must be greater than a single tick).
         /// </summary>
         bool SingleTick { get; set; }
         /// <summary>

--- a/GameServerCore/Domain/GameObjects/Spell/Sector/ISpellSector.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/Sector/ISpellSector.cs
@@ -9,10 +9,6 @@ namespace GameServerCore.Domain.GameObjects.Spell.Sector
         /// </summary>
         ICastInfo CastInfo { get; }
         /// <summary>
-        /// Object this sector is bound to. Null if the sector is location targeted.
-        /// </summary>
-        IGameObject BindObject { get; }
-        /// <summary>
         /// Spell which created this projectile.
         /// </summary>
         ISpell SpellOrigin { get; }

--- a/GameServerCore/Enums/SectorType.cs
+++ b/GameServerCore/Enums/SectorType.cs
@@ -8,14 +8,17 @@
         None = 0x0,
         /// <summary>
         /// Location targeted area of effect in the shape of a circle.
+        /// If the spell which created the sector is targeted, the sector will originate at the target.
         /// </summary>
         Area = 0x1,
         /// <summary>
         /// Location and direction targeted area of effect in the shape of a wedge (circular sector). Shape determined by sector angle.
+        /// If the spell which created the sector is targeted, the sector will originate at the target, and will use the target's facing direction.
         /// </summary>
         Cone = 0x2,
         /// <summary>
         /// Location and direction targeted area of effect in the shape of a polygon with edges converging on specified points.
+        /// If the spell which created the sector is targeted, the sector will originate at the target, and will use the target's facing direction.
         /// </summary>
         Polygon = 0x3,
         /// <summary>

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -272,19 +272,21 @@ namespace LeagueSandbox.GameServer.API
         /// <summary>
         /// Creates a new particle with the specified parameters.
         /// </summary>
+        /// <param name="caster">GameObject that caused this particle to spawn.</param>
         /// <param name="bindObj">GameObject that the particle should bind to.</param>
         /// <param name="particle">Internal name of the particle.</param>
         /// <param name="position">Position to spawn at.</param>
+        /// <param name="lifetime">Time in seconds the particle should last.</param>
         /// <param name="size">Scale.</param>
         /// <param name="bone">Bone on the owner the particle should be attached to.</param>
         /// <param name="targetBone">Bone on the target the particle should be attached to.</param>
         /// <param name="direction">3D direction the particle should face.</param>
-        /// <param name="lifetime">Time in seconds the particle should last.</param>
+        /// <param name="followGroundTilt">Whether or not the particle should be titled along the ground towards its end position.</param>
         /// <param name="reqVision">Whether or not the particle can be obstructed by terrain.</param>
         /// <returns>New particle instance.</returns>
-        public static IParticle AddParticle(IGameObject bindObj, string particle, Vector2 position, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL)
+        public static IParticle AddParticle(IGameObject caster, IGameObject bindObj, string particle, Vector2 position, float lifetime = 0, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), bool followGroundTilt = false, bool reqVision = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL)
         {
-            var p = new Particle(_game, bindObj, position, particle, size, bone, targetBone, 0, direction, lifetime, reqVision, true, teamOnly);
+            var p = new Particle(_game, caster, bindObj, position, particle, size, bone, targetBone, 0, direction, followGroundTilt, lifetime, reqVision, true, teamOnly);
             return p;
         }
 
@@ -292,19 +294,21 @@ namespace LeagueSandbox.GameServer.API
         /// Creates a new particle with the specified parameters.
         /// This particle will be attached to a target.
         /// </summary>
+        /// <param name="caster">GameObject that caused this particle to spawn.</param>
         /// <param name="bindObj">GameObject that the particle should bind to (prioritized over target).</param>
         /// <param name="particle">Internal name of the particle.</param>
         /// <param name="target">GameObject that the particle should bind to after the bindObj.</param>
+        /// <param name="lifetime">Time in seconds the particle should last.</param>
         /// <param name="size">Scale.</param>
         /// <param name="bone">Bone on the owner the particle should be attached to.</param>
         /// <param name="targetBone">Bone on the target the particle should be attached to.</param>
         /// <param name="direction">3D direction the particle should face.</param>
-        /// <param name="lifetime">Time in seconds the particle should last.</param>
+        /// <param name="followGroundTilt">Whether or not the particle should be titled along the ground towards its end position.</param>
         /// <param name="reqVision">Whether or not the particle can be obstructed by terrain.</param>
         /// <returns>New particle instance.</returns>
-        public static IParticle AddParticleTarget(IGameObject bindObj, string particle, IGameObject target, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), float lifetime = 0, bool reqVision = true)
+        public static IParticle AddParticleTarget(IGameObject caster, IGameObject bindObj, string particle, IGameObject target, float lifetime = 0, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), bool followGroundTilt = false, bool reqVision = true)
         {
-            var p = new Particle(_game, bindObj, target, particle, size, bone, targetBone, 0, direction, lifetime, reqVision);
+            var p = new Particle(_game, caster, bindObj, target, particle, size, bone, targetBone, 0, direction, followGroundTilt, lifetime, reqVision);
             return p;
         }
 

--- a/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
+++ b/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
@@ -176,7 +176,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                 }
             }
 
-            var circleparticle = new Particle(_game, _userChampion, _userChampion.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, 0.1f, false, false);
+            var circleparticle = new Particle(_game, _userChampion, _userChampion, _userChampion.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, false, 0.1f, false, false);
             _circleParticles.Add(_userChampion.NetId, circleparticle);
             _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
@@ -215,7 +215,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                         _arrowParticlesList.Add(_userChampion.NetId, new List<Particle>());
                     }
 
-                    var arrowparticle = new Particle(_game, _userChampion, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, 0.1f, false, false);
+                    var arrowparticle = new Particle(_game, _userChampion, _userChampion, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, false, 0.1f, false, false);
                     _arrowParticlesList[_userChampion.NetId].Add(arrowparticle);
 
                     _game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
@@ -273,7 +273,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                     }
                 }
 
-                var circleparticle = new Particle(_game, champion, champion.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, 0.1f, false, false);
+                var circleparticle = new Particle(_game, champion, champion, champion.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, false, 0.1f, false, false);
                 _circleParticles.Add(champion.NetId, circleparticle);
                 _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
@@ -312,7 +312,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                             _arrowParticlesList.Add(champion.NetId, new List<Particle>());
                         }
 
-                        var arrowparticle = new Particle(_game, champion, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, 0.1f, false, false);
+                        var arrowparticle = new Particle(_game, champion, champion, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, false, 0.1f, false, false);
                         _arrowParticlesList[champion.NetId].Add(arrowparticle);
 
                         _game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
@@ -370,7 +370,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                         }
                     }
 
-                    var circleparticle = new Particle(_game, missile, missile.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, 0.1f, false, false);
+                    var circleparticle = new Particle(_game, null, missile, missile.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, false, 0.1f, false, false);
                     _circleParticles.Add(missile.NetId, circleparticle);
                     _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
@@ -404,7 +404,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                             var to = Vector2.Normalize(new Vector2(wpTarget.X, wpTarget.Y) - current);
 
                             var direction = new Vector3(to.X, 0, to.Y);
-                            var arrowparticle = new Particle(_game, missile, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, 0.1f, false, false);
+                            var arrowparticle = new Particle(_game, null, missile, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, false, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowparticle);
 
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
@@ -424,27 +424,27 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                             var dirTangent = Extensions.Rotate(new Vector2(missile.Direction.X, missile.Direction.Z), 90.0f) * missile.CollisionRadius;
                             var dirTangent2 = Extensions.Rotate(new Vector2(missile.Direction.X, missile.Direction.Z), 270.0f) * missile.CollisionRadius;
 
-                            var arrowParticleStart = new Particle(_game, missile, current, "DebugArrow_green.troy", 0.5f, "", "", 0, missile.Direction, 0.1f, false, false);
+                            var arrowParticleStart = new Particle(_game, null, missile, current, "DebugArrow_green.troy", 0.5f, "", "", 0, missile.Direction, false, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleStart);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart, userId);
 
-                            var arrowParticleEnd = new Particle(_game, missile, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, missile.Direction, 0.1f, false, false);
+                            var arrowParticleEnd = new Particle(_game, null, missile, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, missile.Direction, false, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleEnd);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd, userId);
 
-                            var arrowParticleEnd2Temp = new Particle(_game, missile, new Vector2(wpTarget.X + dirTangent.X, wpTarget.Y + dirTangent.Y), "Global_Indicator_Line_Beam.troy", 0.0f, "", "", 0, missile.Direction, 0.1f, false, false);
+                            var arrowParticleEnd2Temp = new Particle(_game, null, missile, new Vector2(wpTarget.X + dirTangent.X, wpTarget.Y + dirTangent.Y), "Global_Indicator_Line_Beam.troy", 0.0f, "", "", 0, missile.Direction, false, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleEnd2Temp);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd2Temp, userId);
 
-                            var arrowParticleStart2 = new Particle(_game, arrowParticleEnd2Temp, new Vector2(current.X + dirTangent.X, current.Y + dirTangent.Y), "Global_Indicator_Line_Beam.troy", 1.0f, "", "", 0, missile.Direction, 0.1f, false, false);
+                            var arrowParticleStart2 = new Particle(_game, null, arrowParticleEnd2Temp, new Vector2(current.X + dirTangent.X, current.Y + dirTangent.Y), "Global_Indicator_Line_Beam.troy", 1.0f, "", "", 0, missile.Direction, false, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleStart2);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart2, userId);
 
-                            var arrowParticleEnd3Temp = new Particle(_game, missile, new Vector2(wpTarget.X + dirTangent2.X, wpTarget.Y + dirTangent2.Y), "Global_Indicator_Line_Beam.troy", 0.0f, "", "", 0, missile.Direction, 0.1f, false, false);
+                            var arrowParticleEnd3Temp = new Particle(_game, null, missile, new Vector2(wpTarget.X + dirTangent2.X, wpTarget.Y + dirTangent2.Y), "Global_Indicator_Line_Beam.troy", 0.0f, "", "", 0, missile.Direction, false, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleEnd3Temp);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd3Temp, userId);
 
-                            var arrowParticleStart3 = new Particle(_game, arrowParticleEnd3Temp, new Vector2(current.X + dirTangent2.X, current.Y + dirTangent2.Y), "Global_Indicator_Line_Beam.troy", 1.0f, "", "", 0, missile.Direction, 0.1f, false, false);
+                            var arrowParticleStart3 = new Particle(_game, null, arrowParticleEnd3Temp, new Vector2(current.X + dirTangent2.X, current.Y + dirTangent2.Y), "Global_Indicator_Line_Beam.troy", 1.0f, "", "", 0, missile.Direction, false, 0.1f, false, false);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleStart3);
                             _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart3, userId);
                         }

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSector.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSector.cs
@@ -27,10 +27,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
         /// </summary>
         public ICastInfo CastInfo { get; protected set; }
         /// <summary>
-        /// Object this sector is bound to. Null if the sector is location targeted.
-        /// </summary>
-        public IGameObject BindObject { get; protected set; }
-        /// <summary>
         /// Spell which created this projectile.
         /// </summary>
         public ISpell SpellOrigin { get; protected set; }
@@ -54,7 +50,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             ISpell originSpell,
             ICastInfo castInfo,
             uint netId = 0
-        ) : base(game, new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z), Math.Max(parameters.HalfLength, parameters.HalfWidth), 0, netId)
+        ) : base(game, new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z), Math.Max(parameters.HalfLength, parameters.Width), 0, netId)
         {
             _timeSinceCreation = 0.0f;
             _lastTickTime = 0.0f;
@@ -65,12 +61,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             SpellOrigin = originSpell;
             ObjectsHit = new List<IGameObject>();
             HitCount = 0;
-
-            // TODO: Implement full support for multiple targets.
-            if (castInfo.Targets[0].Unit != null)
-            {
-                BindObject = castInfo.Targets[0].Unit;
-            }
 
             VisionRadius = SpellOrigin.SpellData.MissilePerceptionBubbleRadius;
 
@@ -92,7 +82,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
                 return;
             }
 
-            if (BindObject != null)
+            if (Parameters.BindObject != null)
             {
                 Move(diff);
             }
@@ -246,11 +236,11 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
         /// Gets the position of this projectile's target (unit or destination).
         /// </summary>
         /// <returns>Vector2 position of target. Vector2(float.NaN, float.NaN) if projectile has no target.</returns>
-        public Vector2 GetTargetPosition()
+        public virtual Vector2 GetTargetPosition()
         {
-            if (BindObject != null)
+            if (Parameters.BindObject != null)
             {
-                return BindObject.Position;
+                return Parameters.BindObject.Position;
             }
 
             return Position;

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSectorCone.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSectorCone.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Numerics;
 using GameServerCore;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
-using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Domain.GameObjects.Spell.Sector;
-using GameServerCore.Enums;
-using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
 {
@@ -31,19 +27,23 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             var dirTemp = Vector2.Normalize(goingTo);
 
             // usually doesn't happen
-            if (float.IsNaN(dirTemp.X) || float.IsNaN(dirTemp.Y))
+            if (float.IsNaN(dirTemp.X) || float.IsNaN(dirTemp.Y) && Parameters.BindObject != null)
             {
-                if (float.IsNaN(BindObject.Direction.X) || float.IsNaN(BindObject.Direction.Y))
+                if (float.IsNaN(Parameters.BindObject.Direction.X) || float.IsNaN(Parameters.BindObject.Direction.Y))
                 {
                     dirTemp = new Vector2(1, 0);
                 }
                 else
                 {
-                    dirTemp = new Vector2(BindObject.Direction.X, BindObject.Direction.Z);
+                    dirTemp = new Vector2(Parameters.BindObject.Direction.X, Parameters.BindObject.Direction.Z);
                 }
 
                 var endPos = Position + (dirTemp * SpellOrigin.GetCurrentCastRange());
                 CastInfo.TargetPositionEnd = new Vector3(endPos.X, 0, endPos.Y);
+            }
+            else
+            {
+                dirTemp = new Vector2(1, 0);
             }
 
             Direction = new Vector3(dirTemp.X, 0, dirTemp.Y);
@@ -56,7 +56,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
         public override void Move(float diff)
         {
             // Change direction to the bind object's facing direction.
-            Direction = BindObject.Direction;
+            Direction = Parameters.BindObject.Direction;
 
             // Then move.
             base.Move(diff);

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSectorPolygon.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSectorPolygon.cs
@@ -14,9 +14,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
     /// </summary>
     internal class SpellSectorPolygon : SpellSector, ISpellSector
     {
-        public Vector2[] _trueVertices;
-        public float _trueWidth;
-        public float _trueHalfLength;
+        private Vector2[] _trueVertices;
+        private float _trueWidth;
+        private float _trueHalfLength;
 
         public SpellSectorPolygon(
             Game game,

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSectorPolygon.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSectorPolygon.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using GameServerCore;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Sector;
+
+namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
+{
+    /// <summary>
+    /// Base class for all spell sectors. Functionally acts as a circular spell hitbox.
+    /// Base functionality can be overriden to fit a specific shape.
+    /// </summary>
+    internal class SpellSectorPolygon : SpellSector, ISpellSector
+    {
+        public Vector2[] _trueVertices;
+        public float _trueWidth;
+        public float _trueHalfLength;
+
+        public SpellSectorPolygon(
+            Game game,
+            ISectorParameters parameters,
+            ISpell originSpell,
+            ICastInfo castInfo,
+            uint netId = 0
+        ) : base(game, parameters, originSpell, castInfo, netId)
+        {
+            // TODO: Verify if assignment is necessary.
+            _trueVertices = new Vector2[parameters.PolygonVertices.Length];
+
+            // This whole section involving vertices is simply scaling vertices by Width/HalfLength,
+            // then making sure the distance between vertices after scaling is less than Width/HalfLength
+            // (otherwise, we override them)
+            parameters.PolygonVertices.CopyTo(_trueVertices, 0);
+            _trueWidth = parameters.Width;
+            _trueHalfLength = parameters.HalfLength;
+
+            Vector2? lastVertice = null;
+            for (int i = 0; i < _trueVertices.Length; i++)
+            {
+                Vector2 currVertice = _trueVertices[i];
+
+                // Scale the vertice
+                Vector2 trueVertice = new Vector2(currVertice.X * parameters.Width, currVertice.Y * parameters.HalfLength);
+
+                // Compare distances and override HalfWidth/Length as necessary
+                if (lastVertice != null)
+                {
+                    var distX = currVertice.X - trueVertice.X;
+                    if (distX > _trueWidth)
+                    {
+                        _trueWidth = distX;
+                    }
+
+                    var distY = currVertice.Y - trueVertice.Y;
+                    if (distY > _trueHalfLength)
+                    {
+                        _trueHalfLength = distY;
+                    }
+                }
+
+                // Reassign with true width/halflength.
+                trueVertice = new Vector2(currVertice.X * _trueWidth, currVertice.Y * _trueHalfLength);
+
+                // Save current vertice for next iteration so we can compare distance.
+                lastVertice = trueVertice;
+                // Assign scaled vertice.
+                _trueVertices[i] = trueVertice;
+            }
+
+            if (_trueWidth > _trueHalfLength)
+            {
+                CollisionRadius = _trueWidth;
+            }
+            else
+            {
+                CollisionRadius = _trueHalfLength;
+            }
+
+            Position = GetTargetPosition();
+
+            // The below section is making sure the sector has a correct direction.
+
+            var goingTo = new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z) - Position;
+            var dirTemp = Vector2.Normalize(goingTo);
+
+            if (float.IsNaN(dirTemp.X) || float.IsNaN(dirTemp.Y) && Parameters.BindObject != null)
+            {
+                if (float.IsNaN(Parameters.BindObject.Direction.X) || float.IsNaN(Parameters.BindObject.Direction.Y))
+                {
+                    dirTemp = new Vector2(1, 0);
+                }
+                else
+                {
+                    dirTemp = new Vector2(Parameters.BindObject.Direction.X, Parameters.BindObject.Direction.Z);
+                }
+
+                var endPos = Position + (dirTemp * SpellOrigin.GetCurrentCastRange());
+                CastInfo.TargetPositionEnd = new Vector3(endPos.X, 0, endPos.Y);
+                var startPos = Position - (dirTemp * SpellOrigin.GetCurrentCastRange());
+                CastInfo.TargetPosition = new Vector3(startPos.X, 0, startPos.Y);
+            }
+            else if (float.IsNaN(dirTemp.X) || float.IsNaN(dirTemp.Y))
+            {
+                dirTemp = new Vector2(1, 0);
+            }
+
+            Direction = new Vector3(dirTemp.X, 0, dirTemp.Y);
+
+            VisionRadius = SpellOrigin.SpellData.MissilePerceptionBubbleRadius;
+
+            Team = CastInfo.Owner.Team;
+        }
+
+        public override void Move(float diff)
+        {
+            // Change direction to the bind object's facing direction.
+            Direction = Parameters.BindObject.Direction;
+
+            base.Move(diff);
+        }
+
+        /// <summary>
+        /// Filter function which checks if the given collider is within the bounds of a hitbox.
+        /// </summary>
+        /// <param name="collider">Object to check.</param>
+        /// <returns>True/False.</returns>
+        protected override bool FilterCollisions(IGameObject collider)
+        {
+            if (_trueVertices.Length <= 0)
+            {
+                return false;
+            }
+
+            var start = new Vector2(CastInfo.TargetPosition.X, CastInfo.TargetPosition.Z);
+            var end = new Vector2(CastInfo.TargetPositionEnd.X, CastInfo.TargetPositionEnd.Z);
+
+            // First check if the start or end points are inside the collider.
+            // Without this check, due to how the sector was positioned in initialization, units at the very edge of the sector will fail the circle -> line intersection check.
+            if (Extensions.IsVectorWithinRange(start, collider.Position, collider.CollisionRadius)
+                || Extensions.IsVectorWithinRange(end, collider.Position, collider.CollisionRadius))
+            {
+                return true;
+            }
+
+            // Get the current direction of the sector (negated and added 90 degrees for clockwise rotation of vertices)
+            var angleDir = -Extensions.UnitVectorToAngle(new Vector2(Direction.X, Direction.Z)) + 90f;
+
+            // This section checks if the any of the lines connecting each vertice intersect with the collider's collision radius.
+            var collision = false;
+            int next = 0;
+            for (int curr = 0; curr < _trueVertices.Length; curr++)
+            {
+                next = curr++;
+
+                // Last vertice connects to the first.
+                if (next == _trueVertices.Length)
+                {
+                    next = 0;
+                }
+
+                // Move to sector position, rotate with facing direction, then make collider.Position the origin for CircleLineIntersection.
+                var currVert = Position + _trueVertices[curr].Rotate(angleDir) - collider.Position;
+                var nextVert = Position + _trueVertices[next].Rotate(angleDir) - collider.Position;
+
+                // Then, for each vertice, check if it is colliding.
+                if (Extensions.IsVectorWithinRange(currVert, Vector2.Zero, collider.CollisionRadius)
+                    || Extensions.IsVectorWithinRange(nextVert, Vector2.Zero, collider.CollisionRadius))
+                {
+                    return true;
+                }
+
+                // Otherwise, we perform a circle -> line intersection check.
+                collision = Extensions.CircleLineIntersection(currVert, nextVert, collider.CollisionRadius).Count > 0;
+
+                if (collision)
+                {
+                    break;
+                }
+            }
+
+            return collision;
+        }
+
+        public override Vector2 GetTargetPosition()
+        {
+            if (Parameters.BindObject != null)
+            {
+                return API.ApiFunctionManager.GetPointFromUnit(Parameters.BindObject, _trueHalfLength);
+            }
+
+            return new Vector2(CastInfo.SpellCastLaunchPosition.X, CastInfo.SpellCastLaunchPosition.Z);
+        }
+    }
+}

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSectorPolygon.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSectorPolygon.cs
@@ -36,24 +36,24 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             _trueWidth = parameters.Width;
             _trueHalfLength = parameters.HalfLength;
 
-            Vector2? lastVertice = null;
+            Vector2? lastVertex = null;
             for (int i = 0; i < _trueVertices.Length; i++)
             {
-                Vector2 currVertice = _trueVertices[i];
+                Vector2 currVertex = _trueVertices[i];
 
-                // Scale the vertice
-                Vector2 trueVertice = new Vector2(currVertice.X * parameters.Width, currVertice.Y * parameters.HalfLength);
+                // Scale the vertex
+                Vector2 trueVertex = new Vector2(currVertex.X * parameters.Width, currVertex.Y * parameters.HalfLength);
 
                 // Compare distances and override HalfWidth/Length as necessary
-                if (lastVertice != null)
+                if (lastVertex != null)
                 {
-                    var distX = currVertice.X - trueVertice.X;
+                    var distX = currVertex.X - trueVertex.X;
                     if (distX > _trueWidth)
                     {
                         _trueWidth = distX;
                     }
 
-                    var distY = currVertice.Y - trueVertice.Y;
+                    var distY = currVertex.Y - trueVertex.Y;
                     if (distY > _trueHalfLength)
                     {
                         _trueHalfLength = distY;
@@ -61,12 +61,12 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
                 }
 
                 // Reassign with true width/halflength.
-                trueVertice = new Vector2(currVertice.X * _trueWidth, currVertice.Y * _trueHalfLength);
+                trueVertex = new Vector2(currVertex.X * _trueWidth, currVertex.Y * _trueHalfLength);
 
-                // Save current vertice for next iteration so we can compare distance.
-                lastVertice = trueVertice;
-                // Assign scaled vertice.
-                _trueVertices[i] = trueVertice;
+                // Save current vertex for next iteration so we can compare distance.
+                lastVertex = trueVertex;
+                // Assign scaled vertex.
+                _trueVertices[i] = trueVertex;
             }
 
             if (_trueWidth > _trueHalfLength)
@@ -147,14 +147,14 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             // Get the current direction of the sector (negated and added 90 degrees for clockwise rotation of vertices)
             var angleDir = -Extensions.UnitVectorToAngle(new Vector2(Direction.X, Direction.Z)) + 90f;
 
-            // This section checks if the any of the lines connecting each vertice intersect with the collider's collision radius.
+            // This section checks if the any of the lines connecting each vertex intersect with the collider's collision radius.
             var collision = false;
             int next = 0;
             for (int curr = 0; curr < _trueVertices.Length; curr++)
             {
                 next = curr++;
 
-                // Last vertice connects to the first.
+                // Last vertex connects to the first.
                 if (next == _trueVertices.Length)
                 {
                     next = 0;
@@ -164,7 +164,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
                 var currVert = Position + _trueVertices[curr].Rotate(angleDir) - collider.Position;
                 var nextVert = Position + _trueVertices[next].Rotate(angleDir) - collider.Position;
 
-                // Then, for each vertice, check if it is colliding.
+                // Then, for each vertex, check if it is colliding.
                 if (Extensions.IsVectorWithinRange(currVert, Vector2.Zero, collider.CollisionRadius)
                     || Extensions.IsVectorWithinRange(nextVert, Vector2.Zero, collider.CollisionRadius))
                 {

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -127,11 +127,11 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             {
                 if (SpellData.HaveHitBone)
                 {
-                    ApiFunctionManager.AddParticleTarget(CastInfo.Owner, SpellData.HitEffectName, u, targetBone: SpellData.HitBoneName, lifetime: 1.0f);
+                    ApiFunctionManager.AddParticleTarget(CastInfo.Owner, null, SpellData.HitEffectName, u, targetBone: SpellData.HitBoneName, lifetime: 1.0f);
                 }
                 else
                 {
-                    ApiFunctionManager.AddParticleTarget(CastInfo.Owner, SpellData.HitEffectName, u, lifetime: 1.0f);
+                    ApiFunctionManager.AddParticleTarget(CastInfo.Owner, null, SpellData.HitEffectName, u, lifetime: 1.0f);
                 }
             }
 
@@ -887,7 +887,13 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 }
                 case SectorType.Polygon:
                 {
-                    // TODO
+                    s = new SpellSectorPolygon(
+                        _game,
+                        parameters,
+                        this,
+                        CastInfo,
+                        netId
+                    );
                     break;
                 }
                 case SectorType.Ring:

--- a/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
@@ -1,7 +1,9 @@
-﻿using GameServerCore.Domain.GameObjects.Spell.Missile;
+﻿using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Domain.GameObjects.Spell.Sector;
 using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
+using System.Numerics;
 
 namespace LeagueSandbox.GameServer.Scripting.CSharp
 {
@@ -100,20 +102,34 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
     public class SectorParameters : ISectorParameters
     {
         /// <summary>
+        /// Optional object the sector should be bound to. The sector will be attached to this object and will use its facing direction.
+        /// </summary>
+        public IGameObject BindObject { get; set; } = null;
+        /// <summary>
         /// Half the distance from the center of the sector to the maximum Y-value.
-        /// If this is larger than HalfWidth, it will be used as the area around the sector to check for collisions.
+        /// If this is larger than Width, it will be used as the area around the sector to check for collisions.
+        /// Scales the distance (in y) between PolygonVertices.
         /// </summary>
         public float HalfLength { get; set; } = 0f;
         /// <summary>
-        /// Half the distance from the center of the sector to the maximum X-value.
+        /// Distance from the center of the sector to the maximum X-value.
         /// If this is larger than HalfLength, it will be used as the area around the sector to check for collisions.
+        /// Scales the distance (in x) between PolygonVertices.
         /// </summary>
-        public float HalfWidth { get; set; } = 0f;
+        public float Width { get; set; } = 0f;
         /// <summary>
         /// If the Type is Cone, this will filter collisions that are in front of the sector and are within this angle from the sector's center.
         /// Should be a value from 0->360
         /// </summary>
         public float ConeAngle { get; set; } = 0f;
+        /// <summary>
+        /// If the Type is Polygon, this will represent the vertices of the sector.
+        /// Vertices are relative to the origin (SpellCastLaunchPosition or target position & direction).
+        /// If the distance between points exceeds HalfLength/Width, that distance will be used instead as the collision radius check for the sector.
+        /// Points should be ordered such that each point connects to the next (with the last point connecting to the first point).
+        /// Due to HalfLength and Width scaling the distance between vertices, it is recommended that points be arranged with x and y values between 0 and 1.
+        /// </summary>
+        public Vector2[] PolygonVertices { get; set; }
         /// <summary>
         /// Maximum amount of time this spell sector should last (in seconds) before being automatically removed.
         /// Setting to -1 will cause the spell sector to last until manually removed.


### PR DESCRIPTION
Implemented Polygon spell sector type and refactored particles by adding a few missing variables for packets, then updating their initialization and usage throughout the project.

* Packets:
  * FXCreateGroup function now properly handles multi-target bound particles and FollowGroundTilt and SpecificTeam variables.
* Spell:
  * Implemented SpellSectorPolygon in CreateSpellSector function.
* Particle:
  * Added Caster and FollowsGroundTilt variables for packets.
* SpellSector:
  * Cone:
    * Utilized Parameters.BindObject.
    * Added default for dirTemp.
  * Implemented SpellSectorPolygon
  * Moved BindObject variable to SectorParameters.
  * Removed initialization check of CastInfo.Targets.
  * Changed GetTargetPosition to virtual for other sector types (polygon in this case).
* SectorParameters & ScriptMetadata:
  * Added BindObject.
  * Renamed HalfWidth to Width.
  * Added PolygonVertices for defining the shape of a polygon sector.
* Scripting:
  * Updated AddParticle/Target functions for new variables and packet fixes.
  * Updated most scripts to use the new AddParticle/Target scheme.
* Debug Mode:
  * Updated usage of Particle initialization.

Resolve #1113