### PR TITLE
Resolve #1191, Resolve #1193 -- Fix Dash & Status Issues

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
@@ -12,24 +12,25 @@ namespace Buffs
         public BuffType BuffType => BuffType.STUN;
         public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
         public int MaxStacks => 1;
-        public bool IsHidden => false;
+        public bool IsHidden => true;
 
         public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            unit.Stats.SetActionState(ActionState.CAN_ATTACK, false);
-            unit.Stats.SetActionState(ActionState.CAN_CAST, false);
-            unit.Stats.SetActionState(ActionState.CAN_MOVE, false);
+            SetStatus(unit, StatusFlags.CanAttack, false);
+            SetStatus(unit, StatusFlags.CanMove, false);
+            SetStatus(unit, StatusFlags.CanCast, false);
 
             ForceMovement(unit, "RUN", buff.SourceUnit.Position, 1800f, 0, 5.0f, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
         }
 
+        // TODO: Use OnMoveEnd event and call this manually.
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            unit.Stats.SetActionState(ActionState.CAN_ATTACK, true);
-            unit.Stats.SetActionState(ActionState.CAN_CAST, true);
-            unit.Stats.SetActionState(ActionState.CAN_MOVE, true);
+            SetStatus(unit, StatusFlags.CanAttack, true);
+            SetStatus(unit, StatusFlags.CanCast, true);
+            SetStatus(unit, StatusFlags.CanMove, true);
 
             if (buff.SourceUnit is IObjAiBase ai && unit is IChampion ch)
             {

--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
@@ -9,18 +9,16 @@ namespace Buffs
 {
     internal class RocketGrab2 : IBuffGameScript
     {
-        public BuffType BuffType => BuffType.STUN;
+        public BuffType BuffType => BuffType.INTERNAL;
         public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
         public int MaxStacks => 1;
-        public bool IsHidden => true;
+        public bool IsHidden => false;
 
         public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            SetStatus(unit, StatusFlags.CanAttack, false);
-            SetStatus(unit, StatusFlags.CanMove, false);
-            SetStatus(unit, StatusFlags.CanCast, false);
+            buff.SetStatusEffect(StatusFlags.CanAttack | StatusFlags.CanMove | StatusFlags.CanCast, false);
 
             ForceMovement(unit, "RUN", buff.SourceUnit.Position, 1800f, 0, 5.0f, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
         }
@@ -28,9 +26,7 @@ namespace Buffs
         // TODO: Use OnMoveEnd event and call this manually.
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            SetStatus(unit, StatusFlags.CanAttack, true);
-            SetStatus(unit, StatusFlags.CanCast, true);
-            SetStatus(unit, StatusFlags.CanMove, true);
+            buff.SetStatusEffect(StatusFlags.CanAttack | StatusFlags.CanMove | StatusFlags.CanCast, true);
 
             if (buff.SourceUnit is IObjAiBase ai && unit is IChampion ch)
             {

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Stun.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Stun.cs
@@ -11,25 +11,33 @@ namespace Buffs
         public BuffType BuffType => BuffType.STUN;
         public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
         public int MaxStacks => 1;
-        public bool IsHidden => true;
+        public bool IsHidden => false;
 
         public IStatsModifier StatsModifier { get; private set; }
 
+        IAttackableUnit owner;
         IParticle stun;
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            stun = AddParticleTarget(ownerSpell.CastInfo.Owner, null, "Global_Stun.troy", unit, buff.Duration, bone: "head");
+            owner = unit;
+            SetStatus(unit, StatusFlags.Stunned, true);
+            stun = AddParticleTarget(ownerSpell.CastInfo.Owner, unit, "LOC_Stun.troy", unit, buff.Duration, bone: "head");
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
+            owner = null;
+            SetStatus(unit, StatusFlags.Stunned, false);
             RemoveParticle(stun);
         }
 
         public void OnUpdate(float diff)
         {
-
+            if (owner != null)
+            {
+                SetStatus(owner, StatusFlags.Stunned, true);
+            }
         }
     }
 }

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Stun.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Stun.cs
@@ -15,29 +15,22 @@ namespace Buffs
 
         public IStatsModifier StatsModifier { get; private set; }
 
-        IAttackableUnit owner;
         IParticle stun;
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            owner = unit;
-            SetStatus(unit, StatusFlags.Stunned, true);
+            buff.SetStatusEffect(StatusFlags.Stunned, true);
             stun = AddParticleTarget(ownerSpell.CastInfo.Owner, unit, "LOC_Stun.troy", unit, buff.Duration, bone: "head");
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            owner = null;
-            SetStatus(unit, StatusFlags.Stunned, false);
+            buff.SetStatusEffect(StatusFlags.Stunned, false);
             RemoveParticle(stun);
         }
 
         public void OnUpdate(float diff)
         {
-            if (owner != null)
-            {
-                SetStatus(owner, StatusFlags.Stunned, true);
-            }
         }
     }
 }

