### PR TITLE
Resolve #1172 -- [Buffs] Fix RENEW_EXISTING

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/MasterYi/Highlander.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/MasterYi/Highlander.cs
@@ -10,7 +10,7 @@ namespace Buffs
     internal class Highlander : IBuffGameScript
     {
         public BuffType BuffType => BuffType.COMBAT_ENCHANCER;
-        public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
+        public BuffAddType BuffAddType => BuffAddType.RENEW_EXISTING;
         public int MaxStacks => 1;
         public bool IsHidden => false;
 

--- a/Content/LeagueSandbox-Scripts/Champions/MasterYi/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/MasterYi/R.cs
@@ -8,7 +8,7 @@ using GameServerCore.Scripting.CSharp;
 
 namespace Spells
 {
-    public class MasterYiHighlander : ISpellScript
+    public class Highlander : ISpellScript
     {
         public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
@@ -25,7 +25,7 @@ namespace Spells
 
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
-            AddBuff("Highlander", 10.0f, 1, spell, target, owner);
+            AddBuff("Highlander", 10.0f, 1, spell, owner, owner);
         }
 
         public void OnSpellCast(ISpell spell)

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -614,7 +614,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 
                     prevbuff.DeactivateBuff();
                     RemoveBuff(b.Name, false);
-                    BuffList.Remove(prevbuff);
 
                     // Clear the newly given buff's slot since we will move it into the previous buff's slot.
                     RemoveBuffSlot(b);
@@ -632,13 +631,22 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                     {
                         _game.PacketNotifier.NotifyNPC_BuffReplace(b);
                     }
+
+                    // New buff means new script, so we need to activate it.
                     b.ActivateBuff();
                 }
-                // If the buff is supposed to reset the timer on any existing buff instances of the same name.
                 else if (b.BuffAddType == BuffAddType.RENEW_EXISTING)
                 {
+                    // Clear the newly created buff's slot so we aren't wasting slots.
+                    if (b != ParentBuffs[b.Name])
+                    {
+                        RemoveBuffSlot(b);
+                    }
+
+                    // Reset the already existing buff's timer.
                     ParentBuffs[b.Name].ResetTimeElapsed();
 
+                    // Update the visual buff in-game (just resets the time on the icon).
                     if (!b.IsHidden)
                     {
                         _game.PacketNotifier.NotifyNPC_BuffReplace(ParentBuffs[b.Name]);


### PR DESCRIPTION
Resolve #1172
* Buffs:
  * Fixed a client-side crash due to RENEW_EXISTING taking up too many slots with temporary buffs when renewed with AttackableUnit.AddBuff.