### PR TITLE
Resolve #1184 -- Added New Listeners

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Sion/Passive.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Sion/Passive.cs
@@ -1,0 +1,83 @@
+using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Scripting.CSharp;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeagueSandbox.GameServer.API;
+using GameServerCore.Domain;
+using System.Collections.Generic;
+
+namespace Buffs
+{
+    internal class SionPassive : IBuffGameScript
+    {
+        public BuffType BuffType => BuffType.COMBAT_ENCHANCER;
+        public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
+        public int MaxStacks => 1;
+        public bool IsHidden => false;
+
+        public IStatsModifier StatsModifier { get; private set; }
+
+        float timer = 0f;
+        float tickCount = 0f;
+        IChampion champion;
+        IBuff thisBuff;
+        IParticle p;
+        IParticle p2;
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            ApiEventManager.OnDeath.AddListener(this, unit, OnDeath, true);
+            champion = unit as IChampion;
+            thisBuff = buff;
+
+            //These Particles aren't working
+            //p = AddParticleTarget(unit, null, "Sion_Skin01_Passive_Skin.troy", unit, buff.Duration);
+            //p2 = AddParticleTarget(unit, null, "Sion_Skin01_Passive_Ax.troy", unit, buff.Duration);
+
+            for (byte i = 0; i < 4; i++)
+            {
+                if (champion != null)
+                {
+                    champion.SetSpell("SionPassiveSpeed", i, true);
+                }
+            };
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {            
+            string[] originalAbilities = new string[] {"SionQ", "SionW", "SionE", "SionR"};
+            for (byte i = 0; i < 4; i++)
+            {
+                if (champion != null)
+                {
+                    champion.SetSpell(originalAbilities[i], i, true);
+                }
+            }
+
+            unit.TakeDamage(unit, 100000f, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_INTERNALRAW, false);
+
+            RemoveBuff(unit, "SionPassiveDelay");
+            RemoveBuff(unit, "SionPassive");
+            //RemoveParticle(p);
+            //RemoveParticle(p2);
+        }
+
+        public void OnDeath(IDeathData deathData)
+        {
+            if (thisBuff != null && !thisBuff.Elapsed())
+            {
+                thisBuff.DeactivateBuff();
+            }
+        }
+        public void OnUpdate(float diff)
+        {
+            timer += diff;
+            if (timer > 250f && champion != null)
+            {
+                champion.TakeDamage(champion, 1 + champion.Stats.Level + tickCount * (0.7f * (champion.Stats.Level * 0.7f)), DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_INTERNALRAW, false);
+                timer = 0;
+                tickCount++;
+            }
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/Sion/PassiveHandler.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Sion/PassiveHandler.cs
@@ -1,0 +1,40 @@
+using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Scripting.CSharp;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+
+namespace Buffs
+{
+    internal class SionPassiveDelay : IBuffGameScript
+    {
+        public BuffType BuffType => BuffType.COMBAT_DEHANCER;
+        public BuffAddType BuffAddType => BuffAddType.RENEW_EXISTING;
+        public int MaxStacks => 1;
+        public bool IsHidden => false;
+
+        public IStatsModifier StatsModifier { get; private set; }
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            unit.SetIsTargetableToTeam(TeamId.TEAM_BLUE, false);
+            unit.SetIsTargetableToTeam(TeamId.TEAM_PURPLE, false);
+            unit.SetIsTargetableToTeam(TeamId.TEAM_PURPLE, false);
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            var champion = unit as IChampion;
+            champion.Respawn();//Implement a custom spawn position function later
+            unit.SetIsTargetableToTeam(TeamId.TEAM_BLUE, true);
+            unit.SetIsTargetableToTeam(TeamId.TEAM_PURPLE, true);
+            unit.SetIsTargetableToTeam(TeamId.TEAM_PURPLE, true);
+            AddBuff("SionPassive", 60f, 1, ownerSpell, unit, champion);
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/Sion/PassiveSpeedBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Sion/PassiveSpeedBuff.cs
@@ -1,0 +1,31 @@
+using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Scripting.CSharp;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeagueSandbox.GameServer.API;
+using GameServerCore.Domain;
+using System.Collections.Generic;
+
+namespace Buffs
+{
+    internal class SionPassiveSpeed : IBuffGameScript
+    {
+        public BuffType BuffType => BuffType.COMBAT_ENCHANCER;
+        public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
+        public int MaxStacks => 1;
+        public bool IsHidden => false;
+
+        public IStatsModifier StatsModifier { get; private set; }
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+        }
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+        }
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Champions/Sion/Passive Ability.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Sion/Passive Ability.cs
@@ -1,0 +1,53 @@
+using GameServerCore.Domain.GameObjects;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using System.Numerics;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using GameServerCore.Domain;
+using GameServerLib.GameObjects.AttackableUnits;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+
+namespace Spells
+{
+    public class SionPassiveSpeed : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata => new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true
+            // TODO
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+        public void OnSpellCast(ISpell spell)
+        {
+            AddBuff("SionPassiveSpeed", 1.5f, 1, spell, spell.CastInfo.Owner, spell.CastInfo.Owner);
+        }
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+        public void OnSpellChannelCancel(ISpell spell)
+        {
+        }
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}
+

--- a/Content/LeagueSandbox-Scripts/Champions/Sion/Passive.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Sion/Passive.cs
@@ -1,0 +1,72 @@
+using GameServerCore.Domain.GameObjects;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using System.Numerics;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using GameServerCore.Domain;
+using GameServerLib.GameObjects.AttackableUnits;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+
+namespace Spells
+{
+    public class SionQ : ISpellScript //Was supposed to be "SionPassive", but passive scripts aren't getting read 
+    {
+        ISpell Spell;
+        int counter;
+        public ISpellScriptMetadata ScriptMetadata => new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true
+            // TODO
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+            ApiEventManager.OnDeath.AddListener(this, owner, OnDeath, true);
+            ApiEventManager.OnResurrect.AddListener(this, owner, OnRessurect, false);
+            Spell = spell;
+        }
+        public void OnDeath(IDeathData deathData)
+        {
+            AddBuff("SionPassiveDelay", 2f, 1, Spell, deathData.Unit, deathData.Unit as IObjAiBase);
+        } 
+        public void OnRessurect(IObjAiBase owner)
+        {
+            counter++;
+            //This is to avoid a loop in his passive.
+            if (counter == 2)
+            {
+                ApiEventManager.OnDeath.AddListener(this, owner, OnDeath, true); 
+                counter = 0;
+            }
+        }
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+            owner.TakeDamage(owner, 10000, GameServerCore.Enums.DamageType.DAMAGE_TYPE_TRUE, GameServerCore.Enums.DamageSource.DAMAGE_SOURCE_INTERNALRAW, false);
+        }
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+        public void OnSpellChannelCancel(ISpell spell)
+        {
+        }
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}
+

--- a/Content/LeagueSandbox-Scripts/Champions/Sion/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Sion/W.cs
@@ -1,0 +1,82 @@
+using GameServerCore.Domain.GameObjects;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using System.Numerics;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using GameServerCore.Domain;
+using GameServerLib.GameObjects.AttackableUnits;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+
+namespace Spells
+{
+    public class SionW : ISpellScript
+    {
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
+        ISpell thisSpell;
+
+        public ISpellScriptMetadata ScriptMetadata => new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true
+            // TODO
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+            ApiEventManager.OnKillUnit.AddListener(this, owner, OnKillMinion, false);
+            ApiEventManager.OnKill.AddListener(this, owner, OnKillChampion, false);
+            thisSpell = spell;
+        }
+        public void OnKillMinion(IDeathData deathData)
+        {
+            if (thisSpell.CastInfo.SpellLevel >= 1)
+            {
+                var owner = deathData.Killer;
+                float extraHealth = 2f;
+
+                StatsModifier.HealthPoints.FlatBonus = extraHealth;
+                deathData.Killer.AddStatModifier(StatsModifier);
+                owner.Stats.CurrentHealth += extraHealth;
+            }
+        }
+        public void OnKillChampion(IDeathData deathData)
+        {
+            if (thisSpell.CastInfo.SpellLevel >= 1)
+            {
+                var owner = deathData.Killer;
+                float extraHealth = 10f;
+
+                StatsModifier.HealthPoints.FlatBonus = extraHealth;
+                owner.AddStatModifier(StatsModifier);
+                owner.Stats.CurrentHealth += extraHealth;
+            }
+        }
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+        public void OnSpellChannelCancel(ISpell spell)
+        {
+        }
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}
+

--- a/GameServerCore/Domain/GameObjects/IChampion.cs
+++ b/GameServerCore/Domain/GameObjects/IChampion.cs
@@ -19,6 +19,6 @@ namespace GameServerCore.Domain.GameObjects
         void Respawn();
         bool OnDisconnect();
 
-        void OnKill(IAttackableUnit killed);
+        void OnKill(IDeathData deathData);
     }
 }

--- a/GameServerLib/API/ApiEventManager.cs
+++ b/GameServerLib/API/ApiEventManager.cs
@@ -1,8 +1,10 @@
-﻿using GameServerCore.Domain.GameObjects;
+﻿using GameServerCore.Domain;
+using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Domain.GameObjects.Spell.Sector;
 using GameServerCore.Enums;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.Logging;
 using log4net;
 using System;
@@ -78,10 +80,16 @@ namespace LeagueSandbox.GameServer.API
         public static void RemoveAllListenersForOwner(object owner)
         {
             OnCreateSector.RemoveListener(owner);
+            OnDeath.RemoveListener(owner);
             OnHitUnit.RemoveListener(owner);
+            OnKill.RemoveListener(owner);
+            OnKillUnit.RemoveListener(owner);
             OnLaunchAttack.RemoveListener(owner);
             OnLaunchMissile.RemoveListener(owner);
+            OnLevelUp.RemoveListener(owner);
+            OnLevelUpSpell.RemoveListener(owner);
             OnPreAttack.RemoveListener(owner);
+            OnResurrect.RemoveListener(owner);
             OnSpellCast.RemoveListener(owner);
             OnSpellChannel.RemoveListener(owner);
             OnSpellChannelCancel.RemoveListener(owner);
@@ -90,16 +98,23 @@ namespace LeagueSandbox.GameServer.API
             OnSpellSectorHit.RemoveListener(owner);
             OnSpellPostCast.RemoveListener(owner);
             OnSpellPostChannel.RemoveListener(owner);
+            OnPreTakeDamage.RemoveListener(owner);
             OnTakeDamage.RemoveListener(owner);
             OnUnitCrowdControlled.RemoveListener(owner);
             OnUnitUpdateMoveOrder.RemoveListener(owner);
         }
 
         public static EventOnCreateSector OnCreateSector = new EventOnCreateSector();
+        public static EventOnDeath OnDeath = new EventOnDeath();
         public static EventOnHitUnit OnHitUnit = new EventOnHitUnit();
+        public static EventOnKill OnKill = new EventOnKill();
+        public static EventOnKillUnit OnKillUnit = new EventOnKillUnit();
         public static EventOnLaunchAttack OnLaunchAttack = new EventOnLaunchAttack();
         public static EventOnLaunchMissile OnLaunchMissile = new EventOnLaunchMissile();
+        public static EventOnLevelUp OnLevelUp = new EventOnLevelUp();
+        public static EventOnLevelUpSpell OnLevelUpSpell = new EventOnLevelUpSpell();
         public static EventOnPreAttack OnPreAttack = new EventOnPreAttack();
+        public static EventOnResurrect OnResurrect = new EventOnResurrect();
         public static EventOnSpellCast OnSpellCast = new EventOnSpellCast();
         public static EventOnSpellChannel OnSpellChannel = new EventOnSpellChannel();
         public static EventOnSpellChannelCancel OnSpellChannelCancel = new EventOnSpellChannelCancel();
@@ -108,6 +123,7 @@ namespace LeagueSandbox.GameServer.API
         public static EventOnSpellSectorHit OnSpellSectorHit = new EventOnSpellSectorHit();
         public static EventOnSpellPostCast OnSpellPostCast = new EventOnSpellPostCast();
         public static EventOnSpellPostChannel OnSpellPostChannel = new EventOnSpellPostChannel();
+        public static EventOnPreTakeDamage OnPreTakeDamage = new EventOnPreTakeDamage();
         public static EventOnTakeDamage OnTakeDamage = new EventOnTakeDamage();
         // TODO: Handle crowd control the same as normal dashes.
         public static EventOnUnitCrowdControlled OnUnitCrowdControlled = new EventOnUnitCrowdControlled();
@@ -155,6 +171,40 @@ namespace LeagueSandbox.GameServer.API
             }
         }
     }
