### PR TITLE
Resolve #1249, Resolve #713 -- Introduced Bots + Level Command fix

### DIFF
--- a/GameServerCore/Domain/GameObjects/IChampion.cs
+++ b/GameServerCore/Domain/GameObjects/IChampion.cs
@@ -16,7 +16,7 @@ namespace GameServerCore.Domain.GameObjects
         void UpdateSkin(int skinNo);
         uint GetPlayerId();
         void AddExperience(float experience);
-        void LevelUp();
+        bool LevelUp(bool force = false);
         void Recall();
         void Respawn();
         bool OnDisconnect();

--- a/GameServerCore/Domain/GameObjects/IMinion.cs
+++ b/GameServerCore/Domain/GameObjects/IMinion.cs
@@ -25,10 +25,6 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         bool IsLaneMinion { get; }
         /// <summary>
-        /// Whether or not this minion is considered a bot.
-        /// </summary>
-        bool IsBot { get; }
-        /// <summary>
         /// Whether or not this minion is considered a pet.
         /// </summary>
         bool IsPet { get; }

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -66,6 +66,8 @@ namespace GameServerCore.Domain.GameObjects
         /// Unit this AI will auto attack when it is in auto attack range.
         /// </summary>
         IAttackableUnit TargetUnit { get; set; }
+        // TODO: Implement AI Scripting for this (for AI in general).
+        bool IsBot { get; }
 
         void LoadPassiveScript(ISpell spell);
         /// <summary>

--- a/GameServerCore/Domain/IPlayerConfig.cs
+++ b/GameServerCore/Domain/IPlayerConfig.cs
@@ -1,0 +1,18 @@
+﻿namespace GameServerCore.Domain
+{
+    public interface IPlayerConfig
+    {
+        long PlayerID { get; }
+        string Rank { get; }
+        string Name { get; }
+        string Champion { get; }
+        string Team { get; }
+        short Skin { get; }
+        string Summoner1 { get; }
+        string Summoner2 { get; }
+        short Ribbon { get; }
+        int Icon { get; }
+        string BlowfishKey { get; }
+        IRuneCollection Runes { get; }
+    }
+}

--- a/GameServerCore/IPlayerManager.cs
+++ b/GameServerCore/IPlayerManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.NetInfo;
 
@@ -7,8 +8,10 @@ namespace GameServerCore
 {
     public interface IPlayerManager
     {
+        void AddPlayer(KeyValuePair<string, IPlayerConfig> p);
+        void AddPlayer(Tuple<uint, ClientInfo> p);
         ClientInfo GetClientInfoByChampion(IChampion champ);
         ClientInfo GetPeerInfo(long playerId);
-        List<Tuple<uint, ClientInfo>> GetPlayers();
+        List<Tuple<uint, ClientInfo>> GetPlayers(bool includeBots = false);
     }
 }

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -76,11 +76,11 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="target">Champion that is being targeted by the attacker.</param>
         void NotifyAI_TargetHeroS2C(IObjAiBase attacker, IChampion target);
         /// <summary>
-        /// Sends a packet to the specified user that informs them of their summoner data such as runes, summoner spells, masteries (or talents as named internally), etc.
+        /// Sends a packet to the specified user or all users informing them of the given client's summoner data such as runes, summoner spells, masteries (or talents as named internally), etc.
         /// </summary>
-        /// <param name="userId">User to send the packet to.</param>
         /// <param name="client">Info about the player's summoner data.</param>
-        void NotifyAvatarInfo(int userId, ClientInfo client);
+        /// <param name="userId">User to send the packet to. Set to -1 to broadcast.</param>
+        void NotifyAvatarInfo(ClientInfo client, int userId = -1);
         /// <summary>
         /// Sends a packet to all players detailing that the specified  unit is starting their next auto attack.
         /// </summary>
@@ -566,25 +566,27 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="p">Projectile that has changed target.</param>
         void NotifyS2C_ChangeMissileTarget(ISpellMissile p);
         /// <summary>
