### PR TITLE
Resolve #1250 -- Particle crash hotfix

### DIFF
--- a/GameServerLib/GameObjects/Particle.cs
+++ b/GameServerLib/GameObjects/Particle.cs
@@ -111,7 +111,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             FollowsGroundTilt = followGroundTilt;
             Flags = flags;
 
-            if (Name.Contains(".troy"))
+            if (particleName.Contains(".troy"))
             {
                 Name = particleName;
             }
@@ -171,7 +171,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             FollowsGroundTilt = followGroundTilt;
             Flags = flags;
 
-            if (Name.Contains(".troy"))
+            if (particleName.Contains(".troy"))
             {
                 Name = particleName;
             }
@@ -227,7 +227,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             FollowsGroundTilt = followGroundTilt;
             Flags = flags;
 
-            if (Name.Contains(".troy"))
+            if (particleName.Contains(".troy"))
             {
                 Name = particleName;
             }


### PR DESCRIPTION
* Fixed a crash that would occur when creating a particle due to the if statement checking for the Name variable instead of the value that will get assigned to it.