+    public class EventOnDeath
+    {
+        private readonly List<Tuple<object, IAttackableUnit, Action<IDeathData>, bool>> _listeners = new List<Tuple<object, IAttackableUnit, Action<IDeathData>, bool>>();
+
+        public void AddListener(object owner, IAttackableUnit target, Action<IDeathData> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, IAttackableUnit, Action<IDeathData>, bool>(owner, target, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll((listener) => listener.Item1 == owner);
+        }
+        public void Publish(IDeathData deathData)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == deathData.Unit)
+                {
+                    _listeners[i].Item3(deathData);
+                    if (_listeners[i].Item4)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
+                }
+            }
+        }
+    }
 
     public class EventOnHitUnit
     {
@@ -195,7 +245,74 @@ namespace LeagueSandbox.GameServer.API
             }
         }
     }
+    public class EventOnKill
+    {
+        private readonly List<Tuple<object, IAttackableUnit, Action<IDeathData>, bool>> _listeners = new List<Tuple<object, IAttackableUnit, Action<IDeathData>, bool>>();
 
+        public void AddListener(object owner, IAttackableUnit killer, Action<IDeathData> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, IAttackableUnit, Action<IDeathData>, bool>(owner, killer, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll((listener) => listener.Item1 == owner);
+        }
+        public void Publish(IDeathData deathData)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == deathData.Killer)
+                {
+                    _listeners[i].Item3(deathData);
+                    if (_listeners[i].Item4)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
+                }
+            }
+        }
+    }
+    public class EventOnKillUnit
+    {
+        private readonly List<Tuple<object, IAttackableUnit, Action<IDeathData>, bool>> _listeners = new List<Tuple<object, IAttackableUnit, Action<IDeathData>, bool>>();
+
+        public void AddListener(object owner, IAttackableUnit killer, Action<IDeathData> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, IAttackableUnit, Action<IDeathData>, bool>(owner, killer, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll((listener) => listener.Item1 == owner);
+        }
+        public void Publish(IDeathData deathData)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == deathData.Killer)
+                {
+                    _listeners[i].Item3(deathData);
+                    if (_listeners[i].Item4)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
+                }
+            }
+        }
+    }
     public class EventOnLaunchAttack
     {
         private readonly List<Tuple<object, IObjAiBase, Action<ISpell>, bool>> _listeners = new List<Tuple<object, IObjAiBase, Action<ISpell>, bool>>();
@@ -274,6 +391,74 @@ namespace LeagueSandbox.GameServer.API
         }
     }
 