-        /// Sends a packet to the specified user detailing that the hero designated to the given clientInfo has been created.
+        /// Sends a packet to the specified user or all users detailing that the hero designated to the given clientInfo has been created.
         /// </summary>
-        /// <param name="userId">User to send the packet to.</param>
         /// <param name="clientInfo">Information about the client which had their hero created.</param>
-        void NotifyS2C_CreateHero(int userId, ClientInfo clientInfo);
+        /// <param name="userId">User to send the packet to. Set to -1 to broadcast.</param>
+        void NotifyS2C_CreateHero(ClientInfo clientInfo, int userId = -1);
         /// <summary>
         /// Sends a packet to either all players or the specified player detailing that the specified LaneTurret has spawned.
         /// </summary>
         /// <param name="turret">LaneTurret that spawned.</param>
         /// <param name="userId">User to send the packet to.</param>
         void NotifyS2C_CreateTurret(ILaneTurret turret, int userId = 0);
-        void NotifyS2C_DisableHUDForEndOfGame(Tuple<uint, ClientInfo> player);
-
         /// <summary>
-        /// Sends packets to all players which force the players' cameras to the nexus being destroyed, hides their UI, and ends the game.
+        /// Disables the UI for ther end of the game
         /// </summary>
-        /// <param name="cameraPosition">Position of the nexus being destroyed.</param>
-        /// <param name="nexus">Nexus being destroyed.</param>
-        /// <param name="players">All players that can receive packets.</param>
+        /// <param name="player">Player for the UI to be disabled</param>
+        void NotifyS2C_DisableHUDForEndOfGame(Tuple<uint, ClientInfo> player);
+        /// <summary>
+        /// Sends packets to all players notifying the result of a match (Victory or defeat)
+        /// </summary>
+        /// <param name="losingTeam">The Team that lost the match</param>
+        /// <param name="time">The offset for the result to actually be displayed</param>
         void NotifyS2C_EndGame(TeamId losingTeam, float time = 5000);
         /// <summary>
         /// Sends a side bar tip to the specified player (ex: quest tips).

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -488,7 +488,7 @@ namespace LeagueSandbox.GameServer.API
         public static List<IChampion> GetAllPlayers()
         {
             var toreturn = new List<IChampion>();
-            foreach (var player in _game.PlayerManager.GetPlayers())
+            foreach (var player in _game.PlayerManager.GetPlayers(true))
             {
                 toreturn.Add(player.Item2.Champion);
             }

--- a/GameServerLib/Chatbox/Commands/LevelCommand.cs
+++ b/GameServerLib/Chatbox/Commands/LevelCommand.cs
@@ -34,7 +34,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                 }
 
                 var experienceToLevelUp = _mapData.ExpCurve[lvl - 1];
-                _playerManager.GetPeerInfo(userId).Champion.Stats.Experience = experienceToLevelUp;
+                _playerManager.GetPeerInfo(userId).Champion.AddExperience(experienceToLevelUp);
             }
         }
     }

--- a/GameServerLib/Chatbox/Commands/LevelCommand.cs
+++ b/GameServerLib/Chatbox/Commands/LevelCommand.cs
@@ -33,8 +33,12 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                     return;
                 }
 
-                var experienceToLevelUp = _mapData.ExpCurve[lvl - 1];
-                _playerManager.GetPeerInfo(userId).Champion.AddExperience(experienceToLevelUp);
+                var champ = _playerManager.GetPeerInfo(userId).Champion;
+
+                while (champ.Stats.Level < lvl)
+                {
+                    champ.LevelUp(true);
+                }
             }
         }
     }

--- a/GameServerLib/Chatbox/Commands/SpawnCommand.cs
+++ b/GameServerLib/Chatbox/Commands/SpawnCommand.cs
@@ -1,5 +1,7 @@
 ﻿using GameServerCore;
 using GameServerCore.Enums;
+using GameServerCore.NetInfo;
+using LeagueSandbox.GameServer.Content;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using System;
 using System.Collections.Generic;
