### PR TITLE
Resolve #972 -- Fix Teleport Desyncs

### DIFF
--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -67,7 +67,7 @@ namespace GameServerCore.Domain.GameObjects
         /// Variable which stores the number of times a unit has teleported. Used purely for networking.
         /// Resets when reaching byte.MaxValue (255).
         /// </summary>
-        byte TeleportID { get; }
+        byte TeleportID { get; set; }
 
         /// <summary>
         /// Gets the HashString for this unit's model. Used for packets so clients know what data to load.

--- a/GameServerCore/Enums/BuffType.cs
+++ b/GameServerCore/Enums/BuffType.cs
@@ -24,7 +24,6 @@
         NEAR_SIGHT,
         FRENZY,
         FEAR,
-        NET,
         CHARM,
         POISON,
         SUPPRESSION,

--- a/GameServerCore/IObjectManager.cs
+++ b/GameServerCore/IObjectManager.cs
@@ -50,7 +50,6 @@ namespace GameServerCore
         /// <summary>
         /// Gets a new Dictionary containing all GameObjects of type AttackableUnit contained in the list of Vision Units in ObjectManager.
         /// </summary>
-        /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
         /// <returns>Dictionary of (NetID, AttackableUnit) pairs.</returns>
         Dictionary<uint, IAttackableUnit> GetVisionUnits();
 

--- a/GameServerCore/IObjectManager.cs
+++ b/GameServerCore/IObjectManager.cs
@@ -48,6 +48,13 @@ namespace GameServerCore
         void AddVisionUnit(IAttackableUnit unit);
 
         /// <summary>
+        /// Gets a new Dictionary containing all GameObjects of type AttackableUnit contained in the list of Vision Units in ObjectManager.
+        /// </summary>
+        /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
+        /// <returns>Dictionary of (NetID, AttackableUnit) pairs.</returns>
+        Dictionary<uint, IAttackableUnit> GetVisionUnits();
+
+        /// <summary>
         /// Gets a new Dictionary containing all GameObjects of type AttackableUnit of the specified team contained in the list of Vision Units in ObjectManager.
         /// </summary>
         /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -244,7 +244,8 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// <param name="o">GameObject coming into vision.</param>
         /// <param name="userId">User to send the packet to.</param>
-        void NotifyEnterLocalVisibilityClient(IGameObject o, int userId = 0);
+        /// <param name="ignoreVision">Optionally ignore vision checks when sending this packet.</param>
+        void NotifyEnterLocalVisibilityClient(IGameObject o, int userId = 0, bool ignoreVision = false);
         /// <summary>
         /// Sends a packet to either all players with vision of the specified object or the specified user. The packet details the data surrounding the specified GameObject that is required by players when a GameObject enters vision such as items, shields, skin, and movements.
         /// </summary>
@@ -252,8 +253,9 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="userId">User to send the packet to.</param>
         /// <param name="isChampion">Whether or not the GameObject entering vision is a Champion.</param>
         /// <param name="useTeleportID">Whether or not to teleport the object to its current position.</param>
+        /// <param name="ignoreVision">Optionally ignore vision checks when sending this packet.</param>
         /// TODO: Full implementation (items & shields)
-        void NotifyEnterVisibilityClient(IGameObject o, int userId = 0, bool isChampion = false, bool useTeleportID = false);
+        void NotifyEnterVisibilityClient(IGameObject o, int userId = 0, bool isChampion = false, bool useTeleportID = false, bool ignoreVision = false);
         /// <summary>
         /// Sends a packet to all players with vision of the specified unit detailing that the unit has begun facing the specified direction.
         /// </summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -63,8 +63,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public IStats Stats { get; protected set; }
         /// <summary>
         /// Variable which stores the number of times a unit has teleported. Used purely for networking.
+        /// Resets when reaching byte.MaxValue (255).
         /// </summary>
-        public byte TeleportID { get; protected set; }
+        public byte TeleportID { get; set; }
         /// <summary>
         /// Array of buff slots which contains all parent buffs (oldest buff of a given name) applied to this AI.
         /// Maximum of 256 slots, hard limit due to packets.

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -337,7 +337,6 @@ namespace LeagueSandbox.GameServer
         /// <summary>
         /// Gets a new Dictionary containing all GameObjects of type AttackableUnit contained in the list of Vision Units in ObjectManager.
         /// </summary>
-        /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
         /// <returns>Dictionary of (NetID, AttackableUnit) pairs.</returns>
         public Dictionary<uint, IAttackableUnit> GetVisionUnits()
         {

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -135,7 +135,7 @@ namespace LeagueSandbox.GameServer
                         {
                             u.SetVisibleByTeam(team, true);
                             // Might not be necessary, but just for good measure.
-                            _game.PacketNotifier.NotifyEnterVisibilityClient(u);
+                            _game.PacketNotifier.NotifyEnterVisibilityClient(u, useTeleportID: true);
                             RemoveVisionUnit(u);
                             // TODO: send this in one place only
                             _game.PacketNotifier.NotifyUpdatedStats(u, false);
@@ -331,6 +331,26 @@ namespace LeagueSandbox.GameServer
             lock (_visionLock)
             {
                 _visionUnits[team].Remove(netId);
+            }
+        }
+
+        /// <summary>
+        /// Gets a new Dictionary containing all GameObjects of type AttackableUnit contained in the list of Vision Units in ObjectManager.
+        /// </summary>
+        /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
+        /// <returns>Dictionary of (NetID, AttackableUnit) pairs.</returns>
+        public Dictionary<uint, IAttackableUnit> GetVisionUnits()
+        {
+            var ret = new Dictionary<uint, IAttackableUnit>();
+            lock (_visionLock)
+            {
+                var visionUnitsTeam = _visionUnits.Values.SelectMany(x => x).ToDictionary(pair => pair.Key, pair => pair.Value);
+                foreach (var unit in visionUnitsTeam)
+                {
+                    ret.Add(unit.Key, unit.Value);
+                }
+
+                return ret;
             }
         }
 

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -68,7 +68,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 {
                     if (champion.IsVisibleByTeam(peerInfo.Champion.Team))
                     {
-                        _game.PacketNotifier.NotifyEnterVisibilityClient(champion, userId, true);
+                        _game.PacketNotifier.NotifyEnterVisibilityClient(champion, userId, true, true, true);
                     }
                 }
                 else if (kv.Value is ILaneTurret turret)
@@ -87,7 +87,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                     );
 
                     // To suppress game HP-related errors for enemy turrets out of vision
