### PR TITLE
Resolve #1207 -- Item not being consumed hotfix

### DIFF
--- a/GameServerLib/Items/InventoryManager.cs
+++ b/GameServerLib/Items/InventoryManager.cs
@@ -53,18 +53,25 @@ namespace LeagueSandbox.GameServer.Items
         }
         public bool RemoveItem(byte slot, IObjAiBase owner = null, int stacksToRemove = 1)
         {
-            var item = GetItem(slot);
-
+            var item = _inventory.Items[slot];
             if (item == null)
             {
                 return false;
             }
 
             _inventory.RemoveItem(slot, owner, stacksToRemove);
-            
-            if(owner != null)
+
+            if (owner != null)
             {
-                _packetNotifier.NotifyRemoveItem(owner, slot, (byte)item.StackCount);
+                item = _inventory.Items[slot];
+
+                byte stacks = 0;
+                if (item != null)
+                {
+                    stacks = (byte)item.StackCount;
+                }
+
+                _packetNotifier.NotifyRemoveItem(owner, slot, stacks);
             }
 
             return true;


### PR DESCRIPTION
Fixed the NotifyRemoveItem packet using info from a variable that contained info from an item before getting through the "RemoveItem" function

Resolve #1207