@@ -12,7 +14,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         private readonly IPlayerManager _playerManager;
 
         public override string Command => "spawn";
-        public override string Syntax => $"{Command} minionsblue minionspurple";
+        public override string Syntax => $"{Command} champblue champpurple [champion] minionsblue minionspurple";
 
         public SpawnCommand(ChatCommandManager chatCommandManager, Game game)
             : base(chatCommandManager, game)
@@ -23,6 +25,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         public override void Execute(int userId, bool hasReceivedArguments, string arguments = "")
         {
             var split = arguments.ToLower().Split(' ');
+            string championModel = "";
 
             if (split.Length < 2)
             {
@@ -40,6 +43,38 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                 }
 
                 SpawnMinionsForTeam(team, userId);
+            }
+            else if (split[1].StartsWith("champ"))
+            {
+                split[1] = split[1].Replace("champ", "team_").ToUpper();
+                if (!Enum.TryParse(split[1], out TeamId team) || team == TeamId.TEAM_NEUTRAL)
+                {
+                    ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.SYNTAXERROR);
+                    ShowSyntax();
+                    return;
+                }
+
+                if (split.Length > 2)
+                {
+                    championModel = arguments.Split(' ')[2];
+
+                    try
+                    {
+                        Game.Config.ContentManager.GetContentFileFromJson("Stats", championModel);
+                    }
+                    catch (ContentNotFoundException)
+                    {
+                        ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.SYNTAXERROR, "Character Name: " + championModel + " invalid.");
+                        ShowSyntax();
+                        return;
+                    }
+
+                    SpawnChampForTeam(team, userId, championModel);
+
+                    return;
+                }
+
+                SpawnChampForTeam(team, userId, "Katarina");
             }
         }
 
@@ -70,6 +105,49 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                 minion.UpdateMoveOrder(OrderType.Hold);
                 Game.ObjectManager.AddObject(minion);
             }
+        }
+
+        public void SpawnChampForTeam(TeamId team, int userId, string model)
+        {
+            var championPos = _playerManager.GetPeerInfo(userId).Champion.Position;
+
+            var runesTemp = new RuneCollection();
+            var clientInfoTemp = new ClientInfo("", team, 0, 0, 0, model, new string[] { "SummonerHeal", "SummonerFlash" }, -1);
+            uint num = (uint)_playerManager.GetPlayers(true).Count + 1;
+            var playerTemp = new Tuple<uint, ClientInfo>(num, clientInfoTemp);
+
+            _playerManager.AddPlayer(playerTemp);
+
+            var c = new Champion(
+                Game,
+                model,
+                0,
+                0, // Doesnt matter at this point
+                runesTemp,
+                clientInfoTemp,
+                team: team
+            );
+
+            clientInfoTemp.Champion = c;
+
+            c.SetPosition(championPos, false);
+            c.StopMovement();
+            c.UpdateMoveOrder(OrderType.Stop);
+            c.LevelUp();
+
+            Game.PacketNotifier.NotifyS2C_CreateHero(clientInfoTemp);
+            Game.PacketNotifier.NotifyAvatarInfo(clientInfoTemp);
+            Game.ObjectManager.AddObject(c);
+            Game.PacketNotifier.NotifyEnterLocalVisibilityClient(c, ignoreVision: true);
+            Game.PacketNotifier.NotifyUpdatedStats(c, false);
+
+            c.Stats.SetSpellEnabled(13, true);
+            c.Stats.SetSummonerSpellEnabled(0, true);
+            c.Stats.SetSummonerSpellEnabled(1, true);
+
+            Game.PacketNotifier.NotifyEnterVisibilityClient(c, 0, true, false, true);
+
+            ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "Spawned Bot" + clientInfoTemp.Name + " as " + c.Model + " with NetID: " + c.NetId + ".");
         }
     }
 }

--- a/GameServerLib/Chatbox/Commands/TpCommand.cs
+++ b/GameServerLib/Chatbox/Commands/TpCommand.cs
@@ -7,7 +7,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         private readonly IPlayerManager _playerManager;
 
         public override string Command => "tp";