+    public class EventOnLevelUp
+    {
+        private readonly List<Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>> _listeners = new List<Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>>();
+
+        public void AddListener(object owner, IAttackableUnit owner2, Action<IAttackableUnit> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>(owner, owner2, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll((listener) => listener.Item1 == owner);
+        }
+        public void Publish(IAttackableUnit owner)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == owner)
+                {
+                    _listeners[i].Item3(owner);
+                    if (_listeners[i].Item4)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
+                }
+            }
+        }
+    }
+    public class EventOnLevelUpSpell
+    {
+        private readonly List<Tuple<object, ISpell, Action<ISpell>, bool>> _listeners = new List<Tuple<object, ISpell, Action<ISpell>, bool>>();
+
+        public void AddListener(object owner, ISpell spell, Action<ISpell> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, ISpell, Action<ISpell>, bool>(owner, spell, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll((listener) => listener.Item1 == owner);
+        }
+        public void Publish(ISpell spell)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == spell)
+                {
+                    _listeners[i].Item3(spell);
+                    if (_listeners[i].Item4)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
+                }
+            }
+        }
+    }
     public class EventOnPreAttack
     {
         private readonly List<Tuple<object, IObjAiBase, Action<ISpell>, bool>> _listeners = new List<Tuple<object, IObjAiBase, Action<ISpell>, bool>>();
@@ -313,6 +498,41 @@ namespace LeagueSandbox.GameServer.API
         }
     }
 
