### PR TITLE
Resolve #1129 -- Fix Collision Re-pathing

### DIFF
--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -224,6 +224,13 @@ namespace GameServerCore.Domain.GameObjects
         /// <returns></returns>
         bool CanMove();
         /// <summary>
+        /// Teleports this unit to the given position, and optionally repaths from the new position.
+        /// </summary>
+        /// <param name="x">X coordinate to teleport to.</param>
+        /// <param name="y">Y coordinate to teleport to.</param>
+        /// <param name="repath">Whether or not to repath from the new position.</param>
+        void TeleportTo(float x, float y, bool repath = false);
+        /// <summary>
         /// Returns the next waypoint. If all waypoints have been reached then this returns a -inf Vector2
         /// </summary>
         Vector2 GetNextWaypoint();

--- a/GameServerCore/Extensions.cs
+++ b/GameServerCore/Extensions.cs
@@ -364,14 +364,14 @@ namespace GameServerCore
         }
 
         /// <summary>
-        /// Effectively casts two rays from point p to the left and right boundaries of a given circle.
+        /// Casts two rays from point p to the left and right boundaries of a given circle.
         /// </summary>
         /// <param name="p">Point to cast the rays from.</param>
         /// <param name="c">Center of the circle.</param>
         /// <param name="r">Radius of the circle.</param>
         /// <returns>Array of 2 points representing the left and right bounds of the circle respectively.</returns>
         /// TODO: Could probably be more efficient by using an alternative to Cos and Sin.
-        public static Vector2[] CastRayCircle(Vector2 p, Vector2 c, float r)
+        public static Vector2[] CastRayCircleBounds(Vector2 p, Vector2 c, float r)
         {
             var angleToCenter = p.AngleTo(c, p);
             var angleToLeft = angleToCenter + 270f;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -356,26 +356,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public override void OnCollision(IGameObject collider, bool isTerrain = false)
         {
             // TODO: Pathfinding should be responsible for pathing around units so collisions with other units never occur (or at least very little).
-            // Collisions only occur between buildings.
-            if (MovementParameters != null || !(collider is IObjBuilding || collider is IBaseTurret || isTerrain == true))
+            // As a result, collisions for Champions should only occur between buildings and terrain.
+            if (MovementParameters != null || !(collider is IBaseTurret || isTerrain == true))
             {
                 return;
             }
 
             base.OnCollision(collider, isTerrain);
-            if (isTerrain)
-            {
-                //CORE_INFO("I bumped into a wall!");
-            }
-            // Champions are only teleported if they collide with other Champions.
-            // TODO: Implement Collision Priority
-            // TODO: Implement dynamic navigation grid for buildings and turrets.
-            else if (collider is IChampion || collider is IBaseTurret)
-            {
-                // Teleport out of other objects (+1 for insurance).
-                Vector2 exit = Extensions.GetCircleEscapePoint(Position, CollisionRadius * 2, collider.Position, collider.CollisionRadius);
-                TeleportTo(exit.X, exit.Y);
-            }
         }
 
         public override void TakeDamage(IAttackableUnit attacker, float damage, DamageType type, DamageSource source, bool isCrit)

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -357,7 +357,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             // TODO: Pathfinding should be responsible for pathing around units so collisions with other units never occur (or at least very little).
             // As a result, collisions for Champions should only occur between buildings and terrain.
-            if (MovementParameters != null || !(collider is IBaseTurret || isTerrain == true))
+            if (!(collider is IBaseTurret || isTerrain == true))
             {
                 return;
             }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -353,18 +353,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             _game.ObjectManager.StopTargeting(this);
         }
 
-        public override void OnCollision(IGameObject collider, bool isTerrain = false)
-        {
-            // TODO: Pathfinding should be responsible for pathing around units so collisions with other units never occur (or at least very little).
-            // As a result, collisions for Champions should only occur between buildings and terrain.
-            if (!(collider is IBaseTurret || isTerrain == true))
-            {
-                return;
-            }
-
-            base.OnCollision(collider, isTerrain);
-        }
-
         public override void TakeDamage(IAttackableUnit attacker, float damage, DamageType type, DamageSource source, bool isCrit)
         {
             base.TakeDamage(attacker, damage, type, source, isCrit);

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -349,30 +349,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             return ClassifyUnit.DEFAULT;
         }
 
