### PR TITLE
Resolve #1227 Consumables Crash Hotfix

### DIFF
--- a/GameServerLib/Items/Inventory.cs
+++ b/GameServerLib/Items/Inventory.cs
@@ -123,14 +123,20 @@ namespace LeagueSandbox.GameServer.Items
             var itemID = Items[slot].ItemData.ItemId;
             int finalStacks = Items[slot].StackCount - stacksToRemove;
 
-            if ((finalStacks <= 0 || !HasItemWithID(itemID)) && owner != null && ItemScripts.ContainsKey(itemID))
+            if (finalStacks <= 0 || !HasItemWithID(itemID))
             {
-                ItemScripts[itemID].OnDeactivate(owner);
-                if (ItemScripts[itemID].StatsModifier != null)
+                if (ItemScripts.ContainsKey(itemID))
                 {
-                    owner.Stats.RemoveModifier(ItemScripts[itemID].StatsModifier);
+                    if (owner != null)
+                    {
+                        ItemScripts[itemID].OnDeactivate(owner);
+                        if (ItemScripts[itemID].StatsModifier != null)
+                        {
+                            owner.Stats.RemoveModifier(ItemScripts[itemID].StatsModifier);
+                        }
+                    }
+                    ItemScripts.Remove(itemID);
                 }
-                ItemScripts.Remove(itemID);
                 Items[slot] = null;
             }
             else

--- a/GameServerLib/Items/Inventory.cs
+++ b/GameServerLib/Items/Inventory.cs
@@ -117,25 +117,20 @@ namespace LeagueSandbox.GameServer.Items
         {
             if (stacksToRemove < 0)
             {
-                stacksToRemove = 0;
+                throw new Exception("Stacks to be Removed can't be a negative number!");
             }
 
             var itemID = Items[slot].ItemData.ItemId;
             int finalStacks = Items[slot].StackCount - stacksToRemove;
 
-            if (finalStacks <= 0)
+            if ((finalStacks <= 0 || !HasItemWithID(itemID)) && owner != null && ItemScripts.ContainsKey(itemID))
             {
-                if (owner != null)
+                ItemScripts[itemID].OnDeactivate(owner);
+                if (ItemScripts[itemID].StatsModifier != null)
                 {
-                    owner.Stats.RemoveModifier(Items[slot].ItemData);
-
-                    ItemScripts[itemID].OnDeactivate(owner);
-                    if (ItemScripts[itemID].StatsModifier != null)
-                    {
-                        owner.Stats.RemoveModifier(ItemScripts[itemID].StatsModifier);
-                    }
-                    ItemScripts.Remove(itemID);
+                    owner.Stats.RemoveModifier(ItemScripts[itemID].StatsModifier);
                 }
+                ItemScripts.Remove(itemID);
                 Items[slot] = null;
             }
             else

--- a/GameServerLib/Items/Inventory.cs
+++ b/GameServerLib/Items/Inventory.cs
@@ -117,8 +117,9 @@ namespace LeagueSandbox.GameServer.Items
         {
             if (stacksToRemove < 0)
             {
-                throw new Exception("Stacks to be Removed can't be a negative number!");
+                stacksToRemove = 0;
             }
+
             var itemID = Items[slot].ItemData.ItemId;
             int finalStacks = Items[slot].StackCount - stacksToRemove;
 
@@ -133,23 +134,13 @@ namespace LeagueSandbox.GameServer.Items
                     {
                         owner.Stats.RemoveModifier(ItemScripts[itemID].StatsModifier);
                     }
-                    ItemScripts.Remove(GetItem(slot).ItemData.ItemId);
+                    ItemScripts.Remove(itemID);
                 }
                 Items[slot] = null;
             }
             else
             {
                 Items[slot].SetStacks(finalStacks);
-            }
-
-            if (!HasItemWithID(itemID) && owner != null)
-            {
-                ItemScripts[itemID].OnDeactivate(owner);
-                if (ItemScripts[itemID].StatsModifier != null)
-                {
-                    owner.Stats.RemoveModifier(ItemScripts[itemID].StatsModifier);
-                }
-                ItemScripts.Remove(itemID);
             }
         }
         public bool HasItemWithID(int ItemID)


### PR DESCRIPTION
*`RemoveItem` in `Inventory.cs` no longer tries to remove the same item's script twice, resulting on a crash