+    public class EventOnResurrect
+    {
+        private readonly List<Tuple<object, IObjAiBase, Action<IObjAiBase>, bool>> _listeners = new List<Tuple<object, IObjAiBase, Action<IObjAiBase>, bool>>();
+        public void AddListener(object owner, IObjAiBase unit, Action<IObjAiBase> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, IObjAiBase, Action<IObjAiBase>, bool>(owner, unit, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll((listener) => listener.Item1 == owner);
+        }
+        public void Publish(IObjAiBase unit)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == unit)
+                {
+                    _listeners[i].Item3(unit);
+                    if (_listeners[i].Item4)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
+                }
+            }
+        }
+
+    }
     public class EventOnSpellCast
     {
         private readonly List<Tuple<object, ISpell, Action<ISpell>>> _listeners = new List<Tuple<object, ISpell, Action<ISpell>>>();
@@ -600,6 +820,44 @@ namespace LeagueSandbox.GameServer.API
                 if (_listeners[i].Item2 == spell)
                 {
                     _listeners[i].Item3(spell);
+                }
+            }
+        }
+    }
+    public class EventOnPreTakeDamage
+    {
+        private readonly List<Tuple<object, IAttackableUnit, Action<IAttackableUnit, IAttackableUnit>, bool>> _listeners = new List<Tuple<object, IAttackableUnit, Action<IAttackableUnit, IAttackableUnit>, bool>>();
+        public void AddListener(object owner, IAttackableUnit unit, Action<IAttackableUnit, IAttackableUnit> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, IAttackableUnit, Action<IAttackableUnit, IAttackableUnit>, bool>(owner, unit, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+        public void RemoveListener(object owner, IAttackableUnit unit)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner && listener.Item2 == unit);
+        }
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner);
+        }
+        public void Publish(IAttackableUnit unit, IAttackableUnit source)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == unit)
+                {
+                    _listeners[i].Item3(unit, source);
+                    if (_listeners[i].Item4 == true)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
                 }
             }
         }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -660,7 +660,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
 
             s.LevelUp();