-        /// <summary>
-        /// Called when this AI collides with the terrain or with another GameObject. Refer to CollisionHandler for exact cases.
-        /// </summary>
-        /// <param name="collider">GameObject that collided with this AI. Null if terrain.</param>
-        /// <param name="isTerrain">Whether or not this AI collided with terrain.</param>
-        public override void OnCollision(IGameObject collider, bool isTerrain = false)
-        {
-            // If we were trying to path somewhere before colliding, then repath from our new position.
-            if (!IsPathEnded())
-            {
-                List<Vector2> safePath = _game.Map.NavigationGrid.GetPath(Position, _game.Map.NavigationGrid.GetClosestTerrainExit(Waypoints.Last()));
-
-                // TODO: When using this safePath, sometimes we collide with the terrain again, so we use an unsafe path the next collision, however,
-                // sometimes we collide again before we can finish the unsafe path, so we end up looping collisions between safe and unsafe paths, never actually escaping (ex: sharp corners).
-                // Edit the current method to fix the above problem.
-                if (safePath != null)
-                {
-                    SetWaypoints(safePath);
-                }
-            }
-
-            base.OnCollision(collider, isTerrain);
-        }
-
         public override bool Move(float diff)
         {
             // If we have waypoints, but our move order is one of these, we shouldn't move.

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -246,6 +246,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 return;
             }
 
+            // We do not want to teleport out of missiles, sectors, or buildings. Buildings in particular are already baked into the Navigation Grid.
             if (collider is ISpellMissile || collider is ISpellSector || collider is IObjBuilding)
             {
                 return;
@@ -259,11 +260,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 var onCollideWithTerrain = _game.ScriptEngine.GetStaticMethod<Action<IGameObject>>(Model, "Passive", "onCollideWithTerrain");
                 onCollideWithTerrain?.Invoke(this);
 
-                if (isTerrain)
-                {
-                    // only time we would collide with terrain is if we are inside of it, so we should teleport out of it.
-                    exit = _game.Map.NavigationGrid.GetClosestTerrainExit(Position, CollisionRadius + 1.0f);
-                }
+                // only time we would collide with terrain is if we are inside of it, so we should teleport out of it.
+                exit = _game.Map.NavigationGrid.GetClosestTerrainExit(Position, CollisionRadius + 1.0f);
             }
             else
             {

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -177,10 +177,17 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             {
                 List<Vector2> safePath = _game.Map.NavigationGrid.GetPath(Position, _game.Map.NavigationGrid.GetClosestTerrainExit(Waypoints.Last(), CollisionRadius));
 
+                // TODO: When using this safePath, sometimes we collide with the terrain again, so we use an unsafe path the next collision, however,
+                // sometimes we collide again before we can finish the unsafe path, so we end up looping collisions between safe and unsafe paths, never actually escaping (ex: sharp corners).
+                // This is a more fundamental issue where the pathfinding should be taking into account collision radius, rather than simply pathing from center of an object.
                 if (safePath != null)
                 {
                     SetWaypoints(safePath);
                 }
+            }
+            else if (!repath && !IsPathEnded())
+            {
+                ResetWaypoints();
             }
         }
 
@@ -239,27 +246,38 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 return;
             }
 
-            base.OnCollision(collider, isTerrain);
-
             if (collider is ISpellMissile || collider is ISpellSector || collider is IObjBuilding)
             {
-                // TODO: Implement OnMissileCollide/Hit here.
                 return;
             }
 
+            Vector2 exit = Vector2.Zero;
+
             if (isTerrain)
             {
+                // TODO: Replace this with event listener publishing.
                 var onCollideWithTerrain = _game.ScriptEngine.GetStaticMethod<Action<IGameObject>>(Model, "Passive", "onCollideWithTerrain");
                 onCollideWithTerrain?.Invoke(this);
+
+                if (isTerrain)
+                {
+                    // only time we would collide with terrain is if we are inside of it, so we should teleport out of it.
+                    exit = _game.Map.NavigationGrid.GetClosestTerrainExit(Position, CollisionRadius + 1.0f);
+                }
             }
             else
             {
+                // TODO: Replace this with event listener publishing.
                 var onCollide = _game.ScriptEngine.GetStaticMethod<Action<IAttackableUnit, IGameObject>>(Model, "Passive", "onCollide");
                 onCollide?.Invoke(this, collider);
 
                 // Teleport out of other objects (+1 for insurance).
-                Vector2 exit = Extensions.GetCircleEscapePoint(Position, CollisionRadius + 1, collider.Position, collider.CollisionRadius);
-                TeleportTo(exit.X, exit.Y);
+                exit = Extensions.GetCircleEscapePoint(Position, CollisionRadius + 1, collider.Position, collider.CollisionRadius);
+            }
+
+            if (exit != Vector2.Zero)
+            {
+                TeleportTo(exit.X, exit.Y, true);
             }
         }
 
