### PR TITLE
Resolve #1138 -- Fix ForceMovement

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -426,6 +426,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             float travelTime
         )
         {
+            SetWaypoints(new List<Vector2> { Position, target.Position }, false);
+
+            SetTargetUnit(target, true);
+
             // TODO: Take into account the rest of the arguments
             MovementParameters = new ForceMovementParameters
             {
@@ -440,22 +444,15 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             };
             DashElapsedTime = 0;
 
-            // TODO: Verify if this should be a parameter
-            Stats.SetActionState(ActionState.CAN_ATTACK, false);
-            Stats.SetActionState(ActionState.CAN_NOT_ATTACK, true);
-            Stats.SetActionState(ActionState.CAN_MOVE, false);
-            Stats.SetActionState(ActionState.CAN_NOT_MOVE, true);
+            _game.PacketNotifier.NotifyWaypointGroupWithSpeed(this);
+
+            SetDashingState(true);
 
             if (animation != null && animation != "")
             {
                 var animPairs = new Dictionary<string, string> { { "RUN", animation } };
                 SetAnimStates(animPairs);
             }
-
-            SetWaypoints(new List<Vector2> { Position, target.Position }, false);
-
-            SetTargetUnit(target, true);
-            _game.PacketNotifier.NotifyWaypointGroupWithSpeed(this);
 
             // TODO: Verify if we want to use NotifyWaypointListWithSpeed instead as it does not require conversions.
         }

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -1180,8 +1180,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public void SetWaypoints(List<Vector2> newWaypoints, bool networked = true)
         {
             // Waypoints should always have an origin at the current position.
-            // Can't set waypoints if we can't move. However, dashes override this.
-            if (newWaypoints.Count <= 1 || newWaypoints[0] != Position || (!CanMove() && MovementParameters == null))
+            // Can't set waypoints if we can't move. Dashes are also excluded as their paths should be set before being applied.
+            if (newWaypoints.Count <= 1 || newWaypoints[0] != Position || !CanMove() || MovementParameters != null)
             {
                 return;
             }
@@ -1261,6 +1261,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public void DashToLocation(Vector2 endPos, float dashSpeed, string animation = "", float leapGravity = 0.0f, bool keepFacingLastDirection = true)
         {
             var newCoords = _game.Map.NavigationGrid.GetClosestTerrainExit(endPos, CollisionRadius + 1.0f);
+
+            // False because we don't want this to be networked as a normal movement.
+            SetWaypoints(new List<Vector2> { Position, newCoords }, false);
+
             // TODO: Take into account the rest of the arguments
             MovementParameters = new ForceMovementParameters
             {
@@ -1275,14 +1279,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             };
             DashElapsedTime = 0;
 
+            SetDashingState(true);
+
             if (animation != null && animation != "")
             {
                 var animPairs = new Dictionary<string, string> { { "RUN", animation } };
                 SetAnimStates(animPairs);
             }
-
-            // False because we don't want this to be networked as a normal movement.
-            SetWaypoints(new List<Vector2> { Position, newCoords }, false);
 
             _game.PacketNotifier.NotifyWaypointGroupWithSpeed(this);
 
@@ -1303,8 +1306,23 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 MovementParameters = null;
                 DashElapsedTime = 0;
 
+                // TODO: Implement this as a parameter.
+                Stats.SetActionState(ActionState.CAN_ATTACK, true);
+                Stats.SetActionState(ActionState.CAN_NOT_ATTACK, false);
+                Stats.SetActionState(ActionState.CAN_MOVE, true);
+                Stats.SetActionState(ActionState.CAN_NOT_MOVE, false);
+
                 var animPairs = new Dictionary<string, string> { { "RUN", "" } };
                 SetAnimStates(animPairs);
+            }
+
+            if (state)
+            {
+                // TODO: Implement this as a parameter.
+                Stats.SetActionState(ActionState.CAN_ATTACK, false);
+                Stats.SetActionState(ActionState.CAN_NOT_ATTACK, true);
+                Stats.SetActionState(ActionState.CAN_MOVE, false);
+                Stats.SetActionState(ActionState.CAN_NOT_MOVE, true);
             }
         }
 


### PR DESCRIPTION
Resolve #1138
* AttackableUnit:
  * SetWaypoints no longer works when MovementParameters are applied.
  * DashToLocation sets waypoints before applying MovementParameters.
  * SetDashingState automatically prevents (and unsets) units from sending move or attack calls during the dash.
  * DashToLocation utilizes SetDashingState to prevent player move and attack calls during the dash.
* ObjAiBase:
  * DashToTarget sets waypoints (and target) before applying MovementParameters.
  * DashToTarget utilizes SetDashingState to prevent player move and attack calls during the dash.