-        public override string Syntax => $"{Command} x y";
+        public override string Syntax => $"{Command} [target NetID (0 or none for self)] X Y";
 
         public TpCommand(ChatCommandManager chatCommandManager, Game game)
             : base(chatCommandManager, game)
@@ -18,15 +18,21 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         public override void Execute(int userId, bool hasReceivedArguments, string arguments = "")
         {
             var split = arguments.ToLower().Split(' ');
+            uint targetNetID = 0;
             float x, y;
-            if (split.Length < 3)
+
+            if (split.Length < 3 || split.Length > 4)
             {
                 ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.SYNTAXERROR);
                 ShowSyntax();
                 return;
             }
 
-            if (float.TryParse(split[1], out x) && float.TryParse(split[2], out y))
+            if (split.Length > 3 && uint.TryParse(split[1], out targetNetID) && float.TryParse(split[2], out x) && float.TryParse(split[3], out y))
+            {
+                Game.ObjectManager.GetObjectById(targetNetID).TeleportTo(x, y);
+            }
+            else if (float.TryParse(split[1], out x) && float.TryParse(split[2], out y))
             {
                 _playerManager.GetPeerInfo(userId).Champion.TeleportTo(x, y);
             }

--- a/GameServerLib/Config.cs
+++ b/GameServerLib/Config.cs
@@ -18,7 +18,7 @@ namespace LeagueSandbox.GameServer
     /// </summary>
     public class Config
     {
-        public Dictionary<string, PlayerConfig> Players { get; private set; }
+        public Dictionary<string, IPlayerConfig> Players { get; private set; }
         public GameConfig GameConfig { get; private set; }
         public MapData MapData { get; private set; }
         public MapSpawns MapSpawns { get; private set; }
@@ -51,7 +51,7 @@ namespace LeagueSandbox.GameServer
 
         private void LoadConfig(Game game, string json)
         {
-            Players = new Dictionary<string, PlayerConfig>();
+            Players = new Dictionary<string, IPlayerConfig>();
 
             var data = JObject.Parse(json);
 
@@ -358,6 +358,7 @@ public class MapData : IMapData
         }
     }
 }
+
 public class MapSpawns
 {
     public Dictionary<int, PlayerSpawns> Blue = new Dictionary<int, PlayerSpawns>();
@@ -406,29 +407,38 @@ public class GameConfig
 }
 
 
