### PR TITLE
Resolve #1165, Resolve #1164, Resolve #1163, Resolve #1162, Resolve #1161, Resolve #1095, Resolve #879, Progress #1059 -- [QOL] Scripting

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Aatrox/AatroxR.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Aatrox/AatroxR.cs
@@ -5,7 +5,7 @@ using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
-namespace AatroxR
+namespace Buffs
 {
     class AatroxR : IBuffGameScript
     {
@@ -24,15 +24,15 @@ namespace AatroxR
             if (unit is IChampion c)
             {
                 // TODO: Implement Animation Overrides for spells like these
-                if (c.Skin == 0)
+                if (c.SkinID == 0)
                 {
                     pmodelname = "Aatrox_Base_RModel.troy";
                 }
-                else if (c.Skin == 1)
+                else if (c.SkinID == 1)
                 {
                     pmodelname = "Aatrox_Skin01_RModel.troy";
                 }
-                else if (c.Skin == 2)
+                else if (c.SkinID == 2)
                 {
                     pmodelname = "Aatrox_Skin02_RModel.troy";
                 }

--- a/Content/LeagueSandbox-Scripts/Buffs/Akali/QMark.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Akali/QMark.cs
@@ -9,7 +9,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Scripting.CSharp;
 
 
-namespace AkaliMota
+namespace Buffs
 {
     class AkaliMota : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Anivia/Chilled.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Anivia/Chilled.cs
@@ -4,7 +4,7 @@ using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 
-namespace Chilled
+namespace Buffs
 {
     internal class Chilled : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Anivia/GlacialStorm.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Anivia/GlacialStorm.cs
@@ -7,7 +7,7 @@ using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
-namespace GlacialStorm
+namespace Buffs
 {
     class GlacialStorm : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/Overdrive.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/Overdrive.cs
@@ -5,7 +5,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
-namespace Overdrive
+namespace Buffs
 {
     internal class Overdrive : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab.cs
@@ -5,7 +5,7 @@ using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 
-namespace RocketGrab
+namespace Buffs
 {
     internal class RocketGrab : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
@@ -5,7 +5,7 @@ using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 
-namespace RocketGrab2
+namespace Buffs
 {
     internal class RocketGrab2 : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Ezreal/EzrealWBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Ezreal/EzrealWBuff.cs
@@ -4,7 +4,7 @@ using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 
-namespace EzrealWBuff
+namespace Buffs
 {
     class EzrealWBuff : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Gangplank/GangplankE.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Gangplank/GangplankE.cs
@@ -6,7 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.Stats;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Scripting.CSharp;
 
-namespace GangplankE
+namespace Buffs
 {
     internal class GangplankE : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Gangplank/GangplankW.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Gangplank/GangplankW.cs
@@ -4,7 +4,7 @@ using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 
-namespace GangplankW
+namespace Buffs
 {
     internal class GangplankW : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Garen/GarenE.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Garen/GarenE.cs
@@ -3,7 +3,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
 
-namespace GarenE
+namespace Buffs
 {
     internal class GarenE : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Blind.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Blind.cs
@@ -3,7 +3,7 @@ using GameServerCore.Enums;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 
-namespace Blind
+namespace Buffs
 {
     internal class Blind : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Disarm.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Disarm.cs
@@ -3,7 +3,7 @@ using GameServerCore.Enums;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 
-namespace Disarm
+namespace Buffs
 {
     internal class Disarm : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Invulnerable.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Invulnerable.cs
@@ -3,7 +3,7 @@ using GameServerCore.Enums;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 
-namespace Invulnerable
+namespace Buffs
 {
     internal class Invulnerable : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Recall.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Recall.cs
@@ -5,7 +5,7 @@ using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.API;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
-namespace Recall
+namespace Buffs
 {
     class Recall : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Silence.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Silence.cs
@@ -3,7 +3,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
 
-namespace Silence
+namespace Buffs
 {
     internal class Silence : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Stun.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Stun.cs
@@ -4,7 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Scripting.CSharp;
 
-namespace Stun
+namespace Buffs
 {
     internal class Stun : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Graves/Quickdraw.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Graves/Quickdraw.cs
@@ -5,7 +5,7 @@ using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 
-namespace Quickdraw
+namespace Buffs
 {
     internal class Quickdraw : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Items/DeathfireGraspSpell.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Items/DeathfireGraspSpell.cs
@@ -5,7 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 
-namespace DeathfireGraspSpell
+namespace Buffs
 {
     internal class DeathfireGraspSpell : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Items/RegenerationPotion.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Items/RegenerationPotion.cs
@@ -5,7 +5,7 @@ using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 
-namespace RegenerationPotion
+namespace Buffs
 {
     internal class RegenerationPotion : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Items/YoumuusGhostblade.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Items/YoumuusGhostblade.cs
@@ -5,7 +5,7 @@ using LeagueSandbox.GameServer.GameObjects.Stats;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Scripting.CSharp;
 
-namespace YoumuusGhostblade
+namespace Buffs
 {
     internal class YoumuusGhostblade : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkSonicWave.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkSonicWave.cs
@@ -4,7 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Scripting.CSharp;
 
-namespace BlindMonkSonicWave
+namespace Buffs
 {
     internal class BlindMonkSonicWave : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Leona/LeonaShieldOfDaybreak.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Leona/LeonaShieldOfDaybreak.cs
@@ -7,7 +7,7 @@ using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
-namespace LeonaShieldOfDaybreak
+namespace Buffs
 {
     class LeonaShieldOfDaybreak : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Lulu/LuluR.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Lulu/LuluR.cs
@@ -5,7 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 
-namespace LuluR
+namespace Buffs
 {
     internal class LuluR : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Lulu/LuluW/LuluWBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Lulu/LuluW/LuluWBuff.cs
@@ -5,7 +5,7 @@ using LeagueSandbox.GameServer.GameObjects.Stats;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Scripting.CSharp;
 
-namespace LuluWBuff
+namespace Buffs
 {
     internal class LuluWBuff : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Lulu/LuluW/LuluWDebuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Lulu/LuluW/LuluWDebuff.cs
@@ -4,7 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 
-namespace LuluWDebuff
+namespace Buffs
 {
     internal class LuluWDebuff : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/MasterYi/Highlander.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/MasterYi/Highlander.cs
@@ -5,7 +5,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 
-namespace Highlander
+namespace Buffs
 {
     internal class Highlander : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Sivir/SivirW.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Sivir/SivirW.cs
@@ -8,7 +8,7 @@ using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
-namespace SivirW
+namespace Buffs
 {
     class SivirW : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerDot.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerDot.cs
@@ -5,7 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 
-namespace SummonerDot
+namespace Buffs
 {
     internal class SummonerDot : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerExhaustDebuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerExhaustDebuff.cs
@@ -4,7 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 
-namespace SummonerExhaustDebuff
+namespace Buffs
 {
     internal class SummonerExhaustDebuff : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerHasteBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerHasteBuff.cs
@@ -4,7 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 
-namespace SummonerHasteBuff
+namespace Buffs
 {
     internal class SummonerHasteBuff : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerHeal/HealCheck.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerHeal/HealCheck.cs
@@ -3,7 +3,7 @@ using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 
-namespace HealCheck
+namespace Buffs
 {
     internal class HealCheck : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerHeal/HealSpeed.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerHeal/HealSpeed.cs
@@ -5,7 +5,7 @@ using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
-namespace HealSpeed
+namespace Buffs
 {
     internal class HealSpeed : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerReviveSpeedBoost.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Summoners/SummonerReviveSpeedBoost.cs
@@ -4,7 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 
-namespace SummonerReviveSpeedBoost
+namespace Buffs
 {
     internal class SummonerReviveSpeedBoost : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Taric/Radiance/Radiance-ally.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Taric/Radiance/Radiance-ally.cs
@@ -4,7 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 
-namespace Radiance_ally
+namespace Buffs
 {
     internal class Radiance_ally : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Taric/Radiance/Radiance.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Taric/Radiance/Radiance.cs
@@ -4,7 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using GameServerCore.Scripting.CSharp;
 
-namespace Radiance
+namespace Buffs
 {
     internal class Radiance : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Taric/TaricEhud.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Taric/TaricEhud.cs
@@ -3,7 +3,7 @@ using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 
-namespace TaricEhud
+namespace Buffs
 {
     internal class TaricEhud : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Taric/TaricW/TaricWDis.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Taric/TaricW/TaricWDis.cs
@@ -3,7 +3,7 @@ using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 
-namespace TaricWDis
+namespace Buffs
 {
     internal class TaricWDis : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoE.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoE.cs
@@ -5,7 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
 
-namespace YasuoE
+namespace Buffs
 {
     internal class YasuoE : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoEBlock.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoEBlock.cs
@@ -4,7 +4,7 @@ using GameServerCore.Enums;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Scripting.CSharp;
 
-namespace YasuoEBlock
+namespace Buffs
 {
     internal class YasuoEBlock : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoQ1.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoQ1.cs
@@ -3,7 +3,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
 
-namespace YasuoQ01
+namespace Buffs
 {
     internal class YasuoQ01 : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoQ2.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoQ2.cs
@@ -4,7 +4,7 @@ using GameServerCore.Enums;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Scripting.CSharp;
 
-namespace YasuoQ02
+namespace Buffs
 {
     internal class YasuoQ02 : IBuffGameScript
     {

--- a/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedW2.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedW2.cs
@@ -1,0 +1,49 @@
+﻿using System.Numerics;
+using GameServerCore;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using GameServerCore.Enums;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+namespace Buffs
+{
+    public class ZedW2 : IBuffGameScript
+    {
+        public BuffType BuffType => BuffType.INTERNAL;
+        public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
+        public int MaxStacks => 1;
+        public bool IsHidden => false;
+
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
+
+        ZedWHandler Handler;
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            if (unit is IObjAiBase owner)
+            {
+                Handler = (owner.GetBuffWithName("ZedWHandler").BuffScript as ZedWHandler);
+                var w2Spell = owner.SetSpell("ZedW2", 1, true);
+                ApiEventManager.OnSpellCast.AddListener(this, w2Spell, Handler.ShadowSwap);
+            }
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            if (!Handler.QueueSwap)
+            {
+                unit.RemoveBuffsWithName("ZedWHandler");
+            }
+
+            (unit as IObjAiBase).SetSpell("ZedShadowDash", 1, true);
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedWHandler.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedWHandler.cs
@@ -1,0 +1,134 @@
+﻿using System.Numerics;
+using GameServerCore;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using GameServerCore.Enums;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+namespace Buffs
+{
+    class ZedWHandler : IBuffGameScript
+    {
+        public BuffType BuffType => BuffType.COMBAT_ENCHANCER;
+        public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
+        public int MaxStacks => 1;
+        public bool IsHidden => false;
+
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
+
+        ISpell ThisSpell;
+        IBuff ThisBuff;
+        IMinion Shadow;
+        IBuff ShadowBuff;
+        public bool QueueSwap;
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            ThisSpell = ownerSpell;
+            ThisBuff = buff;
+
+            ClearShadows();
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+        }
+
+        public IMinion ShadowSpawn()
+        {
+            var owner = ThisSpell.CastInfo.Owner;
+
+            var spellPos = new Vector2(ThisSpell.CastInfo.TargetPositionEnd.X, ThisSpell.CastInfo.TargetPositionEnd.Z);
+            Shadow = AddMinion(owner, "ZedShadow", "ZedShadow", spellPos, owner.SkinID, true, false);
+
+            var goingTo = new Vector2(ThisSpell.CastInfo.TargetPositionEnd.X, ThisSpell.CastInfo.TargetPositionEnd.Z) - owner.Position;
+            var dirTemp = Vector2.Normalize(goingTo);
+            Shadow.FaceDirection(new Vector3(dirTemp.X, 0, dirTemp.Y));
+
+            AddBuff("ZedWShadowBuff", ThisBuff.Duration, 1, ThisSpell, Shadow, owner);
+
+            return Shadow;
+        }
+
+        /// <summary>
+        /// Perform a cast of the given spell using the shadow (only applies to Q and E).
+        /// </summary>
+        /// <param name="spell">Spell which triggered this shadow cast.</param>
+        /// TODO: Test this with Q and E.
+        public void ShadowCast(ISpell spell)
+        {
+            var slot = spell.CastInfo.SpellSlot;
+            if (slot != 0 || slot != 2 && Shadow != null)
+            {
+                return;
+            }
+
+            FaceDirection(new Vector2(spell.CastInfo.TargetPositionEnd.X, spell.CastInfo.TargetPositionEnd.Z), Shadow, true);
+            SpellCast(spell.CastInfo.Owner, slot, SpellSlotType.SpellSlots, true, spell.CastInfo.Targets[0].Unit, Shadow.Position);
+
+            switch (slot)
+            {
+                case 0:
+                {
+                    PlayAnimation(Shadow, "Spell1");
+                    return;
+                }
+                case 2:
+                {
+                    PlayAnimation(Shadow, "Spell3");
+                    return;
+                }
+            }
+        }
+
+        public void ShadowSwap(ISpell spell)
+        {
+            var owner = spell.CastInfo.Owner;
+
+            if (Shadow != null && !Shadow.IsDead)
+            {
+                if (QueueSwap)
+                {
+                    QueueSwap = false;
+                }
+                var ownerPos = owner.Position;
+                TeleportTo(owner, Shadow.Position.X, Shadow.Position.Y);
+                AddParticleTarget(owner, owner, "zed_base_cloneswap.troy", owner);
+                TeleportTo(Shadow, ownerPos.X, ownerPos.Y);
+                AddParticleTarget(owner, Shadow, "zed_base_cloneswap.troy", Shadow);
+
+                owner.RemoveBuffsWithName("ZedW2");
+                owner.RemoveBuff(ThisBuff);
+            }
+            else if (Shadow == null)
+            {
+                QueueSwap = true;
+                owner.RemoveBuffsWithName("ZedW2");
+            }
+        }
+
+        public void ClearShadows()
+        {
+            if (ShadowBuff != null)
+            {
+                LogInfo("Previous shadow found.");
+                if (!ShadowBuff.Elapsed())
+                {
+                    ShadowBuff.DeactivateBuff();
+                }
+            }
+        }
+
+        public void OnUpdate(float diff)
+        {
+            if (Shadow != null && QueueSwap)
+            {
+                ShadowSwap(ThisSpell);
+            }
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedWPassiveBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedWPassiveBuff.cs
@@ -1,24 +1,28 @@
+﻿using System.Numerics;
+using GameServerCore;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.GameObjects.Stats;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
 namespace Buffs
 {
-    internal class OverdriveSlow : IBuffGameScript
+    class ZedWPassiveBuff : IBuffGameScript
     {
-        public BuffType BuffType => BuffType.SLOW;
+        public BuffType BuffType => BuffType.COMBAT_ENCHANCER;
         public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
         public int MaxStacks => 1;
-        public bool IsHidden => false;
+        public bool IsHidden => true;
 
         public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            StatsModifier.MoveSpeed.PercentBonus = StatsModifier.MoveSpeed.PercentBonus - 0.3f;
-            unit.AddStatModifier(StatsModifier);
+            StatsModifier.AttackDamage.PercentBonus = 5f * ownerSpell.CastInfo.SpellLevel;
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
@@ -27,8 +31,6 @@ namespace Buffs
 
         public void OnUpdate(float diff)
         {
-
         }
     }
 }
-

--- a/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedWShadowBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedWShadowBuff.cs
@@ -1,0 +1,123 @@
+﻿using System.Numerics;
+using GameServerCore;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using GameServerCore.Enums;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+namespace Buffs
+{
+    class ZedWShadowBuff : IBuffGameScript
+    {
+        public BuffType BuffType => BuffType.COMBAT_ENCHANCER;
+        public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
+        public int MaxStacks => 1;
+        public bool IsHidden => false;
+
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
+
+        IBuff ThisBuff;
+        IMinion Shadow;
+        IParticle currentIndicator;
+        int previousIndicatorState;
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            ThisBuff = buff;
+            Shadow = unit as IMinion;
+
+            Shadow.SetIsTargetable(false);
+            Shadow.SetStatus(StatusFlags.Ghosted, true);
+
+            AddParticleTarget(Shadow.Owner, Shadow, "zed_base_w_tar.troy", Shadow);
+
+            currentIndicator = AddParticleTarget(Shadow.Owner, Shadow.Owner, "zed_shadowindicatorfar.troy", Shadow, buff.Duration, flags: FXFlags.TargetDirection);
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            if (Shadow != null && !Shadow.IsDead)
+            {
+                if (currentIndicator != null)
+                {
+                    currentIndicator.SetToRemove();
+                }
+
+                Shadow.SetStatus(StatusFlags.NoRender, true);
+                AddParticle(Shadow.Owner, null, "zed_base_clonedeath.troy", Shadow.Position);
+                Shadow.TakeDamage(Shadow.Owner, 10000f, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_INTERNALRAW, DamageResultType.RESULT_NORMAL);
+            }
+        }
+
+        public int GetIndicatorState()
+        {
+            var dist = Vector2.Distance(Shadow.Owner.Position, Shadow.Position);
+            var state = 0;
+
+            if (!Shadow.Owner.HasBuff("ZedW2"))
+            {
+                return state;
+            }
+
+            if (dist >= 1000.0f)
+            {
+                state = 0;
+            }
+            else if (dist >= 800.0f)
+            {
+                state = 1;
+            }
+            else if (dist >= 0f)
+            {
+                state = 2;
+            }
+
+            return state;
+        }
+
+        public string GetIndicatorName(int state)
+        {
+            switch (state)
+            {
+                case 0:
+                {
+                    return "zed_shadowindicatorfar.troy";
+                }
+                case 1:
+                {
+                    return "zed_shadowindicatormed.troy";
+                }
+                case 2:
+                {
+                    return "zed_shadowindicatornearbloop.troy";
+                }
+                default:
+                {
+                    return "zed_shadowindicatorfar.troy";
+                }
+            }
+        }
+
+        public void OnUpdate(float diff)
+        {
+            if (Shadow != null && !Shadow.IsDead)
+            {
+                int state = GetIndicatorState();
+                if (state != previousIndicatorState)
+                {
+                    previousIndicatorState = state;
+                    if (currentIndicator != null)
+                    {
+                        currentIndicator.SetToRemove();
+                    }
+
+                    currentIndicator = AddParticleTarget(Shadow.Owner, Shadow.Owner, GetIndicatorName(state), Shadow, ThisBuff.Duration - ThisBuff.TimeElapsed, flags: FXFlags.TargetDirection);
+                }
+            }
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedWShadowBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedWShadowBuff.cs
@@ -30,7 +30,7 @@ namespace Buffs
             ThisBuff = buff;
             Shadow = unit as IMinion;
 
-            Shadow.SetIsTargetable(false);
+            Shadow.SetStatus(StatusFlags.Targetable, false);
             Shadow.SetStatus(StatusFlags.Ghosted, true);
 
             AddParticleTarget(Shadow.Owner, Shadow, "zed_base_w_tar.troy", Shadow);

--- a/Content/LeagueSandbox-Scripts/Champions/Aatrox/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Aatrox/R.cs
@@ -22,17 +22,17 @@ namespace Spells
         {
             if (owner is IChampion c)
             {
-                if (c.Skin == 0)
+                if (c.SkinID == 0)
                 {
                     pcastname = "Aatrox_Base_R_Activate.troy";
                     phitname = "Aatrox_Base_R_active_hit_tar.troy";
                 }
-                else if (c.Skin == 1)
+                else if (c.SkinID == 1)
                 {
                     pcastname = "Aatrox_Skin01_R_Activate.troy";
                     phitname = "Aatrox_Skin01_R_active_hit_tar.troy";
                 }
-                else if (c.Skin == 2)
+                else if (c.SkinID == 2)
                 {
                     pcastname = "Aatrox_Skin02_R_Activate.troy";
                     phitname = "Aatrox_Skin02_R_active_hit_tar.troy";

--- a/Content/LeagueSandbox-Scripts/Champions/Annie/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Annie/Q.cs
@@ -30,7 +30,7 @@ namespace Spells
         public void TargetExecute(ISpell spell, IAttackableUnit target, ISpellMissile missile)
         {
             var owner = spell.CastInfo.Owner as IChampion;
-            var ownerSkinID = owner.Skin;
+            var ownerSkinID = owner.SkinID;
             var ap = owner.Stats.AbilityPower.Total * spell.SpellData.MagicDamageCoefficient;
             var damage = 45 + spell.CastInfo.SpellLevel * 35 + ap;
 

--- a/Content/LeagueSandbox-Scripts/Champions/Ezreal/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Ezreal/Q.cs
@@ -40,7 +40,7 @@ namespace Spells
         public void OnSpellPostCast(ISpell spell)
         {
             var owner = spell.CastInfo.Owner as IChampion;
-            var ownerSkinID = owner.Skin;
+            var ownerSkinID = owner.SkinID;
             var targetPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
             var ownerPos = owner.Position;
             var distance = Vector2.Distance(ownerPos, targetPos);

--- a/Content/LeagueSandbox-Scripts/Champions/Lulu/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Lulu/W.cs
@@ -55,7 +55,7 @@ namespace Spells
             var time = 1 + 0.25f * spell.CastInfo.SpellLevel;
             AddBuff("LuluWDebuff", time, 1, spell, champion, owner);
             var model = champion.Model;
-            ChangeModel((owner as IChampion).Skin, target);
+            ChangeModel(owner.SkinID, target);
 
             var p = AddParticleTarget(owner, owner, "Lulu_W_polymorph_01.troy", target);
             CreateTimer(time, () =>

--- a/Content/LeagueSandbox-Scripts/Champions/Shaco/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Shaco/W.cs
@@ -84,7 +84,8 @@ namespace Spells
                         {
                             if (!m.IsDead)
                             {
-                                m.Die(m); //TODO: Fix targeting issues
+                                //TODO: Fix targeting issues
+                                m.TakeDamage(m.Owner, 1000f, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_INTERNALRAW, DamageResultType.RESULT_NORMAL);
                             }
                         });
                     }

--- a/Content/LeagueSandbox-Scripts/Champions/Zed/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Zed/W.cs
@@ -1,0 +1,185 @@
+﻿using System.Numerics;
+using GameServerCore;
+using GameServerCore.Domain;
+using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using LeagueSandbox.GameServer.API;
+using System.Collections.Generic;
+using GameServerCore.Scripting.CSharp;
+
+namespace Spells
+{
+    public class ZedShadowDash : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            AutoFaceDirection = false,
+            TriggersSpellCasts = true
+            // TODO
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+            AddBuff("ZedWPassiveBuff", 1.0f, 1, spell, owner, owner, true);
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+            var owner = spell.CastInfo.Owner as IChampion;
+            var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
+            SpellCast(owner, 4, SpellSlotType.ExtraSlots, spellPos, spellPos, true, Vector2.Zero);
+            PlayAnimation(owner, "Spell2_Cast", timeScale: 0.6f);
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+
+    public class ZedShadowDashMissile : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            // TODO
+        };
+
+        IBuff HandlerBuff;
+        IMinion Shadow;
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+            HandlerBuff = AddBuff("ZedWHandler", 4.0f, 1, spell, owner, owner);
+            AddBuff("ZedW2", 4.0f, 1, spell, owner, owner);
+
+            if (Shadow != null)
+            {
+                var buff = Shadow.GetBuffWithName("ZedWShadowBuff");
+
+                if (buff != null)
+                {
+                    buff.DeactivateBuff();
+                }
+            }
+
+            var missile = spell.CreateSpellMissile(new MissileParameters
+            {
+                Type = MissileType.Circle,
+                OverrideEndPosition = end
+            });
+
+            ApiEventManager.OnSpellMissileEnd.AddListener(this, missile, OnMissileEnd, true);
+        }
+
+        public void OnMissileEnd(ISpellMissile missile)
+        {
+            if (HandlerBuff != null)
+            {
+                Shadow = (HandlerBuff.BuffScript as Buffs.ZedWHandler).ShadowSpawn();
+            }
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+
+    public class ZedW2 : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -87,11 +87,6 @@ namespace GameServerCore.Domain.GameObjects
         /// <returns>True/False.</returns>
         bool GetIsTargetableToTeam(TeamId team);
         /// <summary>
-        /// Sets whether or not this unit should be targetable.
-        /// </summary>
-        /// <param name="targetable">True/False.</param>
-        void SetIsTargetable(bool targetable);
-        /// <summary>
         /// Sets whether or not this unit is targetable to the specified team.
         /// </summary>
         /// <param name="team">TeamId to change.</param>

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -134,8 +134,8 @@ namespace GameServerCore.Domain.GameObjects
         /// <summary>
         /// Called when this unit dies.
         /// </summary>
-        /// <param name="killer">Unit that killed this unit.</param>
-        void Die(IAttackableUnit killer);
+        /// <param name="data">Data of the death.</param>
+        void Die(IDeathData data);
         /// <summary>
         /// Sets this unit's current model to the specified internally named model. *NOTE*: If the model is not present in the client files, all connected players will crash.
         /// </summary>

--- a/GameServerCore/Domain/GameObjects/IBuff.cs
+++ b/GameServerCore/Domain/GameObjects/IBuff.cs
@@ -1,5 +1,6 @@
 ﻿using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Enums;
+using GameServerCore.Scripting.CSharp;
 
 namespace GameServerCore.Domain.GameObjects
 {
@@ -54,6 +55,10 @@ namespace GameServerCore.Domain.GameObjects
         /// Time since this buff's timer started.
         /// </summary>
         float TimeElapsed { get; }
+        /// <summary>
+        /// Script instance for this buff. Casting to a specific buff class gives access its functions and variables.
+        /// </summary>
+        IBuffGameScript BuffScript { get; }
 
         /// <summary>
         /// Used to load the script for the buff.

--- a/GameServerCore/Domain/GameObjects/IChampion.cs
+++ b/GameServerCore/Domain/GameObjects/IChampion.cs
@@ -9,7 +9,6 @@ namespace GameServerCore.Domain.GameObjects
         float RespawnTimer { get; }
         float ChampionGoldFromMinions { get; set; }
         IRuneCollection RuneList { get; }
-        int Skin { get; }
         IChampionStats ChampStats { get; }
         byte SkillPoints { get; set; }
 

--- a/GameServerCore/Domain/GameObjects/IMinion.cs
+++ b/GameServerCore/Domain/GameObjects/IMinion.cs
@@ -1,14 +1,49 @@
-﻿namespace GameServerCore.Domain.GameObjects
+﻿using GameServerCore.Enums;
+
+namespace GameServerCore.Domain.GameObjects
 {
     public interface IMinion : IObjAiBase
     {
-        string Name { get; }
+        /// <summary>
+        /// Unit which spawned this minion.
+        /// </summary>
         IObjAiBase Owner { get; }
-        bool IsWard { get; }
-        bool IsPet { get; }
-        bool IsBot { get; }
-        bool IsLaneMinion { get; }
+        /// <summary>
+        /// Whether or not this minion is considered a clone of its owner.
+        /// </summary>
         bool IsClone { get; }
+        /// <summary>
+        /// Whether or not this minion should ignore collisions.
+        /// </summary>
+        bool IgnoresCollision { get; }
+        /// <summary>
+        /// Whether or not this minion is considered a ward.
+        /// </summary>
+        bool IsWard { get; }
+        /// <summary>
+        /// Whether or not this minion is a LaneMinion.
+        /// </summary>
+        bool IsLaneMinion { get; }
+        /// <summary>
+        /// Whether or not this minion is considered a bot.
+        /// </summary>
+        bool IsBot { get; }
+        /// <summary>
+        /// Whether or not this minion is considered a pet.
+        /// </summary>
+        bool IsPet { get; }
+        /// <summary>
+        /// Whether or not this minion is targetable at all.
+        /// </summary>
+        bool IsTargetable { get; }
+        /// <summary>
+        /// Internal name of the minion.
+        /// </summary>
+        string Name { get; }
+        /// <summary>
+        /// Only unit which is allowed to see this minion.
+        /// </summary>
+        IObjAiBase VisibilityOwner { get; }
 
         void PauseAi(bool pause);
     }

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -26,6 +26,10 @@ namespace GameServerCore.Domain.GameObjects
         /// TODO: Move to AttackableUnit as it relates to stats..
         ICharData CharData { get; }
         /// <summary>
+        /// The ID of the skin this unit should use for its model.
+        /// </summary>
+        public int SkinID { get; }
+        /// <summary>
         /// Whether or not this AI has finished an auto attack.
         /// </summary>
         bool HasAutoAttacked { get; set; }

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -1,6 +1,5 @@
 ﻿using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Enums;
-using LeagueSandbox.GameServer.Content;
 using System.Collections.Generic;
 using System.Numerics;
 

--- a/GameServerCore/Domain/GameObjects/IParticle.cs
+++ b/GameServerCore/Domain/GameObjects/IParticle.cs
@@ -59,6 +59,10 @@ namespace GameServerCore.Domain.GameObjects
         /// Effectively uses the ground height for the end position.
         /// </summary>
         bool FollowsGroundTilt { get; }
+        /// <summary>
+        /// Flags which determine how the particle behaves. Values unknown.
+        /// </summary>
+        FXFlags Flags { get; }
 
         /// <summary>
         /// Returns the total game-time passed since the particle was added to ObjectManager

--- a/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
@@ -114,6 +114,11 @@ namespace GameServerCore.Domain.GameObjects.Spell
         float GetCurrentCastRange();
 
         /// <summary>
+        /// Toggles the auto cast state for this spell.
+        /// </summary>
+        void SetAutocast();
+
+        /// <summary>
         /// Sets the state of the spell to the specified state. Often used when reseting time between spell casts.
         /// </summary>
         /// <param name="state"></param>

--- a/GameServerCore/Domain/GameObjects/Spell/Missile/IMissileParameters.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/Missile/IMissileParameters.cs
@@ -1,4 +1,5 @@
 ﻿using GameServerCore.Enums;
+using System.Numerics;
 
 namespace GameServerCore.Domain.GameObjects.Spell.Missile
 {
@@ -10,5 +11,6 @@ namespace GameServerCore.Domain.GameObjects.Spell.Missile
         int MaximumHits { get; }
 
         MissileType Type { get; }
+        Vector2 OverrideEndPosition { get; }
     }
 }

--- a/GameServerCore/Domain/ICharData.cs
+++ b/GameServerCore/Domain/ICharData.cs
@@ -1,7 +1,6 @@
-﻿using GameServerCore.Domain;
-using GameServerCore.Enums;
+﻿using GameServerCore.Enums;
 
-namespace LeagueSandbox.GameServer.Content
+namespace GameServerCore.Domain
 {
     public interface ICharData
     {

--- a/GameServerCore/Domain/ICharData.cs
+++ b/GameServerCore/Domain/ICharData.cs
@@ -1,4 +1,5 @@
-﻿using GameServerCore.Enums;
+﻿using GameServerCore.Domain;
+using GameServerCore.Enums;
 
 namespace LeagueSandbox.GameServer.Content
 {

--- a/GameServerCore/Domain/IDeathData.cs
+++ b/GameServerCore/Domain/IDeathData.cs
@@ -1,0 +1,38 @@
+﻿using GameServerCore.Domain.GameObjects;
+using GameServerCore.Enums;
+
+namespace GameServerCore.Domain
+{
+    public interface IDeathData
+    {
+        /// <summary>
+        /// Whether or not the death should result in resurrection as a zombie.
+        /// </summary>
+        bool BecomeZombie { get; }
+        /// <summary>
+        /// The type of death. Values unknown.
+        /// </summary>
+        /// TODO: Create an enum for this.
+        byte DieType { get; }
+        /// <summary>
+        /// Unit which is dying.
+        /// </summary>
+        IAttackableUnit Unit { get; }
+        /// <summary>
+        /// Unit which is responsible for the death.
+        /// </summary>
+        IAttackableUnit Killer { get; }
+        /// <summary>
+        /// Type of damage with caused the death.
+        /// </summary>
+        DamageType DamageType { get; }
+        /// <summary>
+        /// Source of the damage which caused the death.
+        /// </summary>
+        DamageSource DamageSource { get; }
+        /// <summary>
+        /// Time until death finishes (fade-out duration?).
+        /// </summary>
+        float DeathDuration { get; }
+    }
+}

--- a/GameServerCore/Domain/IGlobalData.cs
+++ b/GameServerCore/Domain/IGlobalData.cs
@@ -1,4 +1,4 @@
-﻿namespace LeagueSandbox.GameServer.Content
+﻿namespace GameServerCore.Domain
 {
     public interface IGlobalData
     {

--- a/GameServerCore/Domain/IPackage.cs
+++ b/GameServerCore/Domain/IPackage.cs
@@ -1,6 +1,5 @@
 ﻿using GameServerCore.Content;
 using GameServerCore.Domain.GameObjects.Spell;
-using LeagueSandbox.GameServer.Content;
 
 namespace GameServerCore.Domain
 {

--- a/GameServerCore/Domain/IPassiveData.cs
+++ b/GameServerCore/Domain/IPassiveData.cs
@@ -1,4 +1,4 @@
-﻿namespace LeagueSandbox.GameServer.Content
+﻿namespace GameServerCore.Domain
 {
     public interface IPassiveData
     {

--- a/GameServerCore/Enums/FXFlags.cs
+++ b/GameServerCore/Enums/FXFlags.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace GameServerCore.Enums
+{
+    /// <summary>
+    /// Enumerator containing all(?) possible FX flags.
+    /// </summary>
+    /// TODO: Finish labeling enum and verify if there are other possible values.
+    [Flags]
+    public enum FXFlags
+    {
+        /// <summary>
+        /// Particle will face the given direction.
+        /// </summary>
+        GivenDirection = 1 << 4,
+        /// <summary>
+        /// Particle will face the same direction as the object it is bound to.
+        /// </summary>
+        BindDirection = 1 << 5,
+        Unknown3 = GivenDirection + BindDirection,
+        Unknown4 = 1 << 6,
+        /// <summary>
+        /// Particle will face towards its target.
+        /// </summary>
+        TargetDirection = 1 << 7,
+        Unknown6 = BindDirection + TargetDirection,
+        Unknown7 = 1 << 8,
+        Unknown8 = GivenDirection + Unknown7,
+        Unknown9 = BindDirection + TargetDirection + Unknown7,
+        Unknown10 = BindDirection + Unknown4 + TargetDirection + Unknown7
+    }
+}

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -492,6 +492,12 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="s">Spell being cast.</param>
         void NotifyNPC_CastSpellAns(ISpell s);
         /// <summary>
+        /// Sends a packet to all players detailing that the specified unit has been killed by the specified killer.
+        /// </summary>
+        /// <param name="data">Data of the death.</param>
+        /// TODO: Use this. Seems to be often used when the killer = the attacker.
+        void NotifyNPC_Die_Broadcast(IDeathData data);
+        /// <summary>
         /// Sends a packet to all players with vision of the specified AttackableUnit detailing that the attacker has abrubtly stopped their attack (can be a spell or auto attack, although internally AAs are also spells).
         /// </summary>
         /// <param name="attacker">AttackableUnit that stopped their auto attack.</param>
@@ -517,11 +523,22 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="points">New number of points after the upgrade.</param>
         void NotifyNPC_UpgradeSpellAns(int userId, uint netId, byte slot, byte level, byte points);
         /// <summary>
-        /// Sends a packet to all players detailing that the specified AttackableUnit die has died to the specified AttackableUnit killer.
+        /// Sends a packet to all users with vision of the given caster detailing that the given spell has been set to auto cast (as well as the spell in the critSlot) for the given caster.
         /// </summary>
-        /// <param name="unit">AttackableUnit that was killed.</param>
-        /// <param name="killer">AttackableUnit that killed the unit.</param>
-        void NotifyNpcDie(IAttackableUnit unit, IAttackableUnit killer);
+        /// <param name="caster">Unit responsible for the autocasting.</param>
+        /// <param name="spell">Spell to auto cast.</param>
+        /// // TODO: Verify critSlot functionality
+        /// <param name="critSlot">Optional spell slot to cast when a crit is going to occur.</param>
+        void NotifyNPC_SetAutocast(IObjAiBase caster, ISpell spell, byte critSlot = 0);
+        /// <summary>
+        /// Sends a packet to the given user detailing that the given spell has been set to auto cast (as well as the spell in the critSlot) for the given caster.
+        /// </summary>
+        /// <param name="userId">User to send the packet to.</param>
+        /// <param name="caster">Unit responsible for the autocasting.</param>
+        /// <param name="spell">Spell to auto cast.</param>
+        /// // TODO: Verify critSlot functionality
+        /// <param name="critSlot">Optional spell slot to cast when a crit is going to occur.</param>
+        void NotifyNPC_SetAutocast(int userId, IObjAiBase caster, ISpell spell, byte critSlot = 0);
         /// <summary>
         /// Sends a packet to all players detailing that the game has paused.
         /// </summary>
@@ -594,6 +611,11 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="userId">User to send the packet to.</param>
         /// <param name="clientInfo">Information about the client which had their hero created.</param>
         void NotifyS2C_CreateHero(int userId, ClientInfo clientInfo);
+        /// <summary>
+        /// Sends a packet to all players detailing that the specified unit has been killed by the specified killer.
+        /// </summary>
+        /// <param name="data">Data of the death.</param>
+        void NotifyS2C_NPC_Die_MapView(IDeathData data);
         /// <summary>
         /// Sends a packet to all players with vision of the specified object detailing that it is playing the specified animation.
         /// </summary>

--- a/GameServerCore/Scripting/CSharp/ISpellScriptMetadata.cs
+++ b/GameServerCore/Scripting/CSharp/ISpellScriptMetadata.cs
@@ -13,6 +13,11 @@ namespace GameServerCore.Scripting.CSharp
 
         string AutoItemActivateEffect { get; }
 
+        /// <summary>
+        /// Whether or not the caster should automatically face the end position of the spell.
+        /// </summary>
+        bool AutoFaceDirection { get; }
+
         float[] AutoTargetDamageByLevel { get; }
 
         float CastTime { get; }

--- a/GameServerLib/API/ApiEventManager.cs
+++ b/GameServerLib/API/ApiEventManager.cs
@@ -86,6 +86,7 @@ namespace LeagueSandbox.GameServer.API
             OnSpellChannel.RemoveListener(owner);
             OnSpellChannelCancel.RemoveListener(owner);
             OnSpellMissileHit.RemoveListener(owner);
+            OnSpellMissileEnd.RemoveListener(owner);
             OnSpellSectorHit.RemoveListener(owner);
             OnSpellPostCast.RemoveListener(owner);
             OnSpellPostChannel.RemoveListener(owner);
@@ -103,6 +104,7 @@ namespace LeagueSandbox.GameServer.API
         public static EventOnSpellChannel OnSpellChannel = new EventOnSpellChannel();
         public static EventOnSpellChannelCancel OnSpellChannelCancel = new EventOnSpellChannelCancel();
         public static EventOnSpellMissileHit OnSpellMissileHit = new EventOnSpellMissileHit();
+        public static EventOnSpellMissileEnd OnSpellMissileEnd = new EventOnSpellMissileEnd();
         public static EventOnSpellSectorHit OnSpellSectorHit = new EventOnSpellSectorHit();
         public static EventOnSpellPostCast OnSpellPostCast = new EventOnSpellPostCast();
         public static EventOnSpellPostChannel OnSpellPostChannel = new EventOnSpellPostChannel();
@@ -446,6 +448,45 @@ namespace LeagueSandbox.GameServer.API
                 if (_listeners[i].Item2.Key == spell && _listeners[i].Item2.Value == unit)
                 {
                     _listeners[i].Item3(spell, target, p);
+                    if (_listeners[i].Item4 == true)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
+                }
+            }
+        }
+    }
+
+    public class EventOnSpellMissileEnd
+    {
+        private readonly List<Tuple<object, ISpellMissile, Action<ISpellMissile>, bool>> _listeners = new List<Tuple<object, ISpellMissile, Action<ISpellMissile>, bool>>();
+        public void AddListener(object owner, ISpellMissile missile, Action<ISpellMissile> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, ISpellMissile, Action<ISpellMissile>, bool>(owner, missile, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+        public void RemoveListener(object owner, ISpellMissile missile)
+        {
+            _listeners.RemoveAll((listener) => listener.Item1 == owner && listener.Item2 == missile);
+        }
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll((listener) => listener.Item1 == owner);
+        }
+        public void Publish(ISpellMissile m)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == m)
+                {
+                    _listeners[i].Item3(m);
                     if (_listeners[i].Item4 == true)
                     {
                         _listeners.RemoveAt(i);

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -93,10 +93,12 @@ namespace LeagueSandbox.GameServer.API
 
         /// <summary>
         /// Creates a new instance of a GameScriptTimer with the specified arguments.
+        /// This should only be used for debug purposes.
         /// </summary>
         /// <param name="duration">Time till the timer ends.</param>
         /// <param name="callback">Action to perform when the timer ends.</param>
         /// <returns>New GameScriptTimer instance.</returns>
+        [Obsolete("CreateTimer should only be used for debug purposes.")]
         public static GameScriptTimer CreateTimer(float duration, Action callback)
         {
             var newTimer = new GameScriptTimer(duration, callback);

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Enums;
+using GameServerLib.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.Spell;
@@ -283,10 +285,12 @@ namespace LeagueSandbox.GameServer.API
         /// <param name="direction">3D direction the particle should face.</param>
         /// <param name="followGroundTilt">Whether or not the particle should be titled along the ground towards its end position.</param>
         /// <param name="reqVision">Whether or not the particle can be obstructed by terrain.</param>
+        /// <param name="teamOnly">The only team which should be able to see the particle.</param>
+        /// <param name="flags">Flags which determine how the particle behaves. Refer to FXFlags enum.</param>
         /// <returns>New particle instance.</returns>
-        public static IParticle AddParticle(IGameObject caster, IGameObject bindObj, string particle, Vector2 position, float lifetime = 1.0f, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), bool followGroundTilt = false, bool reqVision = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL)
+        public static IParticle AddParticle(IGameObject caster, IGameObject bindObj, string particle, Vector2 position, float lifetime = 1.0f, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), bool followGroundTilt = false, bool reqVision = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL, FXFlags flags = FXFlags.BindDirection)
         {
-            var p = new Particle(_game, caster, bindObj, position, particle, size, bone, targetBone, 0, direction, followGroundTilt, lifetime, reqVision, true, teamOnly);
+            var p = new Particle(_game, caster, bindObj, position, particle, size, bone, targetBone, 0, direction, followGroundTilt, lifetime, reqVision, true, teamOnly, flags);
             return p;
         }
 
@@ -305,10 +309,12 @@ namespace LeagueSandbox.GameServer.API
         /// <param name="direction">3D direction the particle should face.</param>
         /// <param name="followGroundTilt">Whether or not the particle should be titled along the ground towards its end position.</param>
         /// <param name="reqVision">Whether or not the particle can be obstructed by terrain.</param>
+        /// <param name="teamOnly">The only team which should be able to see the particle.</param>
+        /// <param name="flags">Flags which determine how the particle behaves. Refer to FXFlags enum.</param>
         /// <returns>New particle instance.</returns>
-        public static IParticle AddParticleTarget(IGameObject caster, IGameObject bindObj, string particle, IGameObject target, float lifetime = 1.0f, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), bool followGroundTilt = false, bool reqVision = true)
+        public static IParticle AddParticleTarget(IGameObject caster, IGameObject bindObj, string particle, IGameObject target, float lifetime = 1.0f, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), bool followGroundTilt = false, bool reqVision = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL, FXFlags flags = FXFlags.BindDirection)
         {
-            var p = new Particle(_game, caster, bindObj, target, particle, size, bone, targetBone, 0, direction, followGroundTilt, lifetime, reqVision);
+            var p = new Particle(_game, caster, bindObj, target, particle, size, bone, targetBone, 0, direction, followGroundTilt, lifetime, reqVision, true, teamOnly, flags);
             return p;
         }
 
@@ -331,33 +337,35 @@ namespace LeagueSandbox.GameServer.API
         /// <param name="model">Internal name of the model of this minion.</param>
         /// <param name="name">Internal name of the minion.</param>
         /// <param name="position">Position to spawn at.</param>
+        /// <param name="skinId">ID of the skin the minion should use for its model.</param>
+        /// <param name="ignoreCollision">Whether or not the minion should ignore collisions.</param>
+        /// <param name="targetable">Whether or not the minion should be targetable.</param>
+        /// <param name="targetingFlags">Flags determining targetability.</param>
+        /// <param name="visibilityOwner">Specifies the only unit which should be able to see the minion.</param>
         /// <param name="isVisible">Whether or not this minion should be visible.</param>
         /// <param name="aiPaused">Whether or not this minion's AI is inactive.</param>
         /// <returns>New Minion instance.</returns>
-        public static IMinion AddMinion(IObjAiBase owner, string model, string name, Vector2 position, Vector2 facingDirection = new Vector2(), bool isVisible = true, bool aiPaused = true)
+        public static IMinion AddMinion
+        (
+            IObjAiBase owner,
+            string model,
+            string name,
+            Vector2 position,
+            int skinId = 0,
+            bool ignoreCollision = false,
+            bool targetable = true,
+            SpellDataFlags targetingFlags = 0,
+            IObjAiBase visibilityOwner = null,
+            bool isVisible = true,
+            bool aiPaused = true
+        )
         {
-            var m = new Minion(_game, owner, position, model, name, 0, owner.Team);
+            var m = new Minion(_game, owner, position, model, name, 0, owner.Team, skinId, ignoreCollision, targetable, visibilityOwner);
+            m.Stats.IsTargetableToTeam = targetingFlags;
             _game.ObjectManager.AddObject(m);
             m.SetVisibleByTeam(owner.Team, isVisible);
             m.PauseAi(aiPaused);
             return m;
-        }
-
-        /// <summary>
-        /// Creates a new Minion with the specified parameters.
-        /// Minion will spawn at the given target's position.
-        /// </summary>
-        /// <param name="owner">AI unit that owns this minion.</param>
-        /// <param name="model">Internal name of the minion's model.</param>
-        /// <param name="name">Internal name of the minion.</param>
-        /// <param name="target">Target to spawn the minion on.</param>
-        /// <param name="isVisible">Whether or not this minion should be visible.</param>
-        /// <param name="aiPaused">Whether or not this minion's AI is inactive.</param>
-        /// <returns>New Minion instance.</returns>
-        public static IMinion AddMinionTarget(IObjAiBase owner, string model, string name, IGameObject target, bool isVisible = true, bool aiPaused = true)
-        {
-            // TODO: Implement attachable Minions/GameObjects.
-            return AddMinion(owner, model, name, target.Position, isVisible: isVisible, aiPaused: aiPaused);
         }
 
         /// <summary>
@@ -611,6 +619,16 @@ namespace LeagueSandbox.GameServer.API
             unit.SetAnimStates(animPairs);
         }
 
+        /// <summary>
+        /// Toggles the visual auto cast indicator for the given spell.
+        /// </summary>
+        /// <param name="spell">Spell to auto cast.</param>
+        /// TODO: Verify if this works.
+        public static void SetAutocast(ISpell spell)
+        {
+            spell.SetAutocast();
+        }
+
         public static void SetStatus(IAttackableUnit unit, StatusFlags status, bool enabled)
         {
             unit.SetStatus(status, enabled);
@@ -757,6 +775,31 @@ namespace LeagueSandbox.GameServer.API
         public static void StopChanneling(IObjAiBase target, ChannelingStopCondition stopCondition, ChannelingStopSource stopSource)
         {
             target.StopChanneling(stopCondition, stopSource);
+        }
+
+        /// <summary>
+        /// Creates a DeathData variable for use with the IAttackableUnit.Die() function.
+        /// </summary>
+        /// <param name="zombify">Whether or not the unit should become a zombie after death.</param>
+        /// <param name="deathType">Type of death. Values unknown.</param>
+        /// <param name="unit">Unit that died.</param>
+        /// <param name="killer">Killer of the unit.</param>
+        /// <param name="dmgType">Type of damage that caused the death.</param>
+        /// <param name="dmgSource">Source of the damage that caused the death.</param>
+        /// <param name="duration">Time until the death completes (fade-out?).</param>
+        /// <returns></returns>
+        public static IDeathData CreateDeathData(bool zombify, byte deathType, IAttackableUnit unit, IAttackableUnit killer, DamageType dmgType, DamageSource dmgSource, float duration)
+        {
+            return new DeathData
+            {
+                BecomeZombie = zombify,
+                DieType = deathType,
+                Unit = unit,
+                Killer = killer,
+                DamageType = dmgType,
+                DamageSource = dmgSource,
+                DeathDuration = duration
+            };
         }
     }
 }

--- a/GameServerLib/Chatbox/Commands/KillCommand.cs
+++ b/GameServerLib/Chatbox/Commands/KillCommand.cs
@@ -1,4 +1,6 @@
 ﻿using GameServerCore;
+using GameServerCore.Enums;
+using GameServerLib.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 
 namespace LeagueSandbox.GameServer.Chatbox.Commands
@@ -32,7 +34,16 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                 {
                     if (o.Value is Minion minion)
                     {
-                        minion.Die(_playerManager.GetPeerInfo(userId).Champion); // :(
+                        minion.Die(new DeathData
+                        {
+                            BecomeZombie = false,
+                            DieType = 0,
+                            Unit = minion,
+                            Killer = minion,
+                            DamageType = (byte)DamageType.DAMAGE_TYPE_PHYSICAL,
+                            DamageSource = (byte)DamageSource.DAMAGE_SOURCE_RAW,
+                            DeathDuration = 0
+                        }); // :(
                     }
                 }
             }

--- a/GameServerLib/Chatbox/Commands/TargetableCommand.cs
+++ b/GameServerLib/Chatbox/Commands/TargetableCommand.cs
@@ -25,7 +25,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             }
             else
             {
-                _playerManager.GetPeerInfo(userId).Champion.SetIsTargetable(userInput);
+                _playerManager.GetPeerInfo(userId).Champion.SetStatus(GameServerCore.Enums.StatusFlags.Targetable, userInput);
             }
         }
     }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
@@ -69,7 +69,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             foreach (var u in units)
             {
-                if (u.IsDead || u.Team == Team)
+                if (u.IsDead || u.Team == Team || !u.Status.HasFlag(StatusFlags.Targetable))
                 {
                     continue;
                 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
@@ -1,6 +1,7 @@
 ﻿using System.Numerics;
 using System.Text;
 using Force.Crc32;
+using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects.Stats;
@@ -43,8 +44,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             TeamId team = TeamId.TEAM_BLUE,
             uint netId = 0,
             LaneID lane = LaneID.NONE,
-            MapData.MapObject mapObject = null
-        ) : base(game, model, new Stats.Stats(), 88, position, 1200, netId, team)
+            MapData.MapObject mapObject = null,
+            int skinId = 0
+        ) : base(game, model, new Stats.Stats(), 88, position, 1200, skinId, netId, team)
         {
             ParentNetId = Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000;
             Name = name;
@@ -119,9 +121,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// Called when this unit dies.
         /// </summary>
         /// <param name="killer">Unit that killed this unit.</param>
-        public override void Die(IAttackableUnit killer)
+        public override void Die(IDeathData data)
         {
-            foreach (var player in _game.ObjectManager.GetAllChampionsFromTeam(killer.Team))
+            foreach (var player in _game.ObjectManager.GetAllChampionsFromTeam(data.Killer.Team))
             {
                 var goldEarn = _globalGold;
 
@@ -140,8 +142,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 _game.PacketNotifier.NotifyAddGold(player, this, goldEarn);
             }
 
-            _game.PacketNotifier.NotifyUnitAnnounceEvent(UnitAnnounces.TURRET_DESTROYED, this, killer);
-            base.Die(killer);
+            _game.PacketNotifier.NotifyUnitAnnounceEvent(UnitAnnounces.TURRET_DESTROYED, this, data.Killer);
+            base.Die(data);
         }
 
         /// <summary>
@@ -200,7 +202,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
 
             base.Update(diff);
-            Replication.Update();
         }
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -20,7 +20,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public IChampionStats ChampStats { get; private set; } = new ChampionStats();
 
         public byte SkillPoints { get; set; }
-        public int Skin { get; set; }
 
         private float _championHitFlagTimer;
         /// <summary>
@@ -42,7 +41,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                         ClientInfo clientInfo,
                         uint netId = 0,
                         TeamId team = TeamId.TEAM_BLUE)
-            : base(game, model, new Stats.Stats(), 30, new Vector2(), 1200, netId, team)
+            : base(game, model, new Stats.Stats(), 30, new Vector2(), 1200, clientInfo.SkinNo, netId, team)
         {
             _playerId = playerId;
             _playerTeamSpecialId = playerTeamSpecialId;
@@ -206,7 +205,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     _championHitFlagTimer = 0;
                 }
             }
-            Replication.Update();
         }
 
         public void Respawn()
@@ -288,14 +286,14 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
         }
 
-        public override void Die(IAttackableUnit killer)
+        public override void Die(IDeathData data)
         {
             RespawnTimer = _game.Config.MapData.DeathTimes[Stats.Level] * 1000.0f;
             ChampStats.Deaths += 1;
 
-            _game.PacketNotifier.NotifyUnitAnnounceEvent(UnitAnnounces.DEATH, this, killer);
+            _game.PacketNotifier.NotifyUnitAnnounceEvent(UnitAnnounces.DEATH, this, data.Killer);
 
-            var cKiller = killer as IChampion;
+            var cKiller = data.Killer as IChampion;
 
             if (cKiller == null && _championHitFlagTimer > 0)
             {
@@ -305,7 +303,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             if (cKiller == null)
             {
-                _game.PacketNotifier.NotifyChampionDie(this, killer, 0);
+                _game.PacketNotifier.NotifyChampionDie(this, data.Killer, 0);
                 return;
             }
 
@@ -367,7 +365,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
         public void UpdateSkin(int skinNo)
         {
-            Skin = skinNo;
+            SkinID = skinNo;
         }
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
@@ -143,7 +143,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         // AI tasks
         protected bool ScanForTargets()
         {
-            if(TargetUnit != null && !TargetUnit.IsDead)
+            if (TargetUnit != null && !TargetUnit.IsDead)
             {
                 return true;
             }
@@ -158,7 +158,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     u.IsDead ||
                     u.Team == Team ||
                     Vector2.DistanceSquared(Position, u.Position) > DETECT_RANGE * DETECT_RANGE ||
-                    !_game.ObjectManager.TeamHasVisionOn(Team, u))
+                    !_game.ObjectManager.TeamHasVisionOn(Team, u)
+                    || !u.Status.HasFlag(StatusFlags.Targetable))
                 {
                     continue;
                 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
@@ -9,14 +9,48 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 {
     public class Minion : ObjAiBase, IMinion
     {
-        public string Name { get; protected set; }
-        public IObjAiBase Owner { get; } // We'll probably want to change this in the future
-        public bool IsWard { get; protected set; }
-        public bool IsPet { get; protected set; }
-        public bool IsBot { get; protected set; }
-        public bool IsLaneMinion { get; protected set; }
-        public bool IsClone { get; protected set; }
         protected bool _aiPaused;
+
+        /// <summary>
+        /// Unit which spawned this minion.
+        /// </summary>
+        public IObjAiBase Owner { get; }
+        /// <summary>
+        /// Whether or not this minion is considered a clone of its owner.
+        /// </summary>
+        public bool IsClone { get; protected set; }
+        /// <summary>
+        /// Whether or not this minion should ignore collisions.
+        /// </summary>
+        public bool IgnoresCollision { get; protected set; }
+        /// <summary>
+        /// Whether or not this minion is considered a ward.
+        /// </summary>
+        public bool IsWard { get; protected set; }
+        /// <summary>
+        /// Whether or not this minion is a LaneMinion.
+        /// </summary>
+        public bool IsLaneMinion { get; protected set; }
+        /// <summary>
+        /// Whether or not this minion is considered a bot.
+        /// </summary>
+        public bool IsBot { get; protected set; }
+        /// <summary>
+        /// Whether or not this minion is considered a pet.
+        /// </summary>
+        public bool IsPet { get; protected set; }
+        /// <summary>
+        /// Whether or not this minion is targetable at all.
+        /// </summary>
+        public bool IsTargetable { get; protected set; }
+        /// <summary>
+        /// Internal name of the minion.
+        /// </summary>
+        public string Name { get; protected set; }
+        /// <summary>
+        /// Only unit which is allowed to see this minion.
+        /// </summary>
+        public IObjAiBase VisibilityOwner { get; }
 
         public Minion(
             Game game,
@@ -25,8 +59,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             string model,
             string name,
             uint netId = 0,
-            TeamId team = TeamId.TEAM_NEUTRAL
-        ) : base(game, model, new Stats.Stats(), 40, position, 1100, netId, team)
+            TeamId team = TeamId.TEAM_NEUTRAL,
+            int skinId = 0,
+            bool ignoreCollision = false,
+            bool targetable = true,
+            IObjAiBase visibilityOwner = null
+        ) : base(game, model, new Stats.Stats(), 40, position, 1100, skinId, netId, team)
         {
             Name = name;
 
@@ -43,6 +81,19 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
 
             IsLaneMinion = false;
+            IgnoresCollision = ignoreCollision;
+            if (IgnoresCollision)
+            {
+                SetStatus(StatusFlags.Ghosted, true);
+            }
+
+            IsTargetable = targetable;
+            if (!IsTargetable)
+            {
+                SetStatus(StatusFlags.Targetable, false);
+            }
+
+            VisibilityOwner = visibilityOwner;
 
             SetVisibleByTeam(Team, true);
 
@@ -69,13 +120,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             {
                 if (MovementParameters != null || _aiPaused)
                 {
-                    Replication.Update();
                     return;
                 }
 
                 AIMove();
             }
-            Replication.Update();
         }
 
         public virtual bool AIMove()

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -39,6 +39,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// </summary>
         /// TODO: Move to AttackableUnit as it relates to stats.
         public ICharData CharData { get; }
+        /// <summary>
+        /// The ID of the skin this unit should use for its model.
+        /// </summary>
+        public int SkinID { get; set; }
         public bool HasAutoAttacked { get; set; }
         /// <summary>
         /// Whether or not this AI has made their first auto attack against their current target. Refreshes after untargeting or targeting another unit.
@@ -75,12 +79,14 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public Dictionary<short, ISpell> Spells { get; }
 
         public ObjAiBase(Game game, string model, Stats.Stats stats, int collisionRadius = 40,
-            Vector2 position = new Vector2(), int visionRadius = 0, uint netId = 0, TeamId team = TeamId.TEAM_NEUTRAL) :
+            Vector2 position = new Vector2(), int visionRadius = 0, int skinId = 0, uint netId = 0, TeamId team = TeamId.TEAM_NEUTRAL) :
             base(game, model, stats, collisionRadius, position, visionRadius, netId, team)
         {
             _itemManager = game.ItemManager;
 
             CharData = _game.Config.ContentManager.GetCharData(Model);
+
+            SkinID = skinId;
 
             stats.LoadStats(CharData);
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -812,6 +812,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// TODO: Remove Target class.
         public void SetTargetUnit(IAttackableUnit target, bool networked = false)
         {
+            if (target == null || target.IsDead || !target.Status.HasFlag(StatusFlags.Targetable))
+            {
+                target = null;
+            }
+
             TargetUnit = target;
 
             if (networked)
@@ -1009,6 +1014,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 else
                 {
                     // Acquires the closest target.
+                    // TODO: Make a function which uses this method and use it for every case of target acquisition (ex minions, turrets, attackmove).
                     if (MoveOrder == OrderType.AttackMove)
                     {
                         var objects = _game.ObjectManager.GetObjects();
@@ -1021,11 +1027,17 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                             if (!(it.Value is IAttackableUnit u) ||
                                 u.IsDead ||
                                 u.Team == Team ||
-                                Vector2.DistanceSquared(Position, u.Position) > range * range)
+                                Vector2.DistanceSquared(Position, u.Position) > range * range ||
+                                !u.Status.HasFlag(StatusFlags.Targetable))
+                            {
                                 continue;
+                            }
 
                             if (!(Vector2.DistanceSquared(Position, u.Position) < distanceSqrToTarget))
+                            {
                                 continue;
+                            }
+
                             distanceSqrToTarget = Vector2.DistanceSquared(Position, u.Position);
                             nextTarget = u;
                         }

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -298,7 +298,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// <returns>True/False.</returns>
         public bool GetIsTargetableToTeam(TeamId team)
         {
-            if (Status.HasFlag(StatusFlags.Targetable))
+            if (!Status.HasFlag(StatusFlags.Targetable))
             {
                 return false;
             }

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -124,7 +124,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             Model = model;
             Waypoints = new List<Vector2> { Position };
             CurrentWaypoint = new KeyValuePair<int, Vector2>(1, Position);
-            Status = StatusFlags.CanAttack | StatusFlags.CanCast | StatusFlags.CanMove | StatusFlags.CanMoveEver;
+            Status = StatusFlags.CanAttack | StatusFlags.CanCast | StatusFlags.CanMove | StatusFlags.CanMoveEver | StatusFlags.Targetable;
             MovementParameters = null;
             Stats.AttackSpeedMultiplier.BaseValue = 1.0f;
 
@@ -298,7 +298,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// <returns>True/False.</returns>
         public bool GetIsTargetableToTeam(TeamId team)
         {
-            if (!Stats.IsTargetable)
+            if (Status.HasFlag(StatusFlags.Targetable))
             {
                 return false;
             }
@@ -309,16 +309,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
 
             return !Stats.IsTargetableToTeam.HasFlag(SpellDataFlags.NonTargetableEnemy);
-        }
-
-        /// <summary>
-        /// Sets whether or not this unit should be targetable.
-        /// </summary>
-        /// <param name="targetable">True/False.</param>
-        public void SetIsTargetable(bool targetable)
-        {
-            Stats.IsTargetable = targetable;
-            SetStatus(StatusFlags.Targetable, false);
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -9,6 +9,7 @@ using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Domain.GameObjects.Spell.Sector;
 using GameServerCore.Enums;
+using GameServerLib.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.Logging;
 using log4net;
@@ -24,6 +25,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         // Crucial Vars.
         private float _statUpdateTimer;
         private object _buffsLock;
+        private IDeathData _death;
 
         // Utility Vars.
         internal const float DETECT_RANGE = 475.0f;
@@ -150,13 +152,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             if (this is IChampion c)
             {
                 var szSkin = "";
-                if (c.Skin < 10)
+                if (c.SkinID < 10)
                 {
-                    szSkin = "0" + c.Skin;
+                    szSkin = "0" + c.SkinID;
                 }
                 else
                 {
-                    szSkin = c.Skin.ToString();
+                    szSkin = c.SkinID.ToString();
                 }
                 gobj += szSkin;
             }
@@ -207,6 +209,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             var onUpdate = _game.ScriptEngine.GetStaticMethod<Action<IAttackableUnit, double>>(Model, "Passive", "OnUpdate");
             onUpdate?.Invoke(this, diff);
 
+            Replication.Update();
+
             if (Waypoints.Count > 1)
             {
                 Move(diff);
@@ -225,6 +229,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 {
                     SetDashingState(false);
                 }
+            }
+
+            if (IsDead && _death != null)
+            {
+                Die(_death);
+                _death = null;
             }
         }
 
@@ -264,6 +274,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
             else
             {
+                if (collider is IAttackableUnit unit && unit.Status.HasFlag(StatusFlags.Ghosted)
+                    || Status.HasFlag(StatusFlags.Ghosted))
+                {
+                    return;
+                }
+
                 // TODO: Replace this with event listener publishing.
                 var onCollide = _game.ScriptEngine.GetStaticMethod<Action<IAttackableUnit, IGameObject>>(Model, "Passive", "onCollide");
                 onCollide?.Invoke(this, collider);
@@ -302,6 +318,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public void SetIsTargetable(bool targetable)
         {
             Stats.IsTargetable = targetable;
+            SetStatus(StatusFlags.Targetable, false);
         }
 
         /// <summary>
@@ -436,7 +453,16 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             if (!IsDead && Stats.CurrentHealth <= 0)
             {
                 IsDead = true;
-                Die(attacker);
+                _death = new DeathData
+                {
+                    BecomeZombie = false, // TODO: Unhardcode
+                    DieType = 0, // TODO: Unhardcode
+                    Unit = this,
+                    Killer = attacker,
+                    DamageType = type,
+                    DamageSource = source,
+                    DeathDuration = 0 // TODO: Unhardcode
+                };
             }
 
             int attackerId = 0, targetId = 0;
@@ -457,8 +483,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 attackerId = (int)_game.PlayerManager.GetClientInfoByChampion((IChampion)attackerMinion.Owner).PlayerId;
             }
 
-            _game.PacketNotifier.NotifyUnitApplyDamage(attacker, this, damage, type, damageText,
-                _game.Config.IsDamageTextGlobal, attackerId, targetId);
+            if (attacker.Team != Team)
+            {
+                _game.PacketNotifier.NotifyUnitApplyDamage(attacker, this, damage, type, damageText,
+                    _game.Config.IsDamageTextGlobal, attackerId, targetId);
+            }
 
             // TODO: send this in one place only
             _game.PacketNotifier.NotifyUpdatedStats(this, false);
@@ -506,20 +535,20 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// <summary>
         /// Function called when this unit's health drops to 0 or less.
         /// </summary>
-        /// <param name="killer">Unit which killed this unit.</param>
-        public virtual void Die(IAttackableUnit killer)
+        /// <param name="data">Data of the death.</param>
+        public virtual void Die(IDeathData data)
         {
             _game.ObjectManager.StopTargeting(this);
 
             if (!IsToRemove())
             {
-                _game.PacketNotifier.NotifyNpcDie(this, killer);
+                _game.PacketNotifier.NotifyS2C_NPC_Die_MapView(data);
             }
 
             SetToRemove();
 
             var onDie = _game.ScriptEngine.GetStaticMethod<Action<IAttackableUnit, IAttackableUnit>>(Model, "Passive", "OnDie");
-            onDie?.Invoke(this, killer);
+            onDie?.Invoke(this, data.Killer);
 
             var exp = _game.Map.MapProperties.GetExperienceFor(this);
             var champs = _game.ObjectManager.GetChampionsInRange(Position, EXP_RANGE, true);
@@ -536,7 +565,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 }
             }
 
-            if (killer != null && killer is IChampion champion)
+            if (data.Killer != null && data.Killer is IChampion champion)
                 champion.OnKill(this);
         }
 
@@ -1268,6 +1297,106 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             else
             {
                 Status &= ~status;
+            }
+
+            switch (status)
+            {
+                case StatusFlags.CanAttack:
+                {
+                    Stats.SetActionState(ActionState.CAN_ATTACK, enabled);
+                    return;
+                }
+                case StatusFlags.CanCast:
+                {
+                    Stats.SetActionState(ActionState.CAN_CAST, enabled);
+                    return;
+                }
+                case StatusFlags.CanMove:
+                {
+                    Stats.SetActionState(ActionState.CAN_MOVE, enabled);
+                    return;
+                }
+                case StatusFlags.CanMoveEver:
+                {
+                    Stats.SetActionState(ActionState.CAN_NOT_MOVE, !enabled);
+                    return;
+                }
+                case StatusFlags.Stealthed:
+                {
+                    Stats.SetActionState(ActionState.STEALTHED, enabled);
+                    return;
+                }
+                case StatusFlags.RevealSpecificUnit:
+                {
+                    Stats.SetActionState(ActionState.REVEAL_SPECIFIC_UNIT, enabled);
+                    return;
+                }
+                case StatusFlags.Taunted:
+                {
+                    Stats.SetActionState(ActionState.TAUNTED, enabled);
+                    return;
+                }
+                case StatusFlags.Feared:
+                {
+                    Stats.SetActionState(ActionState.FEARED, enabled);
+                    // TODO: Verify
+                    Stats.SetActionState(ActionState.IS_FLEEING, enabled);
+                    return;
+                }
+                case StatusFlags.Sleep:
+                {
+                    Stats.SetActionState(ActionState.IS_ASLEEP, enabled);
+                    return;
+                }
+                case StatusFlags.NearSighted:
+                {
+                    Stats.SetActionState(ActionState.IS_NEAR_SIGHTED, enabled);
+                    return;
+                }
+                case StatusFlags.Ghosted:
+                {
+                    Stats.SetActionState(ActionState.IS_GHOSTED, enabled);
+                    return;
+                }
+                case StatusFlags.Charmed:
+                {
+                    Stats.SetActionState(ActionState.CHARMED, enabled);
+                    return;
+                }
+                case StatusFlags.NoRender:
+                {
+                    Stats.SetActionState(ActionState.NO_RENDER, enabled);
+                    return;
+                }
+                case StatusFlags.ForceRenderParticles:
+                {
+                    Stats.SetActionState(ActionState.FORCE_RENDER_PARTICLES, enabled);
+                    return;
+                }
+                case StatusFlags.Targetable:
+                {
+                    Stats.IsTargetable = enabled;
+                    // TODO: Verify.
+                    Stats.SetActionState(ActionState.UNKNOWN, enabled);
+                    return;
+                }    
+            }
+
+            if (!(Status.HasFlag(StatusFlags.CanAttack)
+                    && !Status.HasFlag(StatusFlags.Charmed)
+                    && !Status.HasFlag(StatusFlags.Disarmed)
+                    && !Status.HasFlag(StatusFlags.Feared)
+                    // TODO: Verify
+                    && !Status.HasFlag(StatusFlags.Pacified)
+                    && !Status.HasFlag(StatusFlags.Sleep)
+                    && !Status.HasFlag(StatusFlags.Stunned)
+                    && !Status.HasFlag(StatusFlags.Suppressed)))
+            {
+                Stats.SetActionState(ActionState.CAN_NOT_ATTACK, true);
+            }
+            else if (Stats.GetActionState(ActionState.CAN_NOT_ATTACK))
+            {
+                Stats.SetActionState(ActionState.CAN_NOT_ATTACK, false);
             }
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Inhibitor.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Inhibitor.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Numerics;
 using System.Timers;
+using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
-using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 
 namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.AnimatedBuildings
 {
@@ -42,7 +42,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.Animate
             _game.ObjectManager.AddInhibitor(this);
         }
 
-        public override void Die(IAttackableUnit killer)
+        public override void Die(IDeathData data)
         {
             var objects = _game.ObjectManager.GetObjects().Values;
             foreach (var obj in objects)
@@ -66,16 +66,16 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.Animate
             _respawnTimer.Start();
             _timerStartTime = DateTime.Now;
 
-            if (killer is IChampion c)
+            if (data.Killer is IChampion c)
             {
                 c.Stats.Gold += GOLD_WORTH;
                 _game.PacketNotifier.NotifyAddGold(c, this, GOLD_WORTH);
             }
 
-            SetState(InhibitorState.DEAD, killer);
+            SetState(InhibitorState.DEAD, data.Killer);
             RespawnAnnounced = false;
 
-            base.Die(killer);
+            base.Die(data);
         }
 
         public void SetState(InhibitorState state, IGameObject killer = null)

--- a/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Nexus.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Nexus.cs
@@ -1,4 +1,5 @@
-﻿using GameServerCore.Domain.GameObjects;
+﻿using GameServerCore.Domain;
+using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using System.Numerics;
 
@@ -20,7 +21,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.Animate
             Stats.HealthPoints.BaseValue = 5500;
         }
 
-        public override void Die(IAttackableUnit killer)
+        public override void Die(IDeathData data)
         {
             //On SR the Z value was hardcoded to 188 for blue, 110 Purple, but it seemed fine with for both sides with only 110
             //Double check from where those values came from and if they're accurate.

--- a/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/ObjAnimatedBuilding.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/ObjAnimatedBuilding.cs
@@ -18,7 +18,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.Animate
         public override void Update(float diff)
         {
             base.Update(diff);
-            Replication.Update();
         }
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/DeathData.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/DeathData.cs
@@ -1,0 +1,39 @@
+﻿using GameServerCore.Domain;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Enums;
+
+namespace GameServerLib.GameObjects.AttackableUnits
+{
+    class DeathData : IDeathData
+    {
+        /// <summary>
+        /// Whether or not the death should result in resurrection as a zombie.
+        /// </summary>
+        public bool BecomeZombie { get; set; }
+        /// <summary>
+        /// The type of death. Values unknown.
+        /// </summary>
+        /// TODO: Create an enum for this.
+        public byte DieType { get; set; }
+        /// <summary>
+        /// Unit which is dying.
+        /// </summary>
+        public IAttackableUnit Unit { get; set; }
+        /// <summary>
+        /// Unit which is responsible for the death.
+        /// </summary>
+        public IAttackableUnit Killer { get; set; }
+        /// <summary>
+        /// Type of damage with caused the death.
+        /// </summary>
+        public DamageType DamageType { get; set; }
+        /// <summary>
+        /// Source of the damage which caused the death.
+        /// </summary>
+        public DamageSource DamageSource { get; set; }
+        /// <summary>
+        /// Time until death finishes (fade-out duration?).
+        /// </summary>
+        public float DeathDuration { get; set; }
+    }
+}

--- a/GameServerLib/GameObjects/Buff.cs
+++ b/GameServerLib/GameObjects/Buff.cs
@@ -92,9 +92,9 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         public void ActivateBuff()
         {
-            BuffScript.OnActivate(TargetUnit, this, OriginSpell);
-
             _remove = false;
+
+            BuffScript.OnActivate(TargetUnit, this, OriginSpell);
         }
 
         public void DeactivateBuff()

--- a/GameServerLib/GameObjects/Buff.cs
+++ b/GameServerLib/GameObjects/Buff.cs
@@ -15,7 +15,6 @@ namespace LeagueSandbox.GameServer.GameObjects
         // Crucial Vars.
         private readonly Game _game;
         private readonly CSharpScriptEngine _scriptEngine;
-        private IBuffGameScript _buffGameScript;
 
         // Function Vars.
         private readonly bool _infiniteDuration;
@@ -31,6 +30,10 @@ namespace LeagueSandbox.GameServer.GameObjects
         public IObjAiBase SourceUnit { get; }
         public IAttackableUnit TargetUnit { get; }
         public float TimeElapsed { get; private set; }
+        /// <summary>
+        /// Script instance for this buff. Casting to a specific buff class gives access its functions and variables.
+        /// </summary>
+        public IBuffGameScript BuffScript { get; private set; }
 
         public Buff(Game game, string buffName, float duration, int stacks, ISpell originSpell, IAttackableUnit onto, IObjAiBase from, bool infiniteDuration = false)
         {
@@ -47,22 +50,22 @@ namespace LeagueSandbox.GameServer.GameObjects
 
             LoadScript();
 
-            BuffAddType = _buffGameScript.BuffAddType;
-            if (BuffAddType == (BuffAddType.STACKS_AND_RENEWS | BuffAddType.STACKS_AND_CONTINUE | BuffAddType.STACKS_AND_OVERLAPS) && _buffGameScript.MaxStacks < 2)
+            BuffAddType = BuffScript.BuffAddType;
+            if (BuffAddType == (BuffAddType.STACKS_AND_RENEWS | BuffAddType.STACKS_AND_CONTINUE | BuffAddType.STACKS_AND_OVERLAPS) && BuffScript.MaxStacks < 2)
             {
                 throw new ArgumentException("Error: Tried to create Stackable Buff, but MaxStacks was less than 2.");
             }
 
-            BuffType = _buffGameScript.BuffType;
+            BuffType = BuffScript.BuffType;
             Duration = duration;
-            IsHidden = _buffGameScript.IsHidden;
-            if (_buffGameScript.MaxStacks > 254 && BuffType != BuffType.COUNTER)
+            IsHidden = BuffScript.IsHidden;
+            if (BuffScript.MaxStacks > 254 && BuffType != BuffType.COUNTER)
             {
                 MaxStacks = 254;
             }
             else
             {
-                MaxStacks = Math.Min(_buffGameScript.MaxStacks, int.MaxValue);
+                MaxStacks = Math.Min(BuffScript.MaxStacks, int.MaxValue);
             }
             OriginSpell = originSpell;
             if (onto.HasBuff(Name) && BuffAddType == BuffAddType.STACKS_AND_OVERLAPS)
@@ -83,13 +86,13 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         public void LoadScript()
         {
-            ApiEventManager.RemoveAllListenersForOwner(_buffGameScript);
-            _buffGameScript = _scriptEngine.CreateObject<IBuffGameScript>(Name, Name);
+            ApiEventManager.RemoveAllListenersForOwner(BuffScript);
+            BuffScript = _scriptEngine.CreateObject<IBuffGameScript>("Buffs", Name) ?? new BuffScriptEmpty();
         }
 
         public void ActivateBuff()
         {
-            _buffGameScript.OnActivate(TargetUnit, this, OriginSpell);
+            BuffScript.OnActivate(TargetUnit, this, OriginSpell);
 
             _remove = false;
         }
@@ -102,11 +105,11 @@ namespace LeagueSandbox.GameServer.GameObjects
             }
             _remove = true; // To prevent infinite loop with OnDeactivate calling events
 
-            _buffGameScript.OnDeactivate(TargetUnit, this, OriginSpell);
+            BuffScript.OnDeactivate(TargetUnit, this, OriginSpell);
 
-            if (_buffGameScript.StatsModifier != null)
+            if (BuffScript.StatsModifier != null)
             {
-                TargetUnit.RemoveStatModifier(_buffGameScript.StatsModifier);
+                TargetUnit.RemoveStatModifier(BuffScript.StatsModifier);
             }
         }
 
@@ -117,7 +120,7 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         public IStatsModifier GetStatsModifier()
         {
-            return _buffGameScript.StatsModifier;
+            return BuffScript.StatsModifier;
         }
 
         public bool IsBuffInfinite()
@@ -150,7 +153,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             TimeElapsed += diff / 1000.0f;
             if (Math.Abs(Duration) > Extensions.COMPARE_EPSILON)
             {
-                _buffGameScript?.OnUpdate(diff);
+                BuffScript?.OnUpdate(diff);
                 if (TimeElapsed >= Duration)
                 {
                     DeactivateBuff();

--- a/GameServerLib/GameObjects/Particle.cs
+++ b/GameServerLib/GameObjects/Particle.cs
@@ -65,6 +65,10 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// Effectively uses the ground height for the end position.
         /// </summary>
         public bool FollowsGroundTilt { get; }
+        /// <summary>
+        /// Flags which determine how the particle behaves. Values unknown.
+        /// </summary>
+        public FXFlags Flags { get; }
 
         /// <summary>
         /// Prepares the Particle, setting up the information required for networking it to clients.
@@ -85,7 +89,8 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="reqVision">Whether or not the Particle is affected by vision checks.</param>
         /// <param name="autoSend">Whether or not to automatically send the Particle packet to clients.</param>
         /// <param name="teamOnly">The only team that should be able to see this particle.</param>
-        public Particle(Game game, IGameObject caster, IGameObject bindObj, IGameObject target, string particleName, float scale = 1.0f, string boneName = "", string targetBoneName = "", uint netId = 0, Vector3 direction = new Vector3(), bool followGroundTilt = false, float lifetime = 0, bool reqVision = true, bool autoSend = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL)
+        /// <param name="flags">Flags which determine how the particle behaves. Refer to FXFlags enum.</param>
+        public Particle(Game game, IGameObject caster, IGameObject bindObj, IGameObject target, string particleName, float scale = 1.0f, string boneName = "", string targetBoneName = "", uint netId = 0, Vector3 direction = new Vector3(), bool followGroundTilt = false, float lifetime = 0, bool reqVision = true, bool autoSend = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL, FXFlags flags = FXFlags.GivenDirection)
                : base(game, target.Position, 0, 0, netId)
         {
             Caster = caster;
@@ -101,6 +106,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             VisionAffected = reqVision;
             SpecificTeam = teamOnly;
             FollowsGroundTilt = followGroundTilt;
+            Flags = flags;
 
             _game.ObjectManager.AddObject(this);
 
@@ -129,7 +135,8 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="reqVision">Whether or not the Particle is affected by vision checks.</param>
         /// <param name="autoSend">Whether or not to automatically send the Particle packet to clients.</param>
         /// <param name="teamOnly">The only team that should be able to see this particle.</param>
-        public Particle(Game game, IGameObject caster, IGameObject bindObj, Vector2 targetPos, string particleName, float scale = 1.0f, string boneName = "", string targetBoneName = "", uint netId = 0, Vector3 direction = new Vector3(), bool followGroundTilt = false, float lifetime = 0, bool reqVision = true, bool autoSend = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL)
+        /// <param name="flags">Flags which determine how the particle behaves. Refer to FXFlags enum.</param>
+        public Particle(Game game, IGameObject caster, IGameObject bindObj, Vector2 targetPos, string particleName, float scale = 1.0f, string boneName = "", string targetBoneName = "", uint netId = 0, Vector3 direction = new Vector3(), bool followGroundTilt = false, float lifetime = 0, bool reqVision = true, bool autoSend = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL, FXFlags flags = FXFlags.GivenDirection)
                : base(game, targetPos, 0, 0, netId, teamOnly)
         {
             Caster = caster;
@@ -151,6 +158,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             VisionAffected = reqVision;
             SpecificTeam = teamOnly;
             FollowsGroundTilt = followGroundTilt;
+            Flags = flags;
 
             _game.ObjectManager.AddObject(this);
 

--- a/GameServerLib/GameObjects/Spell/Missile/SpellCircleMissile.cs
+++ b/GameServerLib/GameObjects/Spell/Missile/SpellCircleMissile.cs
@@ -32,10 +32,11 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Missile
             ISpell originSpell,
             ICastInfo castInfo,
             float moveSpeed,
+            Vector2 overrideEndPos,
             SpellDataFlags overrideFlags = 0, // TODO: Find a use for these
             uint netId = 0,
             bool serverOnly = false
-        ) : base(game, collisionRadius, originSpell, castInfo, moveSpeed,  overrideFlags, netId, serverOnly)
+        ) : base(game, collisionRadius, originSpell, castInfo, moveSpeed, overrideFlags, netId, serverOnly)
         {
             // TODO: Verify if there is a case which contradicts this.
             // Line and Circle Missiles are location targeted only.
@@ -63,7 +64,11 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Missile
                 CastInfo.TargetPositionEnd = new Vector3(endPos.X, 0, endPos.Y);
             }
 
-            // TODO: Verify if CastRangeDisplayOverride is the correct variable to use.
+            if (overrideEndPos != default)
+            {
+                endPos = overrideEndPos;
+            }
+
             Destination = endPos;
 
             ObjectsHit = new List<IGameObject>();

--- a/GameServerLib/GameObjects/Spell/Missile/SpellLineMissile.cs
+++ b/GameServerLib/GameObjects/Spell/Missile/SpellLineMissile.cs
@@ -11,6 +11,7 @@ using LeagueSandbox.GameServer.Content;
 
 namespace LeagueSandbox.GameServer.GameObjects.Spell.Missile
 {
+    // TODO: Complete this. Arc missiles have rotational velocity, and follow a repeating pattern similar to a wave function.
     public class SpellLineMissile : SpellCircleMissile, ISpellLineMissile
     {
         // Function Vars.
@@ -24,39 +25,13 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Missile
             ISpell originSpell,
             ICastInfo castInfo,
             float moveSpeed,
+            Vector2 overrideEndPos,
             SpellDataFlags overrideFlags = 0, // TODO: Find a use for these
             uint netId = 0,
             bool serverOnly = false
-        ) : base(game, collisionRadius, originSpell, castInfo, moveSpeed, overrideFlags, netId, serverOnly)
+        ) : base(game, collisionRadius, originSpell, castInfo, moveSpeed, overrideEndPos, overrideFlags, netId, serverOnly)
         {
-            // TODO: Verify if there is a case which contradicts this.
-            // Line and Circle Missiles are location targeted only.
-            TargetUnit = null;
-
-            Position = new Vector2(castInfo.SpellCastLaunchPosition.X, castInfo.SpellCastLaunchPosition.Z);
-
-            var goingTo = new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z) - Position;
-            var dirTemp = Vector2.Normalize(goingTo);
-            var endPos = Position + (dirTemp * SpellOrigin.GetCurrentCastRange());
-
-            // usually doesn't happen
-            if (float.IsNaN(dirTemp.X) || float.IsNaN(dirTemp.Y))
-            {
-                if (float.IsNaN(CastInfo.Owner.Direction.X) || float.IsNaN(CastInfo.Owner.Direction.Y))
-                {
-                    dirTemp = new Vector2(1, 0);
-                }
-                else
-                {
-                    dirTemp = new Vector2(CastInfo.Owner.Direction.X, CastInfo.Owner.Direction.Z);
-                }
-
-                endPos = Position + (dirTemp * SpellOrigin.GetCurrentCastRange());
-                CastInfo.TargetPositionEnd = new Vector3(endPos.X, 0, endPos.Y);
-            }
-
-            // TODO: Verify if CastRangeDisplayOverride is the correct variable to use.
-            Destination = endPos;
+            // Basic functionality of end position is done already by SpellCircleMissile.
         }
 
         public override void Update(float diff)

--- a/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
+++ b/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
@@ -195,6 +195,8 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Missile
         {
             if (!IsToRemove())
             {
+                API.ApiEventManager.OnSpellMissileEnd.Publish(this);
+
                 base.SetToRemove();
 
                 _game.PacketNotifier.NotifyDestroyClientMissile(this);

--- a/GameServerLib/GameObjects/Stats/Stats.cs
+++ b/GameServerLib/GameObjects/Stats/Stats.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
-using LeagueSandbox.GameServer.Content;
 
 namespace LeagueSandbox.GameServer.GameObjects.Stats
 {

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using GameServerCore;
 using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects.Other;
 using LeagueSandbox.GameServer.Logging;
@@ -119,6 +120,16 @@ namespace LeagueSandbox.GameServer
                     }
                 }
 
+                // Destroy any missiles which are targeting an untargetable unit.
+                // TODO: Verify if this should apply to SpellSector.
+                if (obj is ISpellMissile m)
+                {
+                    if (m.TargetUnit != null && !m.TargetUnit.Status.HasFlag(StatusFlags.Targetable))
+                    {
+                        m.SetToRemove();
+                    }
+                }
+
                 if (!(obj is IAttackableUnit))
                     continue;
 
@@ -171,6 +182,12 @@ namespace LeagueSandbox.GameServer
                         {
                             tempBuffs[i].Update(diff);
                         }
+                    }
+
+                    // Stop targeting an untargetable unit.
+                    if (ai.TargetUnit != null && !ai.TargetUnit.Status.HasFlag(StatusFlags.Targetable))
+                    {
+                        StopTargeting(ai.TargetUnit);
                     }
                 }
 

--- a/GameServerLib/Scripting/CSharp/BuffScriptEmpty.cs
+++ b/GameServerLib/Scripting/CSharp/BuffScriptEmpty.cs
@@ -1,24 +1,24 @@
-using GameServerCore.Domain.GameObjects;
+﻿using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.Stats;
+using System.Numerics;
 
-namespace Buffs
+namespace LeagueSandbox.GameServer.Scripting.CSharp
 {
-    internal class OverdriveSlow : IBuffGameScript
+    public class BuffScriptEmpty : IBuffGameScript
     {
-        public BuffType BuffType => BuffType.SLOW;
+        public BuffType BuffType => BuffType.INTERNAL;
         public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
-        public int MaxStacks => 1;
-        public bool IsHidden => false;
+        public int MaxStacks => 0;
+        public bool IsHidden => true;
 
         public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            StatsModifier.MoveSpeed.PercentBonus = StatsModifier.MoveSpeed.PercentBonus - 0.3f;
-            unit.AddStatModifier(StatsModifier);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
@@ -27,8 +27,6 @@ namespace Buffs
 
         public void OnUpdate(float diff)
         {
-
         }
     }
 }
-

--- a/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
@@ -18,6 +18,11 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
 
         public string AutoItemActivateEffect { get; set; } = "";
 
+        /// <summary>
+        /// Whether or not the caster should automatically face the end position of the spell.
+        /// </summary>
+        public bool AutoFaceDirection { get; set; } = true;
+
         public float[] AutoTargetDamageByLevel { get; set; } = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
 
         public float CastTime { get; set; } = 0.0f;
@@ -94,6 +99,10 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         /// What kind of behavior this missile has.
         /// </summary>
         public MissileType Type { get; set; } = MissileType.None;
+        /// <summary>
+        /// Position the missile should end at, only useful for Circle and Arc missile types.
+        /// </summary>
+        public Vector2 OverrideEndPosition { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
* Scripting:
  * Namespaces of all buff scripts changed to "Buffs".
  * Implemented Zed W
  * Fixed a crash with empty buff scripts.
  * Added AutoFaceDirection to script metadata.
  * Added OnSpellMissileEnd event.
  * AddParticle[Target] supports FXFlags.
  * AddMinion supports spawn variables such as IgnoreCollision, IsTargetable[ToTeamFlags], SkinID, and VisibilityOwner.
  * Added SetAutocast function.
  * Added CreateDeathData function for usage in IAttackableUnit.Die() function.
  * Added OverrideEndPosition to MissileParameters for usage with skillshots that are not fired from facing direction.
  * CreateTimer is marked as Obsolete.
* Minion:
  * Added IgnoreCollision, IsTargetable, and VisibilityOwner.
  * Reordered variables to align with SpawnMinionS2C packet.
  * Targeting accounts for targetable status.
* BaseTurret:
  * Targeting accounts for targetable status.
* Spell:
  * Fixed client-side crash with missiles being destroyed before spawning.
  * Added SetAutocast function.
* ObjAiBase:
  * SetTargetUnit does not accept untargetable or dead units.
  * Added SkinID variable and removed duplicates in higher level classes.
* Buff:
  * Script instance is now public.
  * Fixed a bug where removal status would be negated for buffs which re-activate.
* AttackableUnit:
  * Replication is now centralized to AttackableUnit.Update(), removing any other cases in higher level classes.
  * Death occurs in Update after Replication.Update(), allowing for stat mods from scripts to take effect before death.
  * Utilized DeathData for Die() function.
  * Collisions ignore ghosted units.
  * Targetable status is set upon initialization.
  * Removed SetIsTargetable in favor of SetStatus.
* Particle:
  * Added Flags variable.
* ObjectManager:
  * Missiles are destroyed if their target becomes untargetable.
  * Units targeting an untargetable unit have their target unset.
* Core:
  * Added DeathData.
  * Enums:
    * Added (incomplete) FXFlags.
* Packets:
  * Added NPC_Die_Broadcast, NPC_SetAutocast, and S2C_NPC_Die_MapView.
  
Resolve #1165
Resolve #1164
Resolve #1163
Resolve #1162
Resolve #1161
Resolve #1095
Resolve #879
Progress #1059