### PR TITLE
Resolve #1119 -- Fix Collision Priority

### DIFF
--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -594,6 +594,11 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="showWindow">Whether or not to show a window before unpausing (delay).</param>
         void NotifyResumeGame(IAttackableUnit unpauser, bool showWindow);
         /// <summary>
+        /// Sends a packet to all players with vision of the given chain missile that it has updated (unit/position).
+        /// </summary>
+        /// <param name="p">Missile that should be synced.</param>
+        void NotifyS2C_ChainMissileSync(ISpellMissile m);
+        /// <summary>
         /// Sends a packet to all players with vision of the given projectile that it has changed targets (unit/position).
         /// </summary>
         /// <param name="p">Projectile that has changed target.</param>

--- a/GameServerLib/Game.cs
+++ b/GameServerLib/Game.cs
@@ -336,10 +336,14 @@ namespace LeagueSandbox.GameServer
         /// <param name="diff">Number of milliseconds since this tick occurred.</param>
         public void Update(float diff)
         {
+            // This section dictates the priority of updates.
             GameTime += diff;
-            ObjectManager.Update(diff);
-            ProtectionManager.Update(diff);
+            // Collision
             Map.Update(diff);
+            // Objects
+            ObjectManager.Update(diff);
+            // Protection (TODO: Move this into ObjectManager).
+            ProtectionManager.Update(diff);
             ChatCommandManager.GetCommands().ForEach(command => command.Update(diff));
             _gameScriptTimers.ForEach(gsTimer => gsTimer.Update(diff));
             _gameScriptTimers.RemoveAll(gsTimer => gsTimer.IsDead());

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -700,11 +700,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             }
             else
             {
-                if (Script.ScriptMetadata.MissileParameters == null)
-                {
-                    ApplyEffects(CastInfo.Targets[0].Unit, null);
-                }
-
                 if (SpellData.ChannelDuration[CastInfo.SpellLevel] <= 0)
                 {
                     State = SpellState.STATE_COOLDOWN;
@@ -784,7 +779,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                         (int)SpellData.LineWidth,
                         this,
                         CastInfo,
-                        Script.ScriptMetadata.MissileParameters,
+                        parameters,
                         SpellData.MissileSpeed,
                         SpellData.Flags,
                         netId,


### PR DESCRIPTION
Resolve #1119

* Game:
  * Map updates (collision) now occur before any other updates.
* Packets:
  * Updated MissileReplication & S2C_UpdateBounceMissile.
  * Added S2C_ChainMissileSync.
* Spell:
  * ApplyEffects is no longer called for spells which do not spawn missiles or sectors automatically.
  * Chained missiles are now properly created via CreateSpellMissile using the "parameters".