--- a/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedWShadowBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Zed/ZedWShadowBuff.cs
@@ -30,8 +30,8 @@ namespace Buffs
             ThisBuff = buff;
             Shadow = unit as IMinion;
 
-            Shadow.SetStatus(StatusFlags.Targetable, false);
-            Shadow.SetStatus(StatusFlags.Ghosted, true);
+            buff.SetStatusEffect(StatusFlags.Targetable, false);
+            buff.SetStatusEffect(StatusFlags.Ghosted, true);
 
             AddParticleTarget(Shadow.Owner, Shadow, "zed_base_w_tar.troy", Shadow);
 
@@ -47,7 +47,7 @@ namespace Buffs
                     currentIndicator.SetToRemove();
                 }
 
-                Shadow.SetStatus(StatusFlags.NoRender, true);
+                SetStatus(Shadow, StatusFlags.NoRender, true);
                 AddParticle(Shadow.Owner, null, "zed_base_clonedeath.troy", Shadow.Position);
                 Shadow.TakeDamage(Shadow.Owner, 10000f, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_INTERNALRAW, DamageResultType.RESULT_NORMAL);
             }

--- a/Content/LeagueSandbox-Scripts/Champions/Blitzcrank/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Blitzcrank/Q.cs
@@ -102,14 +102,18 @@ namespace Spells
             var owner = spell.CastInfo.Owner;
             var ap = owner.Stats.AbilityPower.Total;
             var damage = 80 + ((spell.CastInfo.SpellLevel - 1) * 55) + ap;
+            var dist = System.Math.Abs(Vector2.Distance(target.Position, owner.Position));
+            var time = dist / 1350f;
+
+            // Grab particle
+            AddBuff("RocketGrab", time, 1, spell, target, owner);
+
             target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+
+            AddBuff("Stun", 0.6f, 1, spell, target, owner);
 
             missile.SetToRemove();
 
-            var dist = System.Math.Abs(Vector2.Distance(target.Position, owner.Position));
-            var time = dist / 1350f;
-            // Grab particle
-            AddBuff("RocketGrab", time, 1, spell, target, owner);
             // SetStatus & auto attack
             AddBuff("RocketGrab2", 0.6f, 1, spell, target, owner);
         }

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -50,11 +50,6 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         IForceMovementParameters MovementParameters { get; }
         /// <summary>
-        /// Amount of time passed since the unit started dashing.
-        /// </summary>
-        /// TODO: Implement a dash class so dash based variables and functions can be separate from units.
-        float DashElapsedTime { get; set; }
-        /// <summary>
         /// Stats used purely in networking the accompishments or status of units and their gameplay affecting stats.
         /// </summary>
         IReplication Replication { get; }

--- a/GameServerCore/Domain/GameObjects/IBuff.cs
+++ b/GameServerCore/Domain/GameObjects/IBuff.cs
@@ -1,6 +1,7 @@
 ﻿using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