@@ -1041,7 +1059,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             return MovementParameters != null;
         }
 
-        public override void TeleportTo(float x, float y)
+        /// <summary>
+        /// Teleports this unit to the given position, and optionally repaths from the new position.
+        /// </summary>
+        /// <param name="x">X coordinate to teleport to.</param>
+        /// <param name="y">Y coordinate to teleport to.</param>
+        /// <param name="repath">Whether or not to repath from the new position.</param>
+        public void TeleportTo(float x, float y, bool repath = false)
         {
             var position = new Vector2(x, y);
 
@@ -1050,8 +1074,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 position = _game.Map.NavigationGrid.GetClosestTerrainExit(new Vector2(x, y), CollisionRadius + 1.0f);
             }
 
-            SetWaypoints(new List<Vector2> { Position, position });
-            SetPosition(position, false);
+            SetPosition(position, repath);
             TeleportID++;
             _game.PacketNotifier.NotifyTeleport(this, position);
         }
@@ -1131,8 +1154,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 // stop moving because we have reached our last waypoint
                 if (nextIndex >= Waypoints.Count)
                 {
-                    Waypoints = new List<Vector2> { Position };
-                    CurrentWaypoint = new KeyValuePair<int, Vector2>(1, Position);
+                    ResetWaypoints();
 
                     if (MovementParameters != null)
                     {
@@ -1162,6 +1184,15 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 return CurrentWaypoint.Value;
             }
             return new Vector2(float.NegativeInfinity, float.NegativeInfinity);
+        }
+
+        /// <summary>
+        /// Resets this unit's waypoints.
+        /// </summary>
+        public void ResetWaypoints()
+        {
+            Waypoints = new List<Vector2> { Position };
+            CurrentWaypoint = new KeyValuePair<int, Vector2>(1, Position);
         }
 
         /// <summary>
@@ -1208,8 +1239,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 return;
             }
 
-            Waypoints = new List<Vector2> { Position };
-            CurrentWaypoint = new KeyValuePair<int, Vector2>(1, Position);
+            ResetWaypoints();
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/Other/CollisionHandler.cs
+++ b/GameServerLib/GameObjects/Other/CollisionHandler.cs
@@ -8,7 +8,7 @@ using UltimateQuadTree;
 namespace LeagueSandbox.GameServer.GameObjects.Other
 {
     /// <summary>
-    /// Class which calls to collision based functions for GameObjects.
+    /// Class which calls collision based functions for GameObjects.
     /// </summary>
     public class CollisionHandler : ICollisionHandler
     {

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSectorCone.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSectorCone.cs
@@ -79,7 +79,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             // Get the current direction of the sector
             var angleDir = Extensions.UnitVectorToAngle(new Vector2(Direction.X, Direction.Z));
             // Get the left and round bounds of the collider (from the sector's perspective)
-            var colliderBounds = Extensions.CastRayCircle(Position, collider.Position, collider.CollisionRadius);
+            var colliderBounds = Extensions.CastRayCircleBounds(Position, collider.Position, collider.CollisionRadius);
 
             // True if the angle from the sector to either the left or right bounds is within the ConeAngle.
             return MathF.Abs(Position.AngleTo(colliderBounds[0], Position) - angleDir) <= Parameters.ConeAngle


### PR DESCRIPTION
Resolve #1129
* Champion:
  * Removed useless teleport logic from OnCollision and ObjBuilding is no longer collideable.
* ObjAiBase:
  * Removed useless OnCollision, as AttackableUnit now accounts for movement/waypoints, so too should it account for collision repathing.
* AttackableUnit:
  * OnCollision properly teleports out of terrain and objects, and optionally repaths afterwards.
  * SetPosition properly stops movement when repathing should not be done.
  * TeleportTo repath option added.