-public class PlayerConfig
+public class PlayerConfig : IPlayerConfig
 {
-    public long PlayerID => (long)_playerData.SelectToken("playerId");
-    public string Rank => (string)_playerData.SelectToken("rank");
-    public string Name => (string)_playerData.SelectToken("name");
-    public string Champion => (string)_playerData.SelectToken("champion");
-    public string Team => (string)_playerData.SelectToken("team");
-    public short Skin => (short)_playerData.SelectToken("skin");
-    public string Summoner1 => (string)_playerData.SelectToken("summoner1");
-    public string Summoner2 => (string)_playerData.SelectToken("summoner2");
-    public short Ribbon => (short)_playerData.SelectToken("ribbon");
-    public int Icon => (int)_playerData.SelectToken("icon");
-    public string BlowfishKey => (string)_playerData.SelectToken("blowfishKey");
+    public long PlayerID { get; private set; }
+    public string Rank { get; private set; }
+    public string Name { get; private set; }
+    public string Champion { get; private set; }
+    public string Team { get; private set; }
+    public short Skin { get; private set; }
+    public string Summoner1 { get; private set; }
+    public string Summoner2 { get; private set; }
+    public short Ribbon { get; private set; }
+    public int Icon { get; private set; }
+    public string BlowfishKey { get; private set; }
     public IRuneCollection Runes { get; }
-
-    private JToken _playerData;
 
     public PlayerConfig(JToken playerData)
     {
-        _playerData = playerData;
+        PlayerID = (long)playerData.SelectToken("playerId");
+        Rank = (string)playerData.SelectToken("rank");
+        Name = (string)playerData.SelectToken("name");
+        Champion = (string)playerData.SelectToken("champion");
+        Team = (string)playerData.SelectToken("team");
+        Skin = (short)playerData.SelectToken("skin");
+        Summoner1 = (string)playerData.SelectToken("summoner1");
+        Summoner2 = (string)playerData.SelectToken("summoner2");
+        Ribbon = (short)playerData.SelectToken("ribbon");
+        Icon = (int)playerData.SelectToken("icon");
+        BlowfishKey = (string)playerData.SelectToken("blowfishKey");
+
         try
         {
-            var runes = _playerData.SelectToken("runes");
+            var runes = playerData.SelectToken("runes");
             Runes = new RuneCollection();
 
             foreach (JProperty runeCategory in runes)
@@ -440,5 +450,22 @@ public class PlayerConfig
         {
             // no runes set in config
         }
+    }
+
+    public PlayerConfig(string name, string champion, long playerId = -1, string rank = "", string team = "BLUE", short skin = 0, string summoner1 = "SummonerHeal", string summoner2 = "SummonerFlash", short ribbon = 0, int icon = 0, string blowfishKey = "")
+    {
+        PlayerID = playerId;
+        Rank = rank;
+        Name = name;
+        Champion = champion;
+        Team = team;
+        Skin = skin;
+        Summoner1 = summoner1;
+        Summoner2 = summoner2;
+        Ribbon = ribbon;
+        Icon = icon;
+        BlowfishKey = blowfishKey;
+
+        Runes = new RuneCollection();
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -66,6 +66,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             Stats.SetSpellEnabled((byte)SpellSlotType.BluePillSlot, true);
 
             Replication = new ReplicationHero(this);
+
+            if (clientInfo.PlayerId == -1)
+            {
+                IsBot = true;
+            }
         }
 
         private string GetPlayerIndex()
@@ -243,7 +248,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             Stats.Experience += experience;
             _game.PacketNotifier.NotifyUnitAddEXP(this, experience);
 
-            if (Stats.Experience >= _game.Config.MapData.ExpCurve[Stats.Level - 1])
+            while (Stats.Experience >= _game.Config.MapData.ExpCurve[Stats.Level - 1] && Stats.Level < _game.Config.MapData.ExpCurve.Count)
             {
                 LevelUp();
             }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -248,20 +248,17 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             Stats.Experience += experience;
             _game.PacketNotifier.NotifyUnitAddEXP(this, experience);
 
-            while (Stats.Experience >= _game.Config.MapData.ExpCurve[Stats.Level - 1] && Stats.Level < _game.Config.MapData.ExpCurve.Count)
-            {
-                LevelUp();
-            }
+            while (Stats.Experience >= _game.Config.MapData.ExpCurve[Stats.Level - 1] && LevelUp());
         }
 
-        public void LevelUp()
+        public bool LevelUp(bool force = false)
         {
             var stats = Stats;
             var expMap = _game.Config.MapData.ExpCurve;
 
             //Ideally we'd use "stats.Level < expMap.Count + 1", but since we still don't have gamemodes implemented yet, i'll be hardcoding the EXP level to cap at lvl 18,
             //Since the SR Map has 30 levels in total because of URF
-            if (stats.Level < 18 && (stats.Level < 1 || stats.Experience >= expMap[stats.Level - 1])) //The + and - 1s are there because the XP files don't have level 1
+            if (stats.Level < 18 && (stats.Level < 1 || (stats.Experience >= expMap[stats.Level - 1] || force))) //The + and - 1s are there because the XP files don't have level 1
             {
                 Stats.LevelUp();
                 Logger.Debug("Champion " + Model + " leveled up to " + stats.Level);
@@ -272,7 +269,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 ApiEventManager.OnLevelUp.Publish(this);
                 _game.PacketNotifier.NotifyNPC_LevelUp(this);
                 _game.PacketNotifier.NotifyUpdatedStats(this, false);
+
+                return true;
             }
+
+            return false;
         }
 
         public void OnKill(IDeathData deathData)

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
@@ -32,10 +32,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// </summary>
         public bool IsLaneMinion { get; protected set; }
         /// <summary>
-        /// Whether or not this minion is considered a bot.
-        /// </summary>
-        public bool IsBot { get; protected set; }
-        /// <summary>
         /// Whether or not this minion is considered a pet.
         /// </summary>
         public bool IsPet { get; protected set; }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -81,6 +81,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public IAttackableUnit TargetUnit { get; set; }
         public Dictionary<short, ISpell> Spells { get; }
         public ICharScript CharScript { get; private set; }
+        public bool IsBot { get; set; }
 
         public ObjAiBase(Game game, string model, Stats.Stats stats, int collisionRadius = 40,
             Vector2 position = new Vector2(), int visionRadius = 0, int skinId = 0, uint netId = 0, TeamId team = TeamId.TEAM_NEUTRAL) :

--- a/GameServerLib/Maps/SurrenderHandler.cs
+++ b/GameServerLib/Maps/SurrenderHandler.cs
@@ -79,7 +79,7 @@ namespace LeagueSandbox.GameServer.Maps
             if (voteCounts.Item1 >= total - 1)
             {
                 IsSurrenderActive = false;
-                foreach (var p in _game.PlayerManager.GetPlayers())
+                foreach (var p in _game.PlayerManager.GetPlayers(true))
                 {
                     _game.PacketNotifier.NotifyTeamSurrenderStatus((int)p.Item1, Team, SurrenderReason.SURRENDER_PASSED, (byte)voteCounts.Item1, (byte)voteCounts.Item2); // TOOD: fix id casting
                 }

--- a/GameServerLib/Packets/PacketHandlers/HandleJoinTeam.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleJoinTeam.cs
@@ -17,7 +17,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 
         public override bool HandlePacket(int userId, JoinTeamRequest req)
         {
-            var players = _playerManager.GetPlayers();
+            var players = _playerManager.GetPlayers(true);
             uint version = uint.Parse(Config.VERSION.ToString().Replace(".", string.Empty));
 
             // Builds team info e.g. first UserId set on Blue has PlayerId 0

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -39,8 +39,8 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             var itemInstance = peerInfo.Champion.Inventory.SetExtraItem(7, bluePill);
 
             // self-inform
-            _game.PacketNotifier.NotifyS2C_CreateHero(userId, peerInfo);
-            _game.PacketNotifier.NotifyAvatarInfo(userId, peerInfo);
+            _game.PacketNotifier.NotifyS2C_CreateHero(peerInfo, userId);
+            _game.PacketNotifier.NotifyAvatarInfo(peerInfo, userId);
 
             _game.PacketNotifier.NotifyBuyItem(userId, peerInfo.Champion, itemInstance);
 

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -36,12 +36,12 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 foreach (var player in _playerManager.GetPlayers())
                 {
                     // Get notified about the spawn of other connected players - IMPORTANT: should only occur one-time
-                    foreach (var p in _playerManager.GetPlayers())
+                    foreach (var p in _playerManager.GetPlayers(true))
                     {
                         if (!p.Item2.IsStartedClient) continue; //user still didn't connect, not get informed about it
                         if (player.Item2.PlayerId == p.Item2.PlayerId) continue; //Don't self-inform twice
-                        _game.PacketNotifier.NotifyS2C_CreateHero((int)player.Item2.PlayerId, p.Item2);
-                        _game.PacketNotifier.NotifyAvatarInfo((int)player.Item2.PlayerId, p.Item2);
+                        _game.PacketNotifier.NotifyS2C_CreateHero(p.Item2, (int)player.Item2.PlayerId);
+                        _game.PacketNotifier.NotifyAvatarInfo(p.Item2, (int)player.Item2.PlayerId);
                     }
 
                     if (player.Item2.PlayerId == userId && !player.Item2.IsMatchingVersion)
@@ -71,7 +71,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             {
                 if (peerInfo.IsDisconnected)
                 {
-                    foreach (var player in _playerManager.GetPlayers())
+                    foreach (var player in _playerManager.GetPlayers(true))
                     {
                         if (player.Item2.Team == peerInfo.Team)
                         {
@@ -97,9 +97,14 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                     return true;
                 }
 
-                foreach (var p in _playerManager.GetPlayers())
+                foreach (var p in _playerManager.GetPlayers(true))
                 {
                     _game.ObjectManager.AddObject(p.Item2.Champion);
+
+                    if (p.Item2.Champion.IsBot)
+                    {
+                        continue;
+                    }
 
                     // Send the initial game time sync packets, then let the map send another
                     var gameTime = _game.GameTime;

--- a/GameServerLib/Players/PlayerManager.cs
+++ b/GameServerLib/Players/PlayerManager.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.Packets;
 using System.Collections.Generic;
 using System;
+using GameServerCore.Domain;
 
 namespace LeagueSandbox.GameServer.Players
 {
@@ -27,7 +28,7 @@ namespace LeagueSandbox.GameServer.Players
             _networkIdManager = game.NetworkIdManager;
         }
 
-        private TeamId GetTeamIdFromConfig(PlayerConfig p)
+        private TeamId GetTeamIdFromConfig(IPlayerConfig p)
         {
             if (p.Team.ToLower().Equals("blue"))
             {
@@ -37,7 +38,7 @@ namespace LeagueSandbox.GameServer.Players
             return TeamId.TEAM_PURPLE;
         }
 
-        public void AddPlayer(KeyValuePair<string, PlayerConfig> p)
+        public void AddPlayer(KeyValuePair<string, IPlayerConfig> p)
         {
             var summonerSkills = new[]
             {
@@ -67,6 +68,11 @@ namespace LeagueSandbox.GameServer.Players
             _players.Add(pair);
         }
 
+        public void AddPlayer(Tuple<uint, ClientInfo> p)
+        {
+            _players.Add(p);
+        }
+
         // GetPlayerFromPeer
         public ClientInfo GetPeerInfo(long playerId)
         {
@@ -83,11 +89,16 @@ namespace LeagueSandbox.GameServer.Players
 
         public ClientInfo GetClientInfoByChampion(IChampion champ)
         {
-            return GetPlayers().Find(c => c.Item2.Champion == champ).Item2;
+            return GetPlayers(true).Find(c => c.Item2.Champion == champ).Item2;
         }
 
-        public List<Tuple<uint, ClientInfo>> GetPlayers()
+        public List<Tuple<uint, ClientInfo>> GetPlayers(bool includeBots = true)
         {
+            if (!includeBots)
+            {
+                return _players.FindAll(c => !c.Item2.Champion.IsBot);
+            }
+
             return _players;
         }
     }

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -215,7 +215,7 @@ namespace PacketDefinitions420
         public bool BroadcastPacketTeam(TeamId team, byte[] data, Channel channelNo,
             PacketFlags flag = PacketFlags.Reliable)
         {
-            foreach (var ci in _playerManager.GetPlayers())
+            foreach (var ci in _playerManager.GetPlayers(true))
             {
                 if (ci.Item2 != null && ci.Item2.Team == team)
                 {


### PR DESCRIPTION
Added the option to spawn a bot champion for the `!spawn` chat command.

* Chat Commands:
  * SpawnCommand now supports `champblue/champpurple [championName]`.
  * TpCommand now supports targeting a NetID `[netID] X Y`.
* Core:
  * Added IPlayerConfig interface for outside access.
* ObjAibase:
  * Added IsBot.
* Minion:
  * Moved IsBot to ObjAIBase.
* Champion:
  * Setup IsBot if playerId is -1.
* Player Manager:
  * Added seperate AddPlayer function for mid-game creation of players.
  * Added option to GetPlayers which can filter out bot players.
* Player Config:
  * Setup changed to support interface.
* Packets:
  * CreateHero and AvatarInfo can now optionally broadcast.
  * Implemented OnEnterTeamVisibility.
  * Removed unused AvatarInfo.

- All changes here are credited to Lizardy (microsoftv)