+using System.Collections.Generic;
 
 namespace GameServerCore.Domain.GameObjects
 {
@@ -10,47 +11,38 @@ namespace GameServerCore.Domain.GameObjects
         /// How this buff should be added and treated when adding new buffs of the same name.
         /// </summary>
         BuffAddType BuffAddType { get; }
-
         /// <summary>
         /// Type of buff to add. Determines how this buff interacts with mechanics of the game. Refer to BuffType.
         /// </summary>
         BuffType BuffType { get; }
-
         /// <summary>
         /// Total time this buff should be applied to its target.
         /// </summary>
         float Duration { get; }
-
         /// <summary>
         /// Whether or not this buff should be shown on clients' buff bar (HUD).
         /// </summary>
         bool IsHidden { get; }
-
         /// <summary>
         /// Internal name of this buff.
         /// </summary>
         string Name { get; }
-
         /// <summary>
         /// Spell which caused this buff to be applied.
         /// </summary>
         ISpell OriginSpell { get; }
-
         /// <summary>
         /// Slot of this buff instance. Maximum allowed is 255 due to packets.
         /// </summary>
         byte Slot { get; }
-
         /// <summary>
         /// Unit which applied this buff to its target.
         /// </summary>
         IObjAiBase SourceUnit { get; }
-
         /// <summary>
         /// Unit which has this buff applied to it.
         /// </summary>
         IAttackableUnit TargetUnit { get; }
-
         /// <summary>
         /// Time since this buff's timer started.
         /// </summary>
@@ -59,16 +51,20 @@ namespace GameServerCore.Domain.GameObjects
         /// Script instance for this buff. Casting to a specific buff class gives access its functions and variables.
         /// </summary>
         IBuffGameScript BuffScript { get; }
+        /// <summary>
+        /// All status effects applied by this buff.
+        /// </summary>
+        Dictionary<StatusFlags, bool> StatusEffects { get; }
 
         /// <summary>
         /// Used to load the script for the buff.
         /// </summary>
         void LoadScript();
-
         void ActivateBuff();
         void DeactivateBuff();
         bool Elapsed();
         IStatsModifier GetStatsModifier();
+        void SetStatusEffect(StatusFlags flag, bool enabled);
         bool IsBuffInfinite();
         bool IsBuffSame(string buffName);
         void ResetTimeElapsed();

--- a/GameServerCore/Domain/GameObjects/IForceMovementParameters.cs
+++ b/GameServerCore/Domain/GameObjects/IForceMovementParameters.cs
@@ -4,13 +4,43 @@ namespace GameServerCore.Domain.GameObjects
 {
     public interface IForceMovementParameters
     {
-        public float PathSpeedOverride { get; }
-        public float ParabolicGravity { get; }
-        public Vector2 ParabolicStartPoint { get; }
-        public bool KeepFacingDirection { get; }
-        public uint FollowNetID { get; }
-        public float FollowDistance { get; }
-        public float FollowBackDistance { get; }
-        public float FollowTravelTime { get; }
+        /// <summary>
+        /// Amount of time passed since the unit started dashing.
+        /// </summary>
+        float ElapsedTime { get; }
+        /// <summary>
+        /// Speed to use for the movement.
+        /// </summary>
+        float PathSpeedOverride { get; }
+        /// <summary>
+        /// How fast to accelerate downwards.
+        /// </summary>
+        float ParabolicGravity { get; }
+        /// <summary>
+        /// Position for the peak of the vertical portion of the movement.
+        /// </summary>
+        Vector2 ParabolicStartPoint { get; }
+        /// <summary>
+        /// Whether or not the unit performing the movement should face the direction it had before starting the movement.
+        /// </summary>
+        bool KeepFacingDirection { get; }
+        /// <summary>
+        /// NetID of the unit to move towards.
+        /// </summary>
+        uint FollowNetID { get; }
+        /// <summary>
+        /// Maximum distance to follow the FollowNetID.
+        /// </summary>
+        float FollowDistance { get; }
+        /// <summary>
+        /// Distance ahead of the FollowNetID to travel after reaching it.
+        /// </summary>
+        float FollowBackDistance { get; }
+        /// <summary>
+        /// Maximum amount of time to follow the FollowNetID.
+        /// </summary>
+        float FollowTravelTime { get; }
+
+        void SetTimeElapsed(float time);
     }
 }

--- a/GameServerCore/Enums/ActionState.cs
+++ b/GameServerCore/Enums/ActionState.cs
@@ -18,11 +18,10 @@ namespace GameServerCore.Enums
         IS_ASLEEP = 1 << 10,
         IS_NEAR_SIGHTED = 1 << 11,
         IS_GHOSTED = 1 << 12,
-
         CHARMED = 1 << 15,
         NO_RENDER = 1 << 16,
         FORCE_RENDER_PARTICLES = 1 << 17,
 
-        UNKNOWN = 1 << 23 // set to 1 by default, interferes with targetability
+        TARGETABLE = 1 << 23
     }
 }

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -631,9 +631,22 @@ namespace LeagueSandbox.GameServer.API
             spell.SetAutocast();
         }
 
