### PR TITLE
Resolve #1204 -- Fix Item Double Consumption & Applying 1 Effect

### DIFF
--- a/GameServerLib/Packets/PacketHandlers/HandleCastSpell.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleCastSpell.cs
@@ -35,17 +35,21 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 return false;
             }
 
-            if (s.CastInfo.SpellSlot >= (int)SpellSlotType.InventorySlots && s.CastInfo.SpellSlot < (int)SpellSlotType.BluePillSlot)
+            if(s.Cast(req.Position, req.EndPosition, targetUnit))
             {
-                var item = s.CastInfo.Owner.Inventory.GetItem(s.SpellName);
-                if (item != null && item.ItemData.Consumed)
+                if (s.CastInfo.SpellSlot >= (int)SpellSlotType.InventorySlots && s.CastInfo.SpellSlot < (int)SpellSlotType.BluePillSlot)
                 {
-                    var inventory = owner.Inventory;
-                    inventory.RemoveItem(inventory.GetItemSlot(item), owner);
+                    var item = s.CastInfo.Owner.Inventory.GetItem(s.SpellName);
+                    if (item != null && item.ItemData.Consumed)
+                    {
+                        var inventory = owner.Inventory;
+                        inventory.RemoveItem(inventory.GetItemSlot(item), owner);
+                    }
                 }
+                return true;
             }
 
-            return s.Cast(req.Position, req.EndPosition, targetUnit);
+            return false;
         }
     }
 }

--- a/GameServerLib/Packets/PacketHandlers/HandleSwapItems.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSwapItems.cs
@@ -28,10 +28,9 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 
             // "Holy shit this needs refactoring" - Mythic, April 13th 2016
             champion.Inventory.SwapItems(req.SlotFrom, req.SlotTo);
+            _game.PacketNotifier.NotifySwapItemAns(champion, req.SlotFrom, req.SlotTo);
             champion.SwapSpells((byte)(req.SlotFrom + Shop.ITEM_ACTIVE_OFFSET),
                 (byte)(req.SlotTo + Shop.ITEM_ACTIVE_OFFSET));
-            _game.PacketNotifier.NotifySwapItemAns(champion, req.SlotFrom, req.SlotTo);
-
             return true;
         }
     }


### PR DESCRIPTION
the item was being removed even if the spell is not casted

sometimes, when the item was being exchanged, the client would remove the item's cast event in inventory, changing the order of the package being shipped, I was also able to fix this problem.

this doesn't solve the bug where the emulator is associating empty slots with spells

Refs #1204