-                    _game.PacketNotifier.NotifyEnterLocalVisibilityClient(turret, userId);
+                    _game.PacketNotifier.NotifyEnterLocalVisibilityClient(turret, userId, ignoreVision: true);
 
                     foreach (var item in turret.Inventory)
                     {

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -51,7 +51,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                          _game.PacketNotifier.NotifyDebugMessage(userId, msg);
                     }
 
-                    _game.PacketNotifier.NotifyEnterLocalVisibilityClient(player.Item2.Champion);
+                    _game.PacketNotifier.NotifyEnterLocalVisibilityClient(player.Item2.Champion, ignoreVision: true);
                     // TODO: send this in one place only
                     _game.PacketNotifier.NotifyUpdatedStats(player.Item2.Champion, false);
                     _game.PacketNotifier.NotifyBlueTip((int) player.Item2.PlayerId, "Welcome to League Sandbox!",
@@ -76,11 +76,11 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                     {
                         if (player.Item2.Team == peerInfo.Team)
                         {
-                            _game.PacketNotifier.NotifyEnterVisibilityClient(player.Item2.Champion, userId, true);
+                            _game.PacketNotifier.NotifyEnterVisibilityClient(player.Item2.Champion, userId, true, true, true);
 
                             /* This is probably not the best way
                              * of updating a champion's level, but it works */
-                             _game.PacketNotifier.NotifyNPC_LevelUp(player.Item2.Champion);
+                            _game.PacketNotifier.NotifyNPC_LevelUp(player.Item2.Champion);
                             if (_game.IsPaused)
                             {
                                  _game.PacketNotifier.NotifyPauseGame((int)_game.PauseTimeLeft, true);

--- a/PacketDefinitions420/PacketExtensions.cs
+++ b/PacketDefinitions420/PacketExtensions.cs
@@ -144,10 +144,15 @@ namespace PacketDefinitions420
                             // TODO: Implement teleportID (likely to be the index (starting at 1) of a waypoint we want to TP to).
                             // Crucial in syncing client positions with server positions, especially when entering vision
                             HasTeleportID = useTeleportID,
-                            TeleportID = 0,
+                            TeleportID = unit.TeleportID,
                             Waypoints = waypoints,
                             SpeedParams = speeds
                         };
+
+                        if (useTeleportID)
+                        {
+                            unit.TeleportID++;
+                        }
 
                         break;
                     }
@@ -178,9 +183,14 @@ namespace PacketDefinitions420
                             // TODO: Implement teleportID (likely to be the index (starting at 1) of a waypoint we want to TP to).
                             // Crucial in syncing client positions with server positions, especially when entering vision
                             HasTeleportID = useTeleportID,
-                            TeleportID = 0,
+                            TeleportID = unit.TeleportID,
                             Waypoints = waypoints
                         };
+
+                        if (useTeleportID)
+                        {
+                            unit.TeleportID++;
+                        }
 
                         break;
                     }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Take a look at [this](https://github.com/LeagueSandbox/GameServer/blob/indev/CON
 ### Manual Setup (Windows/Mac)
 * Download the 4.20 version of League game client:
 	1. [Unscrubbed, packed version](https://mega.nz/#!hpkiQK5A!pFkZJtxCMQktJf4umplAdPC_Fukt0xgMfO7g3bGp1Io)
-	2. [Scrubbed, moddable version](https://drive.google.com/file/d/12sWXWPQdTDIpNTJMOygC61zS7DnoFLfy)
+	2. [Scrubbed, moddable version](https://drive.google.com/file/d/1JVUGe75nMluczrY14xb0KDXiihFRlGnV)
 * For running the git commands below, [Git Bash](https://gitforwindows.org/) is recommended
 * Clone the git repository using ```git clone https://github.com/LeagueSandbox/GameServer.git```, then to download the necessary contents packages, run:
 	* ```cd GameServer```


### PR DESCRIPTION
The issue of teleports was due to the clients not having information about the units that were entering vision, resulting in the client attempting to compensate by first spawning them, then teleporting them to the last known position or waypoint (regardless of if the server suggested a teleportID). This was fixed by disregarding vision checks when units are first spawned, which allowed teleportIDs suggested by the server to work correctly.

All debug modes now work as intended, and a new lane minion debug mode has been added.

Resolve #972

* Packets:
  * EnterLocalVisibility and EnterVisibility can optionally ignore vision when being sent to clients.
    * Used in HandleSpawn, HandleStartGame, and ObjectManager for when GameObjects intially spawn.
* DebugMode:
  * Added lane minion debugging.
  * Fixed other debug mode displaying particles incorrectly.
* AttackableUnit:
  * TeleportID can be set outside of the class.
    * Used in PacketExtensions when using teleportID for MovementData.
* ObjectManager:
  * Added GetVisionUnits which does not require a team parameter.
* General:
  * Updated scrubbed, moddable download link, fixes issues with missing assets.