+        /// <summary>
+        /// Sets the state of the given status for the given unit.
+        /// </summary>
+        /// <param name="unit">Unit to set status.</param>
+        /// <param name="status">Status to set.</param>
+        /// <param name="enabled">Whether or not the status should be enabled.</param>
         public static void SetStatus(IAttackableUnit unit, StatusFlags status, bool enabled)
         {
-            unit.SetStatus(status, enabled);
+            // Loop over all possible status flags and set them individually.
+            foreach (StatusFlags enumFlag in Enum.GetValues(typeof(StatusFlags)))
+            {
+                if (status.HasFlag(enumFlag))
+                {
+                    unit.SetStatus(status, enabled);
+                }
+            }
         }
 
         public static void SetTargetingType(IObjAiBase target, SpellSlotType slotType, int slot, TargetingType newType)

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -640,11 +640,13 @@ namespace LeagueSandbox.GameServer.API
         public static void SetStatus(IAttackableUnit unit, StatusFlags status, bool enabled)
         {
             // Loop over all possible status flags and set them individually.
-            foreach (StatusFlags enumFlag in Enum.GetValues(typeof(StatusFlags)))
+            for (int i = 0; i < 30; i++)
             {
-                if (status.HasFlag(enumFlag))
+                StatusFlags currentFlag = (StatusFlags)(1 << i);
+
+                if (status.HasFlag(currentFlag))
                 {
-                    unit.SetStatus(status, enabled);
+                    unit.SetStatus(currentFlag, enabled);
                 }
             }
         }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -249,14 +249,17 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public override bool CanMove()
         {
             // TODO: Verify if Dashes should bypass this.
-            return !(IsDead || MoveOrder == OrderType.CastSpell
-                    || !(Status.HasFlag(StatusFlags.CanMove) || Status.HasFlag(StatusFlags.CanMoveEver))
-                    || Status.HasFlag(StatusFlags.Immovable)
-                    || Status.HasFlag(StatusFlags.Netted)
-                    || Status.HasFlag(StatusFlags.Rooted)
-                    || Status.HasFlag(StatusFlags.Sleep)
-                    || Status.HasFlag(StatusFlags.Stunned)
-                    || Status.HasFlag(StatusFlags.Suppressed));
+            return !IsDead
+                && ((Status.HasFlag(StatusFlags.CanMove) && Status.HasFlag(StatusFlags.CanMoveEver)) || MovementParameters != null)
+                && (MoveOrder != OrderType.CastSpell
+                // TODO: Verify if priority is still maintained with these MovementParameters checks.
+                || MovementParameters != null
+                || !(Status.HasFlag(StatusFlags.Immovable)
+                || Status.HasFlag(StatusFlags.Netted)
+                || Status.HasFlag(StatusFlags.Rooted)
+                || Status.HasFlag(StatusFlags.Sleep)
+                || Status.HasFlag(StatusFlags.Stunned)
+                || Status.HasFlag(StatusFlags.Suppressed)));
         }
 
         /// <summary>
