### PR TITLE
Resolve #1245 -- Introduced MapMetadata and Rework on how champion XP/Leveling is handled

### DIFF
--- a/Content/LeagueSandbox-Scripts/Maps/Map1/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/CLASSIC.cs
@@ -6,29 +6,23 @@ using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using GameServerCore.Maps;
 using LeagueSandbox.GameServer.Content;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace MapScripts.Map1
 {
     public class CLASSIC : IMapScript
     {
+        public IMapScriptMetadata MapScriptMetadata { get; set; } = new MapScriptMetadata 
+        {
+            MinionPathingOverride = true,
+            EnableBuildingProtection = true
+        };
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
-        public bool EnableBuildingProtection { get; set; } = true;
-        //General Map variable
+        public bool HasFirstBloodHappened { get; set; } = false;
+        public long NextSpawnTime { get; set; } = 90 * 1000;
         public IMapScriptHandler _map;
 
-        //Stuff about minions
-        public bool SpawnEnabled { get; set; }
-        public long NextSpawnTime { get; set; } = 90 * 1000;
-        public long SpawnInterval { get; set; } = 30 * 1000;
-        public bool MinionPathingOverride { get; set; } = true;
-
-        //General things that will affect players globaly, such as default gold per-second, Starting gold....
-        public float GoldPerSecond { get; set; } = 1.9f;
-        public float StartingGold { get; set; } = 475.0f;
-        public bool HasFirstBloodHappened { get; set; } = false;
-        public bool IsKillGoldRewardReductionActive { get; set; } = true;
-        public int BluePillId { get; set; } = 2001;
-        public long FirstGoldTime { get; set; } = 90 * 1000;
 
         //Tower type enumeration might vary slightly from map to map, so we set that up here
         public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)
@@ -248,7 +242,7 @@ namespace MapScripts.Map1
         public virtual void Init(IMapScriptHandler map)
         {
             _map = map;
-            SpawnEnabled = map.IsMinionSpawnEnabled();
+            MapScriptMetadata.MinionSpawnEnabled = map.IsMinionSpawnEnabled();
             map.AddSurrender(1200000.0f, 300000.0f, 30.0f);
 
             //Due to riot's questionable map-naming scheme some towers are missplaced into other lanes during outomated setup, so we have to manually fix them.
@@ -275,6 +269,10 @@ namespace MapScripts.Map1
         //This function gets executed every server tick
         public void Update(float diff)
         {
+            if (_map.GameTime() >= 120 * 1000)
+            {
+                MapScriptMetadata.IsKillGoldRewardReductionActive = false;
+            }
         }
 
 

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/CLASSIC.cs
@@ -5,31 +5,23 @@ using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using GameServerCore.Maps;
+using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.Content;
+using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace MapScripts.Map10
 {
     public class CLASSIC : IMapScript
     {
+        public IMapScriptMetadata MapScriptMetadata { get; set; } = new MapScriptMetadata
+        {
+            EnableBuildingProtection = true,
+            StartingGold = 825.0f
+        };
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
-        public bool EnableBuildingProtection { get; set; } = true;
-
-        //General Map variable
-        private IMapScriptHandler _map;
-
-        //Stuff about minions
-        public bool SpawnEnabled { get; set; }
-        public long NextSpawnTime { get; set; } = 45 * 1000;
-        public long SpawnInterval { get; set; } = 30 * 1000;
-        public bool MinionPathingOverride { get; set; } = false;
-
-        //General things that will affect players globaly, such as default gold per-second, Starting gold....
-        public float GoldPerSecond { get; set; } = 1.9f;
-        public float StartingGold { get; set; } = 825.0f;
         public bool HasFirstBloodHappened { get; set; } = false;
-        public bool IsKillGoldRewardReductionActive { get; set; } = true;
-        public int BluePillId { get; set; } = 2001;
-        public long FirstGoldTime { get; set; } = 90 * 1000;
+        public long NextSpawnTime { get; set; } = 45 * 1000;
+        private IMapScriptHandler _map;
 
         //Tower type enumeration might vary slightly from map to map, so we set that up here
         public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)
@@ -197,7 +189,7 @@ namespace MapScripts.Map10
         {
             _map = map;
 
-            SpawnEnabled = map.IsMinionSpawnEnabled();
+            MapScriptMetadata.MinionSpawnEnabled = map.IsMinionSpawnEnabled();
             map.AddSurrender(1200000.0f, 300000.0f, 30.0f);
 
             //Due to riot's questionable map-naming scheme some towers are missplaced into other lanes during outomated setup, so we have to manually fix them.
@@ -213,18 +205,18 @@ namespace MapScripts.Map10
             map.AddLevelProp("LevelProp_TT_Brazier1", "TT_Brazier", new Vector2(1360.9241f, 5072.1309f), 291.2142f, new Vector3(11.1111f, 134.0f, 0.0f), new Vector3(0.0f, 288.8889f, -22.2222f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Brazier2", "TT_Brazier", new Vector2(423.5712f, 6529.0327f), 385.9983f, new Vector3(-33.3334f, 0.0f, 0.0f), new Vector3(0.0f, 277.7778f, -11.1111f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Brazier3", "TT_Brazier", new Vector2(399.4241f, 8021.057f), 692.2211f, new Vector3(-22.2222f, 0.0f, 0.0f), new Vector3(0.0f, 300f, 0.0f), Vector3.One);
-            map.AddLevelProp("LevelProp_TT_Brazier4", "TT_Brazier", new Vector2(1314.294f, 9495.576f), 582.8416f, new Vector3(-33.3334f, 48.0f,0.0f ), new Vector3(0.0f, 277.7778f, 22.2223f), Vector3.One);
+            map.AddLevelProp("LevelProp_TT_Brazier4", "TT_Brazier", new Vector2(1314.294f, 9495.576f), 582.8416f, new Vector3(-33.3334f, 48.0f, 0.0f), new Vector3(0.0f, 277.7778f, 22.2223f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Brazier5", "TT_Brazier", new Vector2(14080.0f, 9530.3379f), 305.0638f, new Vector3(11.1111f, 120.0f, 0.0f), new Vector3(0.0f, 277.7778f, 0.0f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Brazier6", "TT_Brazier", new Vector2(14990.46f, 8053.91f), 675.8145f, new Vector3(-22.2222f, 0.0f, 0.0f), new Vector3(0.0f, 266.6666f, -11.1111f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Brazier7", "TT_Brazier", new Vector2(15016.35f, 6532.84f), 664.7033f, new Vector3(-11.1111f, 0.0f, 0.0f), new Vector3(0.0f, 255.5555f, -11.1111f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Brazier8", "TT_Brazier", new Vector2(14102.99f, 5098.367f), 580.504f, new Vector3(0.0f, 36.0f, 0.0f), new Vector3(0.0f, 244.4445f, 11.1111f), Vector3.One);
-            map.AddLevelProp("LevelProp_TT_Chains_Bot_Lane", "TT_Chains_Bot_Lane", new Vector2(3624.281f, 3730.965f), -100.4387f, new Vector3(88.8889f,0.0f , 0.0f), new Vector3(0.0f, -33.3334f, 66.6667f), Vector3.One);
+            map.AddLevelProp("LevelProp_TT_Chains_Bot_Lane", "TT_Chains_Bot_Lane", new Vector2(3624.281f, 3730.965f), -100.4387f, new Vector3(88.8889f, 0.0f, 0.0f), new Vector3(0.0f, -33.3334f, 66.6667f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Chains_Order_Base", "TT_Chains_Order_Base", new Vector2(3778.364f, 7573.525f), -496.0713f, new Vector3(-233.3334f, 0.0f, 0.0f), new Vector3(0.0f, -333.3333f, 277.7778f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Chains_Xaos_Base", "TT_Chains_Xaos_Base", new Vector2(11636.06f, 7618.667f), -551.6268f, new Vector3(200.0f, 0.0f, 0.0f), new Vector3(0.0f, -388.8889f, 33.3334f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Chains_Order_Periph", "TT_Chains_Order_Periph", new Vector2(759.1779f, 4740.938f), 507.9883f, new Vector3(-155.5555f, 0.0f, 0.0f), new Vector3(0.0f, 44.4445f, 222.2222f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Nexus_Gears", "TT_Nexus_Gears", new Vector2(3000.0f, 7289.682f), 19.51249f, Vector3.Zero, new Vector3(0.0f, 144.4445f, 0.0f), Vector3.One);
-            map.AddLevelProp("LevelProp_TT_Nexus_Gears1", "TT_Nexus_Gears", new Vector2(12436.4775f, 7366.5859f), -124.9320f, new Vector3(-44.4445f, 180.0f,0.0f ), new Vector3(0.0f, 122.2222f, -122.2222f), Vector3.One);
-            map.AddLevelProp("LevelProp_TT_Shopkeeper1", "TT_Shopkeeper", new Vector2(14169.09f, 7916.989f), 178.1922f, new Vector3(22.2223f, 150f,0.0f ), new Vector3(33.3333f,0.0f , -66.6667f), Vector3.One);
+            map.AddLevelProp("LevelProp_TT_Nexus_Gears1", "TT_Nexus_Gears", new Vector2(12436.4775f, 7366.5859f), -124.9320f, new Vector3(-44.4445f, 180.0f, 0.0f), new Vector3(0.0f, 122.2222f, -122.2222f), Vector3.One);
+            map.AddLevelProp("LevelProp_TT_Shopkeeper1", "TT_Shopkeeper", new Vector2(14169.09f, 7916.989f), 178.1922f, new Vector3(22.2223f, 150f, 0.0f), new Vector3(33.3333f, 0.0f, -66.6667f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Shopkeeper", "TT_Shopkeeper", new Vector2(1340.8141f, 7996.8691f), 126.2980f, new Vector3(208f, -66.6667f, 0.0f), new Vector3(0.0f, 22.2223f, -55.5556f), Vector3.One);
             map.AddLevelProp("LevelProp_TT_Speedshrine_Gears", "TT_Speedshrine_Gears", new Vector2(7706.3052f, 6720.3926f), -124.9320f, Vector3.Zero, Vector3.Zero, Vector3.One);
         }

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/CLASSIC.cs
@@ -5,34 +5,28 @@ using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using GameServerCore.Maps;
+using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.Content;
 using LeagueSandbox.GameServer.Logging;
+using LeagueSandbox.GameServer.Scripting.CSharp;
 using log4net;
 
 namespace MapScripts.Map12
 {
     public class CLASSIC : IMapScript
     {
+        public IMapScriptMetadata MapScriptMetadata { get; set; } = new MapScriptMetadata
+        {
+            StartingGold = 1375.0f,
+            GoldPerSecond = 5.0f,
+            //TODO: Figure out what to do with the recall spell, if ARAM has an special item or just Seals it
+            RecallSpellItemId = 2001,
+            EnableFountainHealing = false
+        };
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
-        public bool EnableBuildingProtection { get; set; } = true;
-
-        //General Map variable
-        private IMapScriptHandler _map;
-        private static ILog _logger = LoggerProvider.GetLogger();
-
-        //Stuff about minions
-        public bool SpawnEnabled { get; set; }
-        public long NextSpawnTime { get; set; } = 45 * 1000;
-        public long SpawnInterval { get; set; } = 30 * 1000;
-        public bool MinionPathingOverride { get; set; } = false;
-
-        //General things that will affect players globaly, such as default gold per-second, Starting gold....
-        public float GoldPerSecond { get; set; } = 5.0f;
-        public float StartingGold { get; set; } = 1375.0f;
         public bool HasFirstBloodHappened { get; set; } = false;
-        public bool IsKillGoldRewardReductionActive { get; set; } = true;
-        public int BluePillId { get; set; } = 2001;
-        public long FirstGoldTime { get; set; } = 90 * 1000;
+        public long NextSpawnTime { get; set; } = 45 * 1000;
+        private IMapScriptHandler _map;
 
         //Tower type enumeration might vary slightly from map to map, so we set that up here
         public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)
@@ -200,7 +194,7 @@ namespace MapScripts.Map12
         {
             _map = map;
 
-            SpawnEnabled = map.IsMinionSpawnEnabled();
+            MapScriptMetadata.MinionSpawnEnabled = map.IsMinionSpawnEnabled();
 
             foreach (var key in map.SpawnBarracks.Keys)
             {

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/CLASSIC.cs
@@ -5,31 +5,23 @@ using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using GameServerCore.Maps;
+using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.Content;
+using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace MapScripts.Map8
 {
     public class CLASSIC : IMapScript
     {
+        public IMapScriptMetadata MapScriptMetadata { get; set; } = new MapScriptMetadata
+        {
+            MinionSpawnEnabled = false,
+            StartingGold = 825.0f
+        };
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
-        public bool EnableBuildingProtection { get; set; } = true;
-
-        //General Map variable
-        private IMapScriptHandler _map;
-
-        //Stuff about minions
-        public bool SpawnEnabled { get; set; } = false;
-        public long NextSpawnTime { get; set; } = 90 * 1000;
-        public long SpawnInterval { get; set; } = 30 * 1000;
-        public bool MinionPathingOverride { get; set; } = false;
-
-        //General things that will affect players globaly, such as default gold per-second, Starting gold....
-        public float GoldPerSecond { get; set; } = 1.9f;
-        public float StartingGold { get; set; } = 825.0f;
         public bool HasFirstBloodHappened { get; set; } = false;
-        public bool IsKillGoldRewardReductionActive { get; set; } = true;
-        public int BluePillId { get; set; } = 2001;
-        public long FirstGoldTime { get; set; } = 90 * 1000;
+        public long NextSpawnTime { get; set; } = 90 * 1000;
+        private IMapScriptHandler _map;
 
         //Tower type enumeration might vary slightly from map to map, so we set that up here
         public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)

--- a/GameServerCore/Domain/GameObjects/IChampion.cs
+++ b/GameServerCore/Domain/GameObjects/IChampion.cs
@@ -15,7 +15,8 @@ namespace GameServerCore.Domain.GameObjects
         // basic
         void UpdateSkin(int skinNo);
         uint GetPlayerId();
-        bool LevelUp();
+        void AddExperience(float experience);
+        void LevelUp();
         void Recall();
         void Respawn();
         bool OnDisconnect();

--- a/GameServerCore/Scripting/CSharp/IMapScript.cs
+++ b/GameServerCore/Scripting/CSharp/IMapScript.cs
@@ -4,24 +4,16 @@ using System.Numerics;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using GameServerCore.Maps;
+using GameServerCore.Scripting.CSharp;
 
 namespace GameServerCore.Domain
 {
     public interface IMapScript : IUpdate
     {
         IGlobalData GlobalData { get; }
-        bool EnableBuildingProtection { get; }
-        long NextSpawnTime { get; set; }
-        long SpawnInterval { get; }
-        //In case someone wishes to use a custom, hardcoded path instead of the one from files
-        bool MinionPathingOverride { get; }
-        float GoldPerSecond { get; }
-        float StartingGold { get; }
+        IMapScriptMetadata MapScriptMetadata { get; }
         bool HasFirstBloodHappened { get; set; }
-        bool IsKillGoldRewardReductionActive { get; set; }
-        int BluePillId { get; }
-        long FirstGoldTime { get; }
-        bool SpawnEnabled { get; set; }
+        long NextSpawnTime { get; set; }
         Dictionary<TurretType, int[]> TurretItems { get; }
         Dictionary<TeamId, string> NexusModels { get; }
         Dictionary<TeamId, string> InhibitorModels { get; }

--- a/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
+++ b/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
@@ -1,0 +1,46 @@
+﻿using GameServerCore.Domain.GameObjects.Spell.Missile;
+using GameServerCore.Domain.GameObjects.Spell.Sector;
+
+namespace GameServerCore.Scripting.CSharp
+{
+    public interface IMapScriptMetadata
+    {
+        bool EnableBuildingProtection { get; set; }
+        /// <summary>
+        /// Wether or not minions are enabled (This can cause issues if enabled and all structures aren't perfectly setup)
+        /// </summary>
+        bool MinionSpawnEnabled { get; set; }
+        /// <summary>
+        /// Time between minion waves (Default: 30 seconds)
+        /// </summary>
+        long SpawnInterval { get; set; }
+        /// <summary>
+        /// Wether the map should use hardcoded minion path coordinates or use the one from league's files (if available) (Default: false)
+        /// </summary>
+        bool MinionPathingOverride { get; set; }
+        /// <summary>
+        /// Ammount of gold per second for all players (Default: 1.9f)
+        /// </summary>
+        float GoldPerSecond { get; set; }
+        /// <summary>
+        /// Initial ammount of gold for all players (Default 475.0f)
+        /// </summary>
+        float StartingGold { get; set; }
+        /// <summary>
+        /// Wether or not players should be rewarded a decreasing ammount of gold based on how many times they died since their last kill (Default: true)
+        /// </summary>
+        bool IsKillGoldRewardReductionActive { get; set; }
+        /// <summary>
+        /// What Item should be used as the "Recall Spell", default recall spell is "bluepill", with ID: 2001 (Deafult: 2001)
+        /// </summary>
+        int RecallSpellItemId { get; set; }
+        /// <summary>
+        /// Time when all players should start generating gold (Default: 90 Seconds)
+        /// </summary>
+        long FirstGoldTime { get; set; }
+        /// <summary>
+        /// Wether or not the fountain should heal the players (Default = true)
+        /// </summary>
+        bool EnableFountainHealing { get; set; }
+    }
+}

--- a/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
+++ b/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
@@ -7,7 +7,7 @@ namespace GameServerCore.Scripting.CSharp
     {
         bool EnableBuildingProtection { get; set; }
         /// <summary>
-        /// Wether or not minions are enabled (This can cause issues if enabled and all structures aren't perfectly setup)
+        /// Whether or not minions are enabled (This can cause issues if enabled and all structures aren't perfectly setup)
         /// </summary>
         bool MinionSpawnEnabled { get; set; }
         /// <summary>
@@ -15,7 +15,7 @@ namespace GameServerCore.Scripting.CSharp
         /// </summary>
         long SpawnInterval { get; set; }
         /// <summary>
-        /// Wether the map should use hardcoded minion path coordinates or use the one from league's files (if available) (Default: false)
+        /// Whether the map should use hardcoded minion path coordinates or use the one from league's files (if available) (Default: false)
         /// </summary>
         bool MinionPathingOverride { get; set; }
         /// <summary>
@@ -27,11 +27,11 @@ namespace GameServerCore.Scripting.CSharp
         /// </summary>
         float StartingGold { get; set; }
         /// <summary>
-        /// Wether or not players should be rewarded a decreasing ammount of gold based on how many times they died since their last kill (Default: true)
+        /// Whether or not players should be rewarded a decreasing ammount of gold based on how many times they died since their last kill (Default: true)
         /// </summary>
         bool IsKillGoldRewardReductionActive { get; set; }
         /// <summary>
-        /// What Item should be used as the "Recall Spell", default recall spell is "bluepill", with ID: 2001 (Deafult: 2001)
+        /// The ItemID that should be used as the "Recall Spell", default recall spell is "BluePill", with ID: 2001 (Default: 2001)
         /// </summary>
         int RecallSpellItemId { get; set; }
         /// <summary>
@@ -39,7 +39,7 @@ namespace GameServerCore.Scripting.CSharp
         /// </summary>
         long FirstGoldTime { get; set; }
         /// <summary>
-        /// Wether or not the fountain should heal the players (Default = true)
+        /// Whether or not the fountain should heal the players (Default = true)
         /// </summary>
         bool EnableFountainHealing { get; set; }
     }

--- a/GameServerLib/Chatbox/Commands/SpawnStateCommand.cs
+++ b/GameServerLib/Chatbox/Commands/SpawnStateCommand.cs
@@ -22,7 +22,7 @@
             }
             else
             {
-                Game.Map.MapScript.SpawnEnabled = input != 0;
+                Game.Map.MapScript.MapScriptMetadata.MinionSpawnEnabled = input != 0;
             }
         }
     }

--- a/GameServerLib/Chatbox/Commands/XpCommand.cs
+++ b/GameServerLib/Chatbox/Commands/XpCommand.cs
@@ -27,7 +27,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
             if (float.TryParse(split[1], out var xp))
             {
-                _playerManager.GetPeerInfo(userId).Champion.Stats.Experience += xp;
+                _playerManager.GetPeerInfo(userId).Champion.AddExperience(xp);
             }
         }
     }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -266,6 +266,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 }
                 ApiEventManager.OnLevelUp.Publish(this);
                 _game.PacketNotifier.NotifyNPC_LevelUp(this);
+                _game.PacketNotifier.NotifyUpdatedStats(this, false);
             }
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -51,8 +51,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             Inventory = InventoryManager.CreateInventory(game.PacketNotifier, game.ScriptEngine);
             Shop = Items.Shop.CreateShop(this, game);
 
-            Stats.Gold = _game.Map.MapScript.StartingGold;
-            Stats.GoldPerSecond.BaseValue = _game.Map.MapScript.GoldPerSecond;
+            Stats.Gold = _game.Map.MapScript.MapScriptMetadata.StartingGold;
+            Stats.GoldPerSecond.BaseValue = _game.Map.MapScript.MapScriptMetadata.GoldPerSecond;
             Stats.IsGeneratingGold = false;
 
             //TODO: automaticaly rise spell levels with CharData.SpellLevelsUp
@@ -180,7 +180,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             base.Update(diff);
 
-            if (!Stats.IsGeneratingGold && _game.GameTime >= _game.Map.MapScript.FirstGoldTime)
+            if (!Stats.IsGeneratingGold && _game.GameTime >= _game.Map.MapScript.MapScriptMetadata.FirstGoldTime)
             {
                 Stats.IsGeneratingGold = true;
                 Logger.Debug("Generating Gold!");
@@ -193,14 +193,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 {
                     Respawn();
                 }
-            }
-
-            if (LevelUp())
-            {
-                ApiEventManager.OnLevelUp.Publish(this);
-                _game.PacketNotifier.NotifyNPC_LevelUp(this);
-                // TODO: send this in one place only
-                _game.PacketNotifier.NotifyUpdatedStats(this, false);
             }
 
             if (_championHitFlagTimer > 0)
@@ -246,7 +238,18 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             TeleportTo(spawnPos.X, spawnPos.Y);
         }
 
-        public bool LevelUp()
+        public void AddExperience(float experience)
+        {
+            Stats.Experience += experience;
+            _game.PacketNotifier.NotifyUnitAddEXP(this, experience);
+
+            if (Stats.Experience >= _game.Config.MapData.ExpCurve[Stats.Level - 1])
+            {
+                LevelUp();
+            }
+        }
+
+        public void LevelUp()
         {
             var stats = Stats;
             var expMap = _game.Config.MapData.ExpCurve;
@@ -261,9 +264,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 {
                     SkillPoints++;
                 }
-                return true;
+                ApiEventManager.OnLevelUp.Publish(this);
+                _game.PacketNotifier.NotifyNPC_LevelUp(this);
             }
-            return false;
         }
 
         public void OnKill(IDeathData deathData)
@@ -351,7 +354,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 return;
             }
 
-            if (_game.Map.MapScript.IsKillGoldRewardReductionActive
+            if (_game.Map.MapScript.MapScriptMetadata.IsKillGoldRewardReductionActive
                 && _game.Map.MapScript.HasFirstBloodHappened)
             {
                 gold -= gold * 0.25f;

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -531,8 +531,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 var expPerChamp = exp / champs.Count;
                 foreach (var c in champs)
                 {
-                    c.Stats.Experience += expPerChamp;
-                    _game.PacketNotifier.NotifyUnitAddEXP(c, expPerChamp);
+                    c.AddExperience(expPerChamp);
                 }
             }
 

--- a/GameServerLib/Maps/MapScriptHandler.cs
+++ b/GameServerLib/Maps/MapScriptHandler.cs
@@ -128,12 +128,7 @@ namespace LeagueSandbox.GameServer.Maps
                 }
             }
 
-            if (_game.GameTime >= 120 * 1000)
-            {
-                MapScript.IsKillGoldRewardReductionActive = false;
-            }
-
-            if (MapScript.SpawnEnabled)
+            if (MapScript.MapScriptMetadata.MinionSpawnEnabled)
             {
                 if (_minionNumber > 0)
                 {
@@ -143,7 +138,7 @@ namespace LeagueSandbox.GameServer.Maps
                         if (SetUpLaneMinion())
                         {
                             _minionNumber = 0;
-                            MapScript.NextSpawnTime = (long)_game.GameTime + MapScript.SpawnInterval;
+                            MapScript.NextSpawnTime = (long)_game.GameTime + MapScript.MapScriptMetadata.SpawnInterval;
                         }
                         else
                         {
@@ -162,7 +157,7 @@ namespace LeagueSandbox.GameServer.Maps
                 surrender.Update(diff);
             }
 
-            if (FountainList != null)
+            if (MapScript.MapScriptMetadata.EnableFountainHealing)
             {
                 foreach (var fountain in FountainList.Values)
                 {
@@ -180,7 +175,7 @@ namespace LeagueSandbox.GameServer.Maps
         {
             LoadBuildings();
             MapScript.Init(this);
-            if (MapScript.EnableBuildingProtection)
+            if (MapScript.MapScriptMetadata.EnableBuildingProtection)
             {
                 LoadBuildingProtection();
             }
@@ -269,7 +264,7 @@ namespace LeagueSandbox.GameServer.Maps
             }
 
             //If the map doesn't have any Minion pathing file but the map script has Minion pathing hardcoded
-            if ((BlueMinionPathing.Count == 0 || MapScript.MinionPathingOverride) && MapScript.MinionPaths != null && MapScript.MinionPaths.Count != 0)
+            if ((BlueMinionPathing.Count == 0 || MapScript.MapScriptMetadata.MinionPathingOverride) && MapScript.MinionPaths != null && MapScript.MinionPaths.Count != 0)
             {
                 foreach (var lane in MapScript.MinionPaths.Keys)
                 {

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -35,7 +35,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             _logger.Debug("Spawning map");
 
             var peerInfo = _playerManager.GetPeerInfo(userId);
-            var bluePill = _itemManager.GetItemType(_game.Map.MapScript.BluePillId);
+            var bluePill = _itemManager.GetItemType(_game.Map.MapScript.MapScriptMetadata.RecallSpellItemId);
             var itemInstance = peerInfo.Champion.Inventory.SetExtraItem(7, bluePill);
 
             // self-inform

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -52,8 +52,8 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                     }
 
                     _game.PacketNotifier.NotifySpawn(player.Item2.Champion, userId, false);
+                    player.Item2.Champion.LevelUp();
                     // TODO: send this in one place only
-                    _game.PacketNotifier.NotifyUpdatedStats(player.Item2.Champion, false);
                     _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int) player.Item2.PlayerId, "Welcome to League Sandbox!",
                         "This is a WIP project.", "", 0, player.Item2.Champion.NetId,
                         _game.NetworkIdManager.GetNewNetId());

--- a/GameServerLib/Scripting/CSharp/EmptyMapScript.cs
+++ b/GameServerLib/Scripting/CSharp/EmptyMapScript.cs
@@ -5,32 +5,22 @@ using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using GameServerCore.Maps;
+using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.Content;
+using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace MapScripts
 {
     public class EmptyMapScript : IMapScript
     {
+        public IMapScriptMetadata MapScriptMetadata { get; set; } = new MapScriptMetadata
+        {
+            MinionPathingOverride = true,
+        };
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
-        public bool EnableBuildingProtection { get; set; } = false;
-
-        //General Map variable
-        private IMapScriptHandler _map;
-
-        //Stuff about minions
-        public bool SpawnEnabled { get; set; }
-        public long FirstSpawnTime { get; set; } = 30 * 1000;
-        public long NextSpawnTime { get; set; } = 30 * 1000;
-        public long SpawnInterval { get; set; } = 30 * 1000;
-        public bool MinionPathingOverride { get; set; } = true;
-
-        //General things that will affect players globaly, such as default gold per-second, Starting gold....
-        public float GoldPerSecond { get; set; } = 1.9f;
-        public float StartingGold { get; set; } = 475.0f;
         public bool HasFirstBloodHappened { get; set; } = false;
-        public bool IsKillGoldRewardReductionActive { get; set; } = true;
-        public int BluePillId { get; set; } = 2001;
-        public long FirstGoldTime { get; set; } = 90 * 1000;
+        public long NextSpawnTime { get; set; } = 90 * 1000;
+        private IMapScriptHandler _map;
 
         //Tower type enumeration might vary slightly from map to map, so we set that up here
         public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)
@@ -112,7 +102,7 @@ namespace MapScripts
         {
             _map = map;
 
-            SpawnEnabled = map.IsMinionSpawnEnabled();
+            MapScriptMetadata.MinionSpawnEnabled = map.IsMinionSpawnEnabled();
             map.AddSurrender(1200000.0f, 300000.0f, 30.0f);
         }
         public void OnMatchStart()

--- a/GameServerLib/Scripting/CSharp/MapScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/MapScriptMetadata.cs
@@ -1,0 +1,27 @@
+﻿using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using GameServerCore.Domain.GameObjects.Spell.Sector;
+using GameServerCore.Enums;
+using GameServerCore.Scripting.CSharp;
+using System.Numerics;
+
+namespace LeagueSandbox.GameServer.Scripting.CSharp
+{
+    public class MapScriptMetadata : IMapScriptMetadata
+    {
+        public bool EnableBuildingProtection { get; set; } = false;
+
+        //Stuff about minions
+        public bool MinionSpawnEnabled { get; set; } = false;
+        public long SpawnInterval { get; set; } = 30 * 1000;
+        public bool MinionPathingOverride { get; set; } = false;
+
+        //General things that will affect players globaly, such as default gold per-second, Starting gold....
+        public float GoldPerSecond { get; set; } = 1.9f;
+        public float StartingGold { get; set; } = 475.0f;
+        public bool IsKillGoldRewardReductionActive { get; set; } = true;
+        public int RecallSpellItemId { get; set; } = 2001;
+        public long FirstGoldTime { get; set; } = 90 * 1000;
+        public bool EnableFountainHealing { get; set; } = true;
+    }
+}

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -2001,7 +2001,7 @@ namespace PacketDefinitions420
                 // TODO: Typo :(
                 AveliablePoints = c.SkillPoints
             };
-
+            NotifyUpdatedStats(c, false);
             _packetHandlerManager.BroadcastPacketVision(c, levelUp.GetBytes(), Channel.CHL_S2C);
         }
 

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -2001,7 +2001,7 @@ namespace PacketDefinitions420
                 // TODO: Typo :(
                 AveliablePoints = c.SkillPoints
             };
-            NotifyUpdatedStats(c, false);
+            
             _packetHandlerManager.BroadcastPacketVision(c, levelUp.GetBytes(), Channel.CHL_S2C);
         }
 


### PR DESCRIPTION
*Introduced `MapMetadata`
    *`MapMetadata` will house essential variables to the map, such as gold per second, initial gold, time between waves...

*MapScripts
    *Removed all old variables from all Maps and introduced `MapMetadata`, making the necessary adjustments.

*Champions
    *Introduced `AddExperience` to handle Experience additions.
    *Champions no longer check every tick if they should or not level up. This is now done when the XP value is changed with the new `AddExperience` function.