### PR TITLE
Resolve #1213 -- Fix Missplaced OnTakeDamage Event

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -438,6 +438,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             ApiEventManager.OnPreTakeDamage.Publish(this, attacker);
 
             Stats.CurrentHealth = Math.Max(0.0f, Stats.CurrentHealth - damage);
+
+            ApiEventManager.OnTakeDamage.Publish(this, attacker);
+
             if (!IsDead && Stats.CurrentHealth <= 0)
             {
                 IsDead = true;
@@ -451,8 +454,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                     DamageSource = source,
                     DeathDuration = 0 // TODO: Unhardcode
                 };
-
-                ApiEventManager.OnTakeDamage.Publish(this, attacker);
             }
 
             int attackerId = 0, targetId = 0;


### PR DESCRIPTION
* Fixed OnTakeDamage being inside a `if` statement that checks if the unit died, which is leading to incorrect behavior.

Resolve #1213 