@@ -430,6 +433,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             // TODO: Take into account the rest of the arguments
             MovementParameters = new ForceMovementParameters
             {
+                ElapsedTime = 0,
                 PathSpeedOverride = dashSpeed,
                 ParabolicGravity = leapGravity,
                 ParabolicStartPoint = Position,
@@ -439,7 +443,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 FollowBackDistance = backDistance,
                 FollowTravelTime = travelTime
             };
-            DashElapsedTime = 0;
 
             _game.PacketNotifier.NotifyWaypointGroupWithSpeed(this);
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -250,16 +250,15 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             // TODO: Verify if Dashes should bypass this.
             return !IsDead
+                // TODO: Verify if priority is still maintained with the MovementParameters checks.
                 && ((Status.HasFlag(StatusFlags.CanMove) && Status.HasFlag(StatusFlags.CanMoveEver)) || MovementParameters != null)
-                && (MoveOrder != OrderType.CastSpell
-                // TODO: Verify if priority is still maintained with these MovementParameters checks.
-                || MovementParameters != null
-                || !(Status.HasFlag(StatusFlags.Immovable)
-                || Status.HasFlag(StatusFlags.Netted)
+                && (MoveOrder != OrderType.CastSpell || MovementParameters != null)
+                && (!(Status.HasFlag(StatusFlags.Netted)
                 || Status.HasFlag(StatusFlags.Rooted)
                 || Status.HasFlag(StatusFlags.Sleep)
                 || Status.HasFlag(StatusFlags.Stunned)
-                || Status.HasFlag(StatusFlags.Suppressed)));
+                || Status.HasFlag(StatusFlags.Suppressed))
+                || MovementParameters != null);
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/AttackableUnits/ForceMovementParameters.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/ForceMovementParameters.cs
@@ -5,13 +5,47 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 {
     public class ForceMovementParameters : IForceMovementParameters
     {
+        /// <summary>
+        /// Amount of time passed since the unit started dashing.
+        /// </summary>
+        public float ElapsedTime { get; set; }
+        /// <summary>
+        /// Speed to use for the movement.
+        /// </summary>
         public float PathSpeedOverride { get; set; }
+        /// <summary>
+        /// Maximum vertical height.
+        /// NOTES: Internally follows the path of a parabola, stretched in the x and y axis by the distance to the destination and stretched in the z axis to the maximum height (this stretching of the z axis scales the vertical speed).
+        /// </summary>
         public float ParabolicGravity { get; set; }
+        /// <summary>
+        /// End position of the movement.
+        /// </summary>
         public Vector2 ParabolicStartPoint { get; set; }
+        /// <summary>
+        /// Whether or not the unit performing the movement should face the direction it had before starting the movement.
+        /// </summary>
         public bool KeepFacingDirection { get; set; }
+        /// <summary>
+        /// NetID of the unit to move towards.
+        /// </summary>
         public uint FollowNetID { get; set; }
+        /// <summary>
+        /// Maximum distance to follow the FollowNetID.
+        /// </summary>
         public float FollowDistance { get; set; }
+        /// <summary>
+        /// Distance ahead of the FollowNetID to travel after reaching it.
+        /// </summary>
         public float FollowBackDistance { get; set; }
+        /// <summary>
+        /// Maximum amount of time to follow the FollowNetID.
+        /// </summary>
         public float FollowTravelTime { get; set; }
+
+        public void SetTimeElapsed(float time)
+        {
+            ElapsedTime = time;
+        }
     }
 }

