### PR TITLE
Resolve #1208, Resolve #1112 -- Fix SpellSectorPolygon

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Global/ExpirationTimer.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/ExpirationTimer.cs
@@ -1,0 +1,38 @@
+﻿using GameServerCore.Domain.GameObjects;
+using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects.Spell;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+
+namespace Buffs
+{
+    internal class ExpirationTimer : IBuffGameScript
+    {
+        public BuffType BuffType => BuffType.INTERNAL;
+        public BuffAddType BuffAddType => BuffAddType.REPLACE_EXISTING;
+        public int MaxStacks => 1;
+        public bool IsHidden => false;
+
+        public IStatsModifier StatsModifier { get; private set; }
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            buff.SetStatusEffect(StatusFlags.NoRender, true);
+            buff.SetStatusEffect(StatusFlags.Ghosted, true);
+            buff.SetStatusEffect(StatusFlags.Targetable, false);
+            buff.SetStatusEffect(StatusFlags.SuppressCallForHelp, true);
+            buff.SetStatusEffect(StatusFlags.ForceRenderParticles, true);
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            buff.SetStatusEffect(StatusFlags.Targetable, true);
+
+            unit.Die(CreateDeathData(false, 0, unit, unit, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_INTERNALRAW, 0));
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Champions/Akali/E.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Akali/E.cs
@@ -44,7 +44,7 @@ namespace Spells
         {
             var sector = spell.CreateSpellSector(new SectorParameters
             {
-                HalfLength = 300f,
+                Length = 300f,
                 SingleTick = true,
                 Type = SectorType.Area
             });

--- a/Content/LeagueSandbox-Scripts/Champions/Anivia/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Anivia/R.cs
@@ -59,7 +59,7 @@ namespace Spells
 
                 DamageSector = spell.CreateSpellSector(new SectorParameters
                 {
-                    HalfLength = 400f,
+                    Length = 400f,
                     Tickrate = 2,
                     CanHitSameTargetConsecutively = true,
                     OverrideFlags = SpellDataFlags.AffectEnemies | SpellDataFlags.AffectNeutral | SpellDataFlags.AffectMinions | SpellDataFlags.AffectHeroes,
@@ -68,7 +68,7 @@ namespace Spells
 
                 SlowSector = spell.CreateSpellSector(new SectorParameters
                 {
-                    HalfLength = 400f,
+                    Length = 400f,
                     Tickrate = 4,
                     CanHitSameTargetConsecutively = true,
                     OverrideFlags = SpellDataFlags.AffectEnemies | SpellDataFlags.AffectNeutral | SpellDataFlags.AffectMinions | SpellDataFlags.AffectHeroes,

--- a/Content/LeagueSandbox-Scripts/Champions/Annie/W.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Annie/W.cs
@@ -47,7 +47,7 @@ namespace Spells
 
             var sector = spell.CreateSpellSector(new SectorParameters
             {
-                HalfLength = 625f,
+                Length = 625f,
                 SingleTick = true,
                 ConeAngle = 24.76f,
                 Type = SectorType.Cone

--- a/Content/LeagueSandbox-Scripts/Champions/Diana/Passive.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Diana/Passive.cs
@@ -1,0 +1,57 @@
+﻿using GameServerCore.Domain.GameObjects;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using System.Numerics;
+using GameServerCore.Scripting.CSharp;
+
+namespace Passives
+{
+    public class DianaPassive : ICharScript
+    {
+        IObjAiBase diana = null;
+        float stanceTime = 500;
+        float stillTime = 0;
+        bool beginStance = false;
+        bool stance = false;
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+            diana = owner;
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+            if (diana != null)
+            {
+                // Not moving
+                if (diana.CurrentWaypoint.Value == diana.Position && !beginStance)
+                {
+                    PlayAnimation(diana, "Attack1", 5f);
+                    beginStance = true;
+                    if (stillTime >= stanceTime && !stance)
+                    {
+                        beginStance = false;
+                        stance = true;
+                        //PlayAnimation(diana, "Attack1", flags: GameServerCore.Enums.AnimationFlags.Lock);
+                    }
+                    else
+                    {
+                        stillTime += diff;
+                    }
+                }
+                else
+                {
+                    stillTime = 0;
+                    beginStance = false;
+                    stance = false;
+                }
+            }
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Champions/Lucian/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Lucian/Q.cs
@@ -48,7 +48,7 @@ namespace Spells
             spell.CreateSpellSector(new SectorParameters
             {
                 BindObject = owner,
-                HalfLength = 550f,
+                Length = 550f,
                 Width = spell.SpellData.LineWidth,
                 PolygonVertices = new Vector2[]
                 {

--- a/Content/LeagueSandbox-Scripts/Champions/Lux/R.cs
+++ b/Content/LeagueSandbox-Scripts/Champions/Lux/R.cs
@@ -1,10 +1,13 @@
 using System.Numerics;
+using GameServerCore.Enums;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
-using GameServerCore.Domain.GameObjects.Spell.Missile;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using GameServerCore.Domain.GameObjects.Spell.Sector;
 
 namespace Spells
 {
@@ -12,6 +15,7 @@ namespace Spells
     {
         public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
+            TriggersSpellCasts = true
             // TODO
         };
 
@@ -29,17 +33,101 @@ namespace Spells
 
         public void OnSpellCast(ISpell spell)
         {
-            var current = new Vector2(spell.CastInfo.Owner.Position.X, spell.CastInfo.Owner.Position.Y);
+            var owner = spell.CastInfo.Owner;
             var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
-            var to = Vector2.Normalize(spellPos - current);
 
-            spell.CastInfo.Owner.FaceDirection(new Vector3(to.X, 0.0f, to.Y), false);
-
-            // TODO: SpellCast LuxMaliceCannonMis
+            SpellCast(owner, 2, SpellSlotType.ExtraSlots, spellPos, spellPos, false, Vector2.Zero);
         }
 
         public void OnSpellPostCast(ISpell spell)
         {
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+
+    public class LuxMaliceCannonMis : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true
+            // TODO
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+            ApiEventManager.OnSpellHit.AddListener(this, spell, TargetExecute, false);
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+            var owner = spell.CastInfo.Owner;
+            SetStatus(owner, StatusFlags.ForceRenderParticles, true);
+            var startPoint = GetPointFromUnit(owner, 145f);
+            var endPoint = GetPointFromUnit(owner, 3400f);
+            var tempMinion = AddMinion(owner, "TestCubeRender", "TestCubeRender", startPoint, ignoreCollision: true, targetable: false);
+            AddBuff("ExpirationTimer", 2.0f, 1, spell, tempMinion, owner);
+
+            // TODO: Vision
+
+            AddParticle(owner, tempMinion, "luxmalicecannon_beam.troy", endPoint, bone: "top", lifetime: 2.0f);
+            AddParticle(owner, tempMinion, "luxmalicecannon_cas.troy", endPoint, bone: "top", lifetime: 2.0f);
+            AddParticle(owner, null, "luxmalicecannon_beammiddle.troy", GetPointFromUnit(owner, 1650f));
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+            var owner = spell.CastInfo.Owner;
+            var endPoint = GetPointFromUnit(owner, 3400f);
+
+            spell.CreateSpellSector(new SectorParameters
+            {
+                BindObject = owner,
+                Length = 3400f,
+                Width = 100f,
+                PolygonVertices = new Vector2[]
+                {
+                    // Basic square, however the values will be scaled by Length/Width, which will make it a rectangle
+                    new Vector2(-1, 0),
+                    new Vector2(-1, 1),
+                    new Vector2(1, 1),
+                    new Vector2(1, 0)
+                },
+                SingleTick = true,
+                Type = SectorType.Polygon
+            });
+        }
+
+        public void TargetExecute(ISpell spell, IAttackableUnit target, ISpellMissile missile, ISpellSector sector)
+        {
+            var owner = spell.CastInfo.Owner;
+
+            var damage = 300f + (100f * spell.CastInfo.SpellLevel - 1) + (owner.Stats.AbilityPower.Total * 0.75f);
+            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL,
+                false);
+            AddParticleTarget(owner, target, "luxmalicecannon_tar.troy", target, 1.0f);
         }
 
         public void OnSpellChannel(ISpell spell)

--- a/GameServerCore/Domain/GameObjects/IParticle.cs
+++ b/GameServerCore/Domain/GameObjects/IParticle.cs
@@ -25,9 +25,13 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         IGameObject TargetObject { get; }
         /// <summary>
-        /// Position this object is spawned at. *NOTE*: Does not update. Refer to TargetObject.GetPosition() if particle is supposed to be attached.
+        /// Position this object is spawned at.
         /// </summary>
-        Vector2 TargetPosition { get; }
+        Vector2 StartPosition { get; }
+        /// <summary>
+        /// Position this object is aimed at and/or moving towards.
+        /// </summary>
+        Vector2 EndPosition { get; }
         /// <summary>
         /// Client-sided, internal name of the bone that this particle should be attached to for networking
         /// </summary>

--- a/GameServerCore/Domain/GameObjects/Spell/Sector/ISectorParameters.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/Sector/ISectorParameters.cs
@@ -13,14 +13,14 @@ namespace GameServerCore.Domain.GameObjects.Spell.Sector
         /// </summary>
         IGameObject BindObject { get; set; }
         /// <summary>
-        /// Half the distance from the center of the sector to the maximum Y-value.
+        /// Distance from the bottom of the sector to the top.
         /// If this is larger than Width, it will be used as the area around the sector to check for collisions.
         /// Scales the distance (in y) between PolygonVertices.
         /// </summary>
-        float HalfLength { get; set; }
+        float Length { get; set; }
         /// <summary>
-        /// Distance from the center of the sector to the maximum X-value.
-        /// If this is larger than HalfLength, it will be used as the area around the sector to check for collisions.
+        /// Distance from the left side of the sector to the right side.
+        /// If this is larger than Length, it will be used as the area around the sector to check for collisions.
         /// Scales the distance (in x) between PolygonVertices.
         /// </summary>
         float Width { get; set; }

--- a/GameServerCore/Domain/GameObjects/Spell/Sector/ISpellSectorPolygon.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/Sector/ISpellSectorPolygon.cs
@@ -1,0 +1,9 @@
+﻿using System.Numerics;
+
+namespace GameServerCore.Domain.GameObjects.Spell.Sector
+{
+    public interface ISpellSectorPolygon : ISpellSector
+    {
+        Vector2[] GetPolygonVertices();
+    }
+}

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -277,6 +277,29 @@ namespace LeagueSandbox.GameServer.API
         /// Creates a new particle with the specified parameters.
         /// </summary>
         /// <param name="caster">GameObject that caused this particle to spawn.</param>
+        /// <param name="particle">Internal name of the particle.</param>
+        /// <param name="start">Position to spawn at.</param>
+        /// <param name="end">Position to end at.</param>
+        /// <param name="lifetime">Time in seconds the particle should last.</param>
+        /// <param name="size">Scale.</param>
+        /// <param name="bone">Bone on the owner the particle should be attached to.</param>
+        /// <param name="targetBone">Bone on the target the particle should be attached to.</param>
+        /// <param name="direction">3D direction the particle should face.</param>
+        /// <param name="followGroundTilt">Whether or not the particle should be titled along the ground towards its end position.</param>
+        /// <param name="reqVision">Whether or not the particle can be obstructed by terrain.</param>
+        /// <param name="teamOnly">The only team which should be able to see the particle.</param>
+        /// <param name="flags">Flags which determine how the particle behaves. Refer to FXFlags enum.</param>
+        /// <returns>New particle instance.</returns>
+        public static IParticle AddParticlePos(IGameObject caster, string particle, Vector2 start, Vector2 end, float lifetime = 1.0f, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), bool followGroundTilt = false, bool reqVision = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL, FXFlags flags = FXFlags.BindDirection)
+        {
+            var p = new Particle(_game, caster, start, end, particle, size, bone, targetBone, 0, direction, followGroundTilt, lifetime, reqVision, true, teamOnly, flags);
+            return p;
+        }
+
+        /// <summary>
+        /// Creates a new particle with the specified parameters.
+        /// </summary>
+        /// <param name="caster">GameObject that caused this particle to spawn.</param>
         /// <param name="bindObj">GameObject that the particle should bind to.</param>
         /// <param name="particle">Internal name of the particle.</param>
         /// <param name="position">Position to spawn at.</param>
@@ -744,7 +767,7 @@ namespace LeagueSandbox.GameServer.API
                 UseAttackCastTime = useAutoAttackSpell,
                 UseAttackCastDelay = false,
                 IsForceCastingOrChannel = isForceCastingOrChanneling,
-                
+
                 SpellSlot = (byte)slot,
                 SpellCastLaunchPosition = caster.GetPosition3D()
             };

--- a/GameServerLib/GameObjects/Particle.cs
+++ b/GameServerLib/GameObjects/Particle.cs
@@ -31,9 +31,13 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// </summary>
         public IGameObject TargetObject { get; }
         /// <summary>
-        /// Position this object is spawned at. *NOTE*: Does not update. Refer to TargetObject.GetPosition() if particle is supposed to be attached.
+        /// Position this object is spawned at.
         /// </summary>
-        public Vector2 TargetPosition { get; private set; }
+        public Vector2 StartPosition { get; private set; }
+        /// <summary>
+        /// Position this object is aimed at and/or moving towards.
+        /// </summary>
+        public Vector2 EndPosition { get; private set; }
         /// <summary>
         /// Client-sided, internal name of the bone that this particle should be attached to on the owner, for networking.
         /// </summary>
@@ -96,7 +100,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             Caster = caster;
             BindObject = bindObj;
             TargetObject = target;
-            TargetPosition = TargetObject.Position;
+            StartPosition = TargetObject.Position;
             Name = particleName;
             BoneName = boneName;
             TargetBoneName = targetBoneName;
@@ -148,7 +152,55 @@ namespace LeagueSandbox.GameServer.GameObjects
             }
 
             TargetObject = null;
-            TargetPosition = targetPos;
+            StartPosition = targetPos;
+            Name = particleName;
+            BoneName = boneName;
+            TargetBoneName = targetBoneName;
+            Scale = scale;
+            Direction = direction;
+            Lifetime = lifetime;
+            VisionAffected = reqVision;
+            SpecificTeam = teamOnly;
+            FollowsGroundTilt = followGroundTilt;
+            Flags = flags;
+
+            _game.ObjectManager.AddObject(this);
+
+            if (autoSend)
+            {
+                _game.PacketNotifier.NotifyFXCreateGroup(this);
+            }
+        }
+
+        /// <summary>
+        /// Prepares the Particle, setting up the information required for networking it to clients.
+        /// This particle will spawn and stay at the specified position.
+        /// </summary>
+        /// <param name="game">Game instance.</param>
+        /// <param name="caster">GameObject that caused this particle to spawn.</param>
+        /// <param name="startPos">Position the particle will spawn at.</param>
+        /// <param name="endPos">Position the particle will end at.</param>
+        /// <param name="particleName">Name used by League of Legends interally (ex: DebugCircle.troy).</param>
+        /// <param name="scale">Scale of the Particle.</param>
+        /// <param name="boneName">Name used by League of Legends internally where the Particle should be attached. Only useful when the target is a GameObject.</param>
+        /// <param name="targetBoneName">Bone of the target to attach to.</param>
+        /// <param name="netId">NetID that should be forced onto the Particle. *NOTE*: Exceptions unhandled, expect crashes if NetID is already owned by a GameObject.</param>
+        /// <param name="direction">3 dimensional vector representing the particle's orientation; unit vector forward.</param>
+        /// <param name="followGroundTilt">Whether or not the particle should be titled along the ground towards its end position.</param>
+        /// <param name="lifetime">Number of seconds the Particle should exist.</param>
+        /// <param name="reqVision">Whether or not the Particle is affected by vision checks.</param>
+        /// <param name="autoSend">Whether or not to automatically send the Particle packet to clients.</param>
+        /// <param name="teamOnly">The only team that should be able to see this particle.</param>
+        /// <param name="flags">Flags which determine how the particle behaves. Refer to FXFlags enum.</param>
+        public Particle(Game game, IGameObject caster, Vector2 startPos, Vector2 endPos, string particleName, float scale = 1.0f, string boneName = "", string targetBoneName = "", uint netId = 0, Vector3 direction = new Vector3(), bool followGroundTilt = false, float lifetime = 0, bool reqVision = true, bool autoSend = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL, FXFlags flags = FXFlags.GivenDirection)
+               : base(game, startPos, 0, 0, netId, teamOnly)
+        {
+            Caster = caster;
+
+            BindObject = null;
+            TargetObject = null;
+            StartPosition = startPos;
+            EndPosition = endPos;
             Name = particleName;
             BoneName = boneName;
             TargetBoneName = targetBoneName;

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSector.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSector.cs
@@ -50,7 +50,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             ISpell originSpell,
             ICastInfo castInfo,
             uint netId = 0
-        ) : base(game, new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z), Math.Max(parameters.HalfLength, parameters.Width), 0, netId)
+        ) : base(game, new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z), Math.Max(parameters.Length, parameters.Width), 0, netId)
         {
             _timeSinceCreation = 0.0f;
             _lastTickTime = 0.0f;

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -692,11 +692,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             }
             else
             {
-                if (Script.ScriptMetadata.MissileParameters == null && Script.ScriptMetadata.SectorParameters == null)
-                {
-                    ApplyEffects(CastInfo.Targets[0].Unit);
-                }
-
                 if (SpellData.ChannelDuration[CastInfo.SpellLevel] <= 0)
                 {
                     State = SpellState.STATE_COOLDOWN;

--- a/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
@@ -115,14 +115,14 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         /// </summary>
         public IGameObject BindObject { get; set; } = null;
         /// <summary>
-        /// Half the distance from the center of the sector to the maximum Y-value.
+        /// Distance from the bottom of the sector to the top.
         /// If this is larger than Width, it will be used as the area around the sector to check for collisions.
         /// Scales the distance (in y) between PolygonVertices.
         /// </summary>
-        public float HalfLength { get; set; } = 0f;
+        public float Length { get; set; } = 0f;
         /// <summary>
-        /// Distance from the center of the sector to the maximum X-value.
-        /// If this is larger than HalfLength, it will be used as the area around the sector to check for collisions.
+        /// Distance from the left side of the sector to the right side.
+        /// If this is larger than Length, it will be used as the area around the sector to check for collisions.
         /// Scales the distance (in x) between PolygonVertices.
         /// </summary>
         public float Width { get; set; } = 0f;

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -346,19 +346,19 @@ namespace PacketDefinitions420
             _packetHandlerManager.BroadcastPacketVision(attacker, basicAttackPacket.GetBytes(), Channel.CHL_S2C);
         }
 
-    /// <summary>
-    /// Sends a side bar tip to the specified player (ex: quest tips).
-    /// </summary>
-    /// <param name="userId">User to send the packet to.</param>
-    /// <param name="title">Title of the tip.</param>
-    /// <param name="text">Description text of the tip.</param>
-    /// <param name="imagePath">Path to an image that will be embedded in the tip.</param>
-    /// <param name="tipCommand">Action suggestion(? unconfirmed).</param>
-    /// <param name="playerNetId">NetID to send the packet to.</param>
-    /// <param name="targetNetId">NetID of the target referenced by the tip.</param>
-    /// TODO: tipCommand should be a lib/core enum that gets translated into a league version specific packet enum as it may change over time.
-    public void NotifyBlueTip(int userId, string title, string text, string imagePath, byte tipCommand, uint playerNetId,
-            uint targetNetId)
+        /// <summary>
+        /// Sends a side bar tip to the specified player (ex: quest tips).
+        /// </summary>
+        /// <param name="userId">User to send the packet to.</param>
+        /// <param name="title">Title of the tip.</param>
+        /// <param name="text">Description text of the tip.</param>
+        /// <param name="imagePath">Path to an image that will be embedded in the tip.</param>
+        /// <param name="tipCommand">Action suggestion(? unconfirmed).</param>
+        /// <param name="playerNetId">NetID to send the packet to.</param>
+        /// <param name="targetNetId">NetID of the target referenced by the tip.</param>
+        /// TODO: tipCommand should be a lib/core enum that gets translated into a league version specific packet enum as it may change over time.
+        public void NotifyBlueTip(int userId, string title, string text, string imagePath, byte tipCommand, uint playerNetId,
+                uint targetNetId)
         {
             var packet = new BlueTip(title, text, imagePath, tipCommand, playerNetId, targetNetId);
             _packetHandlerManager.SendPacket(userId, packet, Channel.CHL_S2C);
@@ -448,7 +448,7 @@ namespace PacketDefinitions420
                 IsSummonerSpell = isSummonerSpell
             };
 
-            switch(changeType)
+            switch (changeType)
             {
                 case GameServerCore.Enums.ChangeSlotSpellDataType.TargetingType:
                 {
@@ -935,7 +935,13 @@ namespace PacketDefinitions420
             var fxPacket = new FX_Create_Group();
             var fxDataList = new List<FXCreateData>();
 
-            var targetHeight = _navGrid.GetHeightAtLocation(particle.TargetPosition.X, particle.TargetPosition.Y);
+            var targetPos = particle.StartPosition;
+            if (particle.BindObject == null && particle.TargetObject == null)
+            {
+                targetPos = particle.EndPosition;
+            }
+
+            var targetHeight = _navGrid.GetHeightAtLocation(particle.StartPosition.X, particle.StartPosition.Y);
             var higherValue = Math.Max(targetHeight, particle.GetHeight());
 
             // TODO: implement option for multiple particles instead of hardcoding one
@@ -949,9 +955,9 @@ namespace PacketDefinitions420
                 PositionY = higherValue,
                 PositionZ = (short)((position.Z - _navGrid.MapHeight / 2) / 2),
 
-                TargetPositionX = (short)((particle.TargetPosition.X - _navGrid.MapWidth / 2) / 2),
+                TargetPositionX = (short)((targetPos.X - _navGrid.MapWidth / 2) / 2),
                 TargetPositionY = higherValue,
-                TargetPositionZ = (short)((particle.TargetPosition.Y - _navGrid.MapHeight / 2) / 2),
+                TargetPositionZ = (short)((targetPos.Y - _navGrid.MapHeight / 2) / 2),
 
                 OwnerPositionX = (short)((ownerPos.X - _navGrid.MapWidth / 2) / 2),
                 OwnerPositionY = ownerPos.Y,


### PR DESCRIPTION
Resolve #1208, #1112

* SpellSector:
  * Polygon:
    * Switched from internal methods of checking intersection to Clipper.
  * Parameters:
    * Updated names and descriptions of Length and Width.
* Particle:
  * Added support for position only particles (does not require objects). Does not support changing height.
* Debug Mode:
  * Added support for sectors (can be improved).
* Scripting:
  * Added ExpirationTimer buff for general use with temporary minions.
  * Implemented Lux R (mostly)
  * Added AddParticlePos function.
* Spell:
  * Fixed an issue with spell hits being applied unnecessarily.