-
+            ApiEventManager.OnLevelUpSpell.Publish(s);
             return s;
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -437,7 +437,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 damage = defense >= 0 ? 100 / (100 + defense) * damage : (2 - 100 / (100 - defense)) * damage;
             }
 
-            ApiEventManager.OnTakeDamage.Publish(this, attacker);
+            ApiEventManager.OnPreTakeDamage.Publish(this, attacker);
 
             Stats.CurrentHealth = Math.Max(0.0f, Stats.CurrentHealth - damage);
             if (!IsDead && Stats.CurrentHealth <= 0)
@@ -453,6 +453,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                     DamageSource = source,
                     DeathDuration = 0 // TODO: Unhardcode
                 };
+
+                ApiEventManager.OnTakeDamage.Publish(this, attacker);
             }
 
             int attackerId = 0, targetId = 0;
@@ -537,9 +539,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 
             SetToRemove();
 
-            var onDie = _game.ScriptEngine.GetStaticMethod<Action<IAttackableUnit, IAttackableUnit>>(Model, "Passive", "OnDie");
-            onDie?.Invoke(this, data.Killer);
-
+            ApiEventManager.OnDeath.Publish(data);
             var exp = _game.Map.MapProperties.GetExperienceFor(this);
             var champs = _game.ObjectManager.GetChampionsInRange(Position, EXP_RANGE, true);
             //Cull allied champions
@@ -556,7 +556,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
 
             if (data.Killer != null && data.Killer is IChampion champion)
-                champion.OnKill(this);
+                champion.OnKill(data);
         }
 
         /// <summary>


### PR DESCRIPTION
*Introduced the Following Listeners:
>OnDeath - Happens when your Champion dies.
>OnRessurrect - Happens when your champion Re-Spawns.
>OnKill - Happens when killing a Champion.
>OnKillUnit - Happens when killing anything but Champions.
>OnLevelUp - Happens when your Champion or an Unit levels Up.
>OnLevelUpSpell - Happens when you level up your spell.
>OnPreTakeDamage - Happens right before taking damage.
Note: Changed OnTakeDamage's position to AFTER taking damage in order to properly acomodade OnPreTakeDamage

*Introduced a VERY simple Sion Passive and W passive just in order to showcase some of the new listeners (Those being OnDeath, OnRessurect, OnKill and OnKillUnit)

Resolve #1184