--- a/GameServerLib/GameObjects/Buff.cs
+++ b/GameServerLib/GameObjects/Buff.cs
@@ -132,17 +132,19 @@ namespace LeagueSandbox.GameServer.GameObjects
         public void SetStatusEffect(StatusFlags flag, bool enabled)
         {
             // Loop over all possible status flags and assign them individually to the dictionary
-            foreach (StatusFlags enumFlag in Enum.GetValues(typeof(StatusFlags)))
+            for (int i = 0; i < 30; i++)
             {
-                if (flag.HasFlag(enumFlag))
+                StatusFlags currentFlag = (StatusFlags)(1 << i);
+
+                if (flag.HasFlag(currentFlag))
                 {
-                    if (StatusEffects.ContainsKey(enumFlag))
+                    if (StatusEffects.ContainsKey(currentFlag))
                     {
-                        StatusEffects[enumFlag] = enabled;
+                        StatusEffects[currentFlag] = enabled;
                         continue;
                     }
 
-                    StatusEffects.Add(enumFlag, enabled);
+                    StatusEffects.Add(currentFlag, enabled);
                 }
             }
         }

--- a/GameServerLib/GameObjects/Buff.cs
+++ b/GameServerLib/GameObjects/Buff.cs
@@ -7,6 +7,7 @@ using LeagueSandbox.GameServer.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.Other;
 using LeagueSandbox.GameServer.API;
 using GameServerCore.Scripting.CSharp;
