### PR TITLE
Resolve #1188, Resolve #1195 -- Fix CharScript Crash

### DIFF
--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -28,7 +28,7 @@ namespace GameServerCore.Domain.GameObjects
         /// <summary>
         /// The ID of the skin this unit should use for its model.
         /// </summary>
-        public int SkinID { get; }
+        int SkinID { get; }
         /// <summary>
         /// Whether or not this AI has finished an auto attack.
         /// </summary>
@@ -61,17 +61,16 @@ namespace GameServerCore.Domain.GameObjects
         OrderType MoveOrder { get; }
         bool IsNextAutoCrit { get; }
         Dictionary<short, ISpell> Spells { get; }
-        public ICharScript CharScript { get; }
+        ICharScript CharScript { get; }
         /// <summary>
         /// Unit this AI will auto attack when it is in auto attack range.
         /// </summary>
         IAttackableUnit TargetUnit { get; set; }
 
+        void LoadPassiveScript(ISpell spell);
         /// <summary>
         /// Function called by this AI's auto attack projectile when it hits its target.
         /// </summary>
-        public void LoadPassiveScript(ISpell spell);
-
         void AutoAttackHit(IAttackableUnit target);
         /// <summary>
         /// Cancels any auto attacks this AI is performing and resets the time between the next auto attack if specified.

--- a/GameServerLib/Game.cs
+++ b/GameServerLib/Game.cs
@@ -284,6 +284,7 @@ namespace LeagueSandbox.GameServer
             {
                 foreach (var champion in ObjectManager.GetAllChampions())
                 {
+                    champion.LoadPassiveScript(champion.Spells[(int)SpellSlotType.PassiveSpellSlot]);
                     champion.GetBuffs().ForEach(buff => buff.LoadScript());
                     champion.Spells.Values.ToList().ForEach(spell => spell.LoadScript());
                 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -25,8 +25,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         // Crucial Vars
         private float _autoAttackCurrentCooldown;
         private bool _skipNextAutoAttack;
-        protected ItemManager _itemManager;
         private Random _random = new Random();
+        private readonly CSharpScriptEngine _charScriptEngine;
+        protected ItemManager _itemManager;
 
         /// <summary>
         /// Variable storing all the data related to this AI's current auto attack. *NOTE*: Will be deprecated as the spells system gets finished.
@@ -80,8 +81,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public IAttackableUnit TargetUnit { get; set; }
         public Dictionary<short, ISpell> Spells { get; }
         public ICharScript CharScript { get; private set; }
-
-        private readonly CSharpScriptEngine _charScriptEngine;
 
         public ObjAiBase(Game game, string model, Stats.Stats stats, int collisionRadius = 40,
             Vector2 position = new Vector2(), int visionRadius = 0, int skinId = 0, uint netId = 0, TeamId team = TeamId.TEAM_NEUTRAL) :
@@ -691,11 +690,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             {
                 return;
             }
-            //Removes Passive
-            else if(slot == (int)SpellSlotType.PassiveSpellSlot)
-            {
-                CharScript.OnDeactivate(this, Spells[(int)SpellSlotType.PassiveSpellSlot]);
-            }
+            // Verify if we want to support removal/re-addition of character scripts.
             //Removes normal Spells
             else
             {

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -104,7 +104,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             else
             {
                 owner.LoadPassiveScript(this);
-                HasEmptyScript = owner.CharScript.GetType() == typeof(CharScriptEmpty);
             }
         }
 
@@ -113,8 +112,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             ApiEventManager.RemoveAllListenersForOwner(Script);
 
             Script = _scriptEngine.CreateObject<ISpellScript>("Spells", SpellName) ?? new SpellScriptEmpty();
-
-            HasEmptyScript = Script.GetType() == typeof(SpellScriptEmpty);
 
             if (Script.ScriptMetadata.TriggersSpellCasts)
             {


### PR DESCRIPTION
Resolve #1188, #1195

* Fixed a crash related to Spell.cs where the HasEmptyScript variable would be false for passives, resulting in a crash.
* DebugMode:
  * Changed lane minion debugging to simply minion debugging.
* Game:
  * Character scripts are supported for hot reloading.