### PR TITLE
Resolve #1136 -- LevelUp now uses StatsModifier

### DIFF
--- a/GameServerCore/Domain/GameObjects/IStatModifier.cs
+++ b/GameServerCore/Domain/GameObjects/IStatModifier.cs
@@ -2,6 +2,7 @@
 {
     public interface IStatModifier
     {
+        float BaseValue { get; set; }
         float BaseBonus { get; set; }
         float PercentBaseBonus { get; set; }
         float FlatBonus { get; set; }

--- a/GameServerLib/GameObjects/Stats/Stat.cs
+++ b/GameServerLib/GameObjects/Stats/Stat.cs
@@ -89,6 +89,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             {
                 return false;
             }
+            BaseValue += statModifier.BaseValue;
             BaseBonus += statModifier.BaseBonus;
             PercentBaseBonus += statModifier.PercentBaseBonus;
             FlatBonus += statModifier.FlatBonus;
@@ -103,6 +104,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             {
                 return false;
             }
+            BaseValue -= statModifier.BaseValue;
             BaseBonus -= statModifier.BaseBonus;
             PercentBaseBonus -= statModifier.PercentBaseBonus;
             FlatBonus -= statModifier.FlatBonus;

--- a/GameServerLib/GameObjects/Stats/StatModifier.cs
+++ b/GameServerLib/GameObjects/Stats/StatModifier.cs
@@ -6,11 +6,13 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
 {
     public class StatModifier : IStatModifier
     {
+        public float BaseValue { get; set; }
         public float BaseBonus { get; set; }
         public float PercentBaseBonus { get; set; }
         public float FlatBonus { get; set; }
         public float PercentBonus { get; set; }
-        public bool StatModified => Math.Abs(BaseBonus) > Extensions.COMPARE_EPSILON ||
+        public bool StatModified => Math.Abs(BaseValue) > Extensions.COMPARE_EPSILON ||
+                                    Math.Abs(BaseBonus) > Extensions.COMPARE_EPSILON ||
                                     Math.Abs(PercentBaseBonus) > Extensions.COMPARE_EPSILON ||
                                     Math.Abs(FlatBonus) > Extensions.COMPARE_EPSILON ||
                                     Math.Abs(PercentBonus) > Extensions.COMPARE_EPSILON;

--- a/GameServerLib/GameObjects/Stats/Stats.cs
+++ b/GameServerLib/GameObjects/Stats/Stats.cs
@@ -215,13 +215,13 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             Level++;
 
             StatsModifier statsLevelUp = new StatsModifier();
-            statsLevelUp.HealthPoints.BaseBonus = HealthPerLevel;
-            statsLevelUp.ManaPoints.BaseBonus = ManaPerLevel;
-            statsLevelUp.AttackDamage.BaseBonus = AdPerLevel;
-            statsLevelUp.Armor.BaseBonus = ArmorPerLevel;
-            statsLevelUp.MagicResist.BaseBonus = MagicResistPerLevel;
-            statsLevelUp.HealthRegeneration.BaseBonus = HealthRegenerationPerLevel;
-            statsLevelUp.ManaRegeneration.BaseBonus = ManaRegenerationPerLevel;
+            statsLevelUp.HealthPoints.BaseValue = HealthPerLevel;
+            statsLevelUp.ManaPoints.BaseValue = ManaPerLevel;
+            statsLevelUp.AttackDamage.BaseValue = AdPerLevel;
+            statsLevelUp.Armor.BaseValue = ArmorPerLevel;
+            statsLevelUp.MagicResist.BaseValue = MagicResistPerLevel;
+            statsLevelUp.HealthRegeneration.BaseValue = HealthRegenerationPerLevel;
+            statsLevelUp.ManaRegeneration.BaseValue = ManaRegenerationPerLevel;
             if (Level > 1)
             {
                 statsLevelUp.AttackSpeed.PercentBaseBonus = GrowthAttackSpeed / 100.0f;

--- a/GameServerLib/GameObjects/Stats/Stats.cs
+++ b/GameServerLib/GameObjects/Stats/Stats.cs
@@ -214,23 +214,22 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
         {
             Level++;
 
-            HealthPoints.BaseValue += HealthPerLevel;
-            CurrentHealth = HealthPoints.Total / (HealthPoints.Total - HealthPerLevel) * CurrentHealth;
-            ManaPoints.BaseValue = ManaPoints.Total + ManaPerLevel;
-            CurrentMana = ManaPoints.Total / (ManaPoints.Total - ManaPerLevel) * CurrentMana;
-            AttackDamage.BaseValue += AdPerLevel;
-            Armor.BaseValue += ArmorPerLevel;
-            MagicResist.BaseValue += MagicResistPerLevel;
-            HealthRegeneration.BaseValue += HealthRegenerationPerLevel;
-            ManaRegeneration.BaseValue += ManaRegenerationPerLevel;
-
+            StatsModifier statsLevelUp = new StatsModifier();
+            statsLevelUp.HealthPoints.BaseBonus = HealthPerLevel;
+            statsLevelUp.ManaPoints.BaseBonus += ManaPerLevel;
+            statsLevelUp.AttackDamage.BaseBonus += AdPerLevel;
+            statsLevelUp.Armor.BaseBonus += ArmorPerLevel;
+            statsLevelUp.MagicResist.BaseBonus += MagicResistPerLevel;
+            statsLevelUp.HealthRegeneration.BaseBonus += HealthRegenerationPerLevel;
+            statsLevelUp.ManaRegeneration.BaseBonus += ManaRegenerationPerLevel;
             if (Level > 1)
             {
-                AttackSpeedMultiplier.ApplyStatModifier(new StatModifier
-                {
-                    PercentBaseBonus = (GrowthAttackSpeed / 100.0f)
-                });
+                statsLevelUp.AttackSpeed.PercentBaseBonus = GrowthAttackSpeed / 100.0f;
             }
+            AddModifier(statsLevelUp);
+
+            CurrentHealth = HealthPoints.Total / (HealthPoints.Total - HealthPerLevel) * CurrentHealth;
+            CurrentMana = ManaPoints.Total / (ManaPoints.Total - ManaPerLevel) * CurrentMana;
         }
 
         public bool GetSpellEnabled(byte id)

--- a/GameServerLib/GameObjects/Stats/Stats.cs
+++ b/GameServerLib/GameObjects/Stats/Stats.cs
@@ -216,12 +216,12 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
 
             StatsModifier statsLevelUp = new StatsModifier();
             statsLevelUp.HealthPoints.BaseBonus = HealthPerLevel;
-            statsLevelUp.ManaPoints.BaseBonus += ManaPerLevel;
-            statsLevelUp.AttackDamage.BaseBonus += AdPerLevel;
-            statsLevelUp.Armor.BaseBonus += ArmorPerLevel;
-            statsLevelUp.MagicResist.BaseBonus += MagicResistPerLevel;
-            statsLevelUp.HealthRegeneration.BaseBonus += HealthRegenerationPerLevel;
-            statsLevelUp.ManaRegeneration.BaseBonus += ManaRegenerationPerLevel;
+            statsLevelUp.ManaPoints.BaseBonus = ManaPerLevel;
+            statsLevelUp.AttackDamage.BaseBonus = AdPerLevel;
+            statsLevelUp.Armor.BaseBonus = ArmorPerLevel;
+            statsLevelUp.MagicResist.BaseBonus = MagicResistPerLevel;
+            statsLevelUp.HealthRegeneration.BaseBonus = HealthRegenerationPerLevel;
+            statsLevelUp.ManaRegeneration.BaseBonus = ManaRegenerationPerLevel;
             if (Level > 1)
             {
                 statsLevelUp.AttackSpeed.PercentBaseBonus = GrowthAttackSpeed / 100.0f;

--- a/GameServerLibTests/Tests/TestStats.cs
+++ b/GameServerLibTests/Tests/TestStats.cs
@@ -31,7 +31,7 @@ namespace LeagueSandbox.GameServerTests.Tests
         [TestMethod]
         public void TestLevelUp()
         {
-            var stats = new Stats();
+            Stats stats = new Stats();  
 
             Assert.AreEqual(0, stats.Level);
 
@@ -39,13 +39,13 @@ namespace LeagueSandbox.GameServerTests.Tests
 
             Assert.AreEqual(1, stats.Level);
 
-            Assert.AreEqual(0, stats.AttackDamage.BaseValue);
-            Assert.AreEqual(0, stats.Armor.BaseValue);
-            Assert.AreEqual(0, stats.HealthPoints.BaseValue);
-            Assert.AreEqual(0, stats.HealthRegeneration.BaseValue);
-            Assert.AreEqual(0, stats.MagicResist.BaseValue);
-            Assert.AreEqual(0, stats.ManaPoints.BaseValue);
-            Assert.AreEqual(0, stats.ManaRegeneration.BaseValue);
+            Assert.AreEqual(0, stats.AttackDamage.BaseBonus);
+            Assert.AreEqual(0, stats.Armor.BaseBonus);
+            Assert.AreEqual(0, stats.HealthPoints.BaseBonus);
+            Assert.AreEqual(0, stats.HealthRegeneration.BaseBonus);
+            Assert.AreEqual(0, stats.MagicResist.BaseBonus);
+            Assert.AreEqual(0, stats.ManaPoints.BaseBonus);
+            Assert.AreEqual(0, stats.ManaRegeneration.BaseBonus);
 
             stats.AdPerLevel = 1;
             stats.ArmorPerLevel = 2;
@@ -59,13 +59,13 @@ namespace LeagueSandbox.GameServerTests.Tests
 
             Assert.AreEqual(2, stats.Level);
 
-            Assert.AreEqual(1, stats.AttackDamage.BaseValue);
-            Assert.AreEqual(2, stats.Armor.BaseValue);
-            Assert.AreEqual(3, stats.HealthPoints.BaseValue);
-            Assert.AreEqual(4, stats.HealthRegeneration.BaseValue);
-            Assert.AreEqual(5, stats.MagicResist.BaseValue);
-            Assert.AreEqual(6, stats.ManaPoints.BaseValue);
-            Assert.AreEqual(7, stats.ManaRegeneration.BaseValue);
+            Assert.AreEqual(1, stats.AttackDamage.BaseBonus);
+            Assert.AreEqual(2, stats.Armor.BaseBonus);
+            Assert.AreEqual(3, stats.HealthPoints.BaseBonus);
+            Assert.AreEqual(4, stats.HealthRegeneration.BaseBonus);
+            Assert.AreEqual(5, stats.MagicResist.BaseBonus);
+            Assert.AreEqual(6, stats.ManaPoints.BaseBonus);
+            Assert.AreEqual(7, stats.ManaRegeneration.BaseBonus);
         }
 
         [TestMethod]

--- a/GameServerLibTests/Tests/TestStats.cs
+++ b/GameServerLibTests/Tests/TestStats.cs
@@ -31,7 +31,7 @@ namespace LeagueSandbox.GameServerTests.Tests
         [TestMethod]
         public void TestLevelUp()
         {
-            var stats = new Stats();  
+            var stats = new Stats();
 
             Assert.AreEqual(0, stats.Level);
 

--- a/GameServerLibTests/Tests/TestStats.cs
+++ b/GameServerLibTests/Tests/TestStats.cs
@@ -31,7 +31,7 @@ namespace LeagueSandbox.GameServerTests.Tests
         [TestMethod]
         public void TestLevelUp()
         {
-            Stats stats = new Stats();  
+            var stats = new Stats();  
 
             Assert.AreEqual(0, stats.Level);
 

--- a/GameServerLibTests/Tests/TestStats.cs
+++ b/GameServerLibTests/Tests/TestStats.cs
@@ -39,13 +39,13 @@ namespace LeagueSandbox.GameServerTests.Tests
 
             Assert.AreEqual(1, stats.Level);
 
-            Assert.AreEqual(0, stats.AttackDamage.BaseBonus);
-            Assert.AreEqual(0, stats.Armor.BaseBonus);
-            Assert.AreEqual(0, stats.HealthPoints.BaseBonus);
-            Assert.AreEqual(0, stats.HealthRegeneration.BaseBonus);
-            Assert.AreEqual(0, stats.MagicResist.BaseBonus);
-            Assert.AreEqual(0, stats.ManaPoints.BaseBonus);
-            Assert.AreEqual(0, stats.ManaRegeneration.BaseBonus);
+            Assert.AreEqual(0, stats.AttackDamage.BaseValue);
+            Assert.AreEqual(0, stats.Armor.BaseValue);
+            Assert.AreEqual(0, stats.HealthPoints.BaseValue);
+            Assert.AreEqual(0, stats.HealthRegeneration.BaseValue);
+            Assert.AreEqual(0, stats.MagicResist.BaseValue);
+            Assert.AreEqual(0, stats.ManaPoints.BaseValue);
+            Assert.AreEqual(0, stats.ManaRegeneration.BaseValue);
 
             stats.AdPerLevel = 1;
             stats.ArmorPerLevel = 2;
@@ -59,13 +59,13 @@ namespace LeagueSandbox.GameServerTests.Tests
 
             Assert.AreEqual(2, stats.Level);
 
-            Assert.AreEqual(1, stats.AttackDamage.BaseBonus);
-            Assert.AreEqual(2, stats.Armor.BaseBonus);
-            Assert.AreEqual(3, stats.HealthPoints.BaseBonus);
-            Assert.AreEqual(4, stats.HealthRegeneration.BaseBonus);
-            Assert.AreEqual(5, stats.MagicResist.BaseBonus);
-            Assert.AreEqual(6, stats.ManaPoints.BaseBonus);
-            Assert.AreEqual(7, stats.ManaRegeneration.BaseBonus);
+            Assert.AreEqual(1, stats.AttackDamage.BaseValue);
+            Assert.AreEqual(2, stats.Armor.BaseValue);
+            Assert.AreEqual(3, stats.HealthPoints.BaseValue);
+            Assert.AreEqual(4, stats.HealthRegeneration.BaseValue);
+            Assert.AreEqual(5, stats.MagicResist.BaseValue);
+            Assert.AreEqual(6, stats.ManaPoints.BaseValue);
+            Assert.AreEqual(7, stats.ManaRegeneration.BaseValue);
         }
 
         [TestMethod]


### PR DESCRIPTION
*Introduced BaseValue to StatsModifier.
*Changed LevelUp() function to use StatsModifier instead of edditing stats directly.
*Fixed Total Mana being summed to the mana pool every level up.

Resolve #1136