### PR TITLE
Inhibit TT fix

### DIFF
--- a/GameServerLib/Config.cs
+++ b/GameServerLib/Config.cs
@@ -191,7 +191,7 @@ namespace LeagueSandbox.GameServer
                 {
                     type = GameObjectTypes.ObjAnimated_HQ;
                 }
-                else if (Name.Contains("Barracks"))
+                else if (Name.Contains("Barracks") && !Name.Contains("_Spawn"))
                 {
                     // Inhibitors are dampeners for the enemy Nexus.
                     type = GameObjectTypes.ObjAnimated_BarracksDampener;


### PR DESCRIPTION
Fix an issue where in some instances (loading Twisted Treeline map), Minion spawn position files would be taken in as inhibitors files