+using System.Collections.Generic;
 
 namespace LeagueSandbox.GameServer.GameObjects
 {
@@ -34,6 +35,10 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// Script instance for this buff. Casting to a specific buff class gives access its functions and variables.
         /// </summary>
         public IBuffGameScript BuffScript { get; private set; }
+        /// <summary>
+        /// All status effects applied by this buff.
+        /// </summary>
+        public Dictionary<StatusFlags, bool> StatusEffects { get; private set; }
 
         public Buff(Game game, string buffName, float duration, int stacks, ISpell originSpell, IAttackableUnit onto, IObjAiBase from, bool infiniteDuration = false)
         {
@@ -82,6 +87,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             SourceUnit = from;
             TimeElapsed = 0;
             TargetUnit = onto;
+            StatusEffects = new Dictionary<StatusFlags, bool>();
         }
 
         public void LoadScript()
@@ -121,6 +127,24 @@ namespace LeagueSandbox.GameServer.GameObjects
         public IStatsModifier GetStatsModifier()
         {
             return BuffScript.StatsModifier;
+        }
+
+        public void SetStatusEffect(StatusFlags flag, bool enabled)
+        {
+            // Loop over all possible status flags and assign them individually to the dictionary
+            foreach (StatusFlags enumFlag in Enum.GetValues(typeof(StatusFlags)))
+            {
+                if (flag.HasFlag(enumFlag))
+                {
+                    if (StatusEffects.ContainsKey(enumFlag))
+                    {
+                        StatusEffects[enumFlag] = enabled;
+                        continue;
+                    }
+
+                    StatusEffects.Add(enumFlag, enabled);
+                }
+            }
         }
 
         public bool IsBuffInfinite()

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -663,24 +663,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
 
         public void FinishCasting()
         {
-            // Updates move order before script PostCast so teleports are sent to clients correctly (not sent if MoveOrder == CastSpell).
-            if (SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
-            {
-                if (!CastInfo.Owner.IsPathEnded())
-                {
-                    CastInfo.Owner.UpdateMoveOrder(OrderType.MoveTo, true);
-                }
-                if (CastInfo.Owner.TargetUnit != null)
-                {
-                    CastInfo.Owner.UpdateMoveOrder(OrderType.AttackTo, true);
-                }
-            }
-            else
-            {
-                // TODO: Verify
-                CastInfo.Owner.UpdateMoveOrder(OrderType.Hold, true);
-            }
-
             if (CastInfo.IsAutoAttack)
             {
                 ApiEventManager.OnLaunchAttack.Publish(CastInfo.Owner, this);
@@ -749,6 +731,24 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             if (CastInfo.Owner.SpellToCast != null)
             {
                 CastInfo.Owner.SetSpellToCast(null, Vector2.Zero);
+            }
+
+            // Updates move order before script PostCast so teleports are sent to clients correctly (not sent if MoveOrder == CastSpell).
+            if (SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
+            {
+                if (!CastInfo.Owner.IsPathEnded())
+                {
+                    CastInfo.Owner.UpdateMoveOrder(OrderType.MoveTo, true);
+                }
+                if (CastInfo.Owner.TargetUnit != null)
+                {
+                    CastInfo.Owner.UpdateMoveOrder(OrderType.AttackTo, true);
+                }
+            }
+            else
+            {
+                // TODO: Verify
+                CastInfo.Owner.UpdateMoveOrder(OrderType.Hold, true);
             }
         }
 

--- a/GameServerLib/GameObjects/Stats/Stats.cs
+++ b/GameServerLib/GameObjects/Stats/Stats.cs
@@ -78,7 +78,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
         {
             SpellCostReduction = 0;
             ManaCost = new float[64];
-            ActionState = ActionState.CAN_ATTACK | ActionState.CAN_CAST | ActionState.CAN_MOVE | ActionState.UNKNOWN;
+            ActionState = ActionState.CAN_ATTACK | ActionState.CAN_CAST | ActionState.CAN_MOVE | ActionState.TARGETABLE;
             IsTargetable = true;
             IsTargetableToTeam = SpellDataFlags.TargetableToAll;
 

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -808,13 +808,35 @@ namespace PacketDefinitions420
             charStackDataList.Add(charStackData);
 
             var type = MovementDataType.Normal;
+            SpeedParams speeds = null;
 
-            if (o is IAttackableUnit unit && unit.Waypoints.Count <= 1)
+            if (o is IAttackableUnit u)
             {
-                type = MovementDataType.Stop;
+                if (u.Waypoints.Count <= 1)
+                {
+                    type = MovementDataType.Stop;
+                }
+
+                if (u.MovementParameters != null)
+                {
+                    type = MovementDataType.WithSpeed;
+
+                    speeds = new SpeedParams
+                    {
+                        PathSpeedOverride = u.MovementParameters.PathSpeedOverride,
+                        ParabolicGravity = u.MovementParameters.ParabolicGravity,
+                        // TODO: Implement as parameter (ex: Aatrox Q).
+                        ParabolicStartPoint = u.MovementParameters.ParabolicStartPoint,
+                        Facing = u.MovementParameters.KeepFacingDirection,
+                        FollowNetID = u.MovementParameters.FollowNetID,
+                        FollowDistance = u.MovementParameters.FollowDistance,
+                        FollowBackDistance = u.MovementParameters.FollowBackDistance,
+                        FollowTravelTime = u.MovementParameters.FollowTravelTime
+                    };
+                }
             }
 
-            var md = PacketExtensions.CreateMovementData(o, _navGrid, type, useTeleportID: useTeleportID);
+            var md = PacketExtensions.CreateMovementData(o, _navGrid, type, speeds, useTeleportID: useTeleportID);
 
             var enterVis = new OnEnterVisibilityClient // TYPO >:(
             {


### PR DESCRIPTION
Resolve #1191, #1193

* PacketHandler:
  * Forced movements are now properly networked for units entering vision.
* AttackableUnit:
  * Utilized CanMove() before calling Move().
  * Added UpdateStatus function which is used to automatically handle the application of the status effects of buffs.
  * Utilized fixed CanMove for SetWaypoints.
  * OnCollision no longer teleports if the owner or the collider is dashing.
  * Reordered SetStatus to align with StatusFlags enum.
  * Minimized SetDashingState action state applications.
  * Placed DashElapsedTime inside MovementParameters.
* ObjAiBase:
  * Refactored CanMove to better handle priority of checks.
* Buff:
  * Added StatusEffects variable for automatic handling of status flags.
  * Added SetStatusEffect function.
* Scripts:
  * SetStatus now adds each status individually to prevent multi-status flags from being ignored.
  * Utilized Buff.SetStatusEffect.