### PR TITLE
Resolve 1265 -- SpawnPosition Overrides in MapScripts

### DIFF
--- a/Content/LeagueSandbox-Scripts/Maps/Map1/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/CLASSIC.cs
@@ -19,13 +19,14 @@ namespace MapScripts.Map1
             MinionPathingOverride = true,
             EnableBuildingProtection = true
         };
+        public IMapScriptHandler _map;
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
         public bool HasFirstBloodHappened { get; set; } = false;
         public long NextSpawnTime { get; set; } = 90 * 1000;
         public string LaneMinionAI { get; set; } = "LaneMinionAI";
         public string LaneTurretAI { get; set; } = "TurretAI";
-        public IMapScriptHandler _map;
 
+        public Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>> PlayerSpawnPoints { get; }
 
         //Tower type enumeration might vary slightly from map to map, so we set that up here
         public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/CLASSIC.cs
@@ -19,12 +19,14 @@ namespace MapScripts.Map10
             EnableBuildingProtection = true,
             StartingGold = 825.0f
         };
+        private IMapScriptHandler _map;
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
         public bool HasFirstBloodHappened { get; set; } = false;
         public long NextSpawnTime { get; set; } = 45 * 1000;
         public string LaneMinionAI { get; set; } = "LaneMinionAI";
         public string LaneTurretAI { get; set; } = "TurretAI";
-        private IMapScriptHandler _map;
+
+        public Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>> PlayerSpawnPoints { get; }
 
         //Tower type enumeration might vary slightly from map to map, so we set that up here
         public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/CLASSIC.cs
@@ -25,12 +25,13 @@ namespace MapScripts.Map12
             EnableFountainHealing = false,
             EnableBuildingProtection = true
         };
+        private IMapScriptHandler _map;
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
         public bool HasFirstBloodHappened { get; set; } = false;
         public long NextSpawnTime { get; set; } = 45 * 1000;
         public string LaneMinionAI { get; set; } = "LaneMinionAI";
         public string LaneTurretAI { get; set; } = "TurretAI";
-        private IMapScriptHandler _map;
+        public Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>> PlayerSpawnPoints { get; }
 
         //Tower type enumeration might vary slightly from map to map, so we set that up here
         public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/CLASSIC.cs
@@ -16,14 +16,46 @@ namespace MapScripts.Map8
         public IMapScriptMetadata MapScriptMetadata { get; set; } = new MapScriptMetadata
         {
             MinionSpawnEnabled = false,
-            StartingGold = 825.0f
+            StartingGold = 825.0f,
+            OverrideSpawnPoints = true
         };
+        private IMapScriptHandler _map;
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
         public bool HasFirstBloodHappened { get; set; } = false;
         public long NextSpawnTime { get; set; } = 90 * 1000;
         public string LaneMinionAI { get; set; } = "LaneMinionAI";
         public string LaneTurretAI { get; set; } = "TurretAI";
-        private IMapScriptHandler _map;
+
+        //Values i got the values for 5 players from replay packets, the value for 1 player is just a guess of mine by using !coords command in-game
+        public Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>> PlayerSpawnPoints { get; } = new Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>>
+        {
+            {TeamId.TEAM_BLUE, new Dictionary<int, Dictionary<int, Vector2>>{
+                { 5, new Dictionary<int, Vector2>{
+                    { 1, new Vector2(687.99036f, 4281.2314f) },
+                    { 2, new Vector2(687.99036f, 4061.2314f) },
+                    { 3, new Vector2(478.79034f,3993.2314f) },
+                    { 4, new Vector2(349.39032f,4171.2314f) },
+                    { 5, new Vector2(438.79034f,4349.2314f) }
+                }},
+                {1, new Dictionary<int, Vector2>{
+                    { 1, new Vector2(580f, 4124f) }
+                }}
+            }},
+
+            {TeamId.TEAM_PURPLE, new Dictionary<int, Dictionary<int, Vector2>>
+                { { 5, new Dictionary<int, Vector2>{
+                    { 1, new Vector2(13468.365f,4281.2324f) },
+                    { 2, new Vector2(13468.365f,4061.2324f) },
+                    { 3, new Vector2(13259.165f,3993.2324f) },
+                    { 4, new Vector2(13129.765f,4171.2324f) },
+                    { 5, new Vector2(13219.165f,4349.2324f) }
+                }},
+                {1, new Dictionary<int, Vector2>{
+                    { 1, new Vector2(13310f, 4124f) }
+                }}
+            }},
+
+        };
 
         //Tower type enumeration might vary slightly from map to map, so we set that up here
         public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)
@@ -199,7 +231,7 @@ namespace MapScripts.Map8
         List<IMinion> infoPoints = new List<IMinion>();
         public void OnMatchStart()
         {
-            for( int i = 0; i < _map.InfoPoints.Count; i++)
+            for (int i = 0; i < _map.InfoPoints.Count; i++)
             {
                 _map.CreateRegion(TeamId.TEAM_BLUE, new Vector2(_map.InfoPoints[i].CentralPoint.X, _map.InfoPoints[i].CentralPoint.Z), RegionType.Unknown2, null, giveVision: true, visionRadius: 800.0f, revealStealth: true, hasCollision: true, collisionRadius: 120.0f, grassRadius: 150.0f, lifeTime: 25000.0f);
                 infoPoints.Add(_map.CreateMinion("OdinNeutralGuardian", "OdinNeutralGuardian", new Vector2(_map.InfoPoints[i].CentralPoint.X, _map.InfoPoints[i].CentralPoint.Z), ignoreCollision: true));

--- a/GameServerCore/Maps/IMapScriptHandler.cs
+++ b/GameServerCore/Maps/IMapScriptHandler.cs
@@ -59,6 +59,10 @@ namespace GameServerCore.Maps
         /// </summary>
         Dictionary<TeamId, IGameObject> ShopList { get; set; }
         /// <summary>
+        /// Coordinates for player SpawnPositions when the match first begins
+        /// </summary>
+        Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>> PlayerSpawnPoints { get; set; }
+        /// <summary>
         /// List of LaneMinion's spawn points
         /// </summary>
         Dictionary<string, IMapObject> SpawnBarracks { get; }

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -242,7 +242,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="inhibitor">Inhibitor to check.</param>
         /// <param name="killer">Killer of the inhibitor (if applicable).</param>
         /// <param name="assists">Assists of the killer (if applicable).</param>
-        void NotifyInhibitorState(IInhibitor inhibitor, IDeathData deathData, List<IChampion> assists = null);
+        void NotifyInhibitorState(IInhibitor inhibitor, IDeathData deathData = null, List<IChampion> assists = null);
         /// Sends a basic heartbeat packet to either the given player or all players.
         /// </summary>
         void NotifyKeyCheck(int clientID, long playerId, uint version, ulong checkSum = 0, byte action = 0, bool broadcast = false);

--- a/GameServerCore/Scripting/CSharp/IMapScript.cs
+++ b/GameServerCore/Scripting/CSharp/IMapScript.cs
@@ -16,6 +16,7 @@ namespace GameServerCore.Domain
         long NextSpawnTime { get; set; }
         string LaneMinionAI { get; }
         string LaneTurretAI { get; }
+        Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>> PlayerSpawnPoints { get; }
         Dictionary<TurretType, int[]> TurretItems { get; }
         Dictionary<TeamId, string> NexusModels { get; }
         Dictionary<TeamId, string> InhibitorModels { get; }

--- a/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
+++ b/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
@@ -42,5 +42,9 @@ namespace GameServerCore.Scripting.CSharp
         /// Whether or not the fountain should heal the players (Default = true)
         /// </summary>
         bool EnableFountainHealing { get; set; }
+        /// <summary>
+        /// Wether or not the map's position is to be overriden
+        /// </summary>
+        bool OverrideSpawnPoints { get; set; }
     }
 }

--- a/GameServerLib/Content/ContentManager.cs
+++ b/GameServerLib/Content/ContentManager.cs
@@ -128,7 +128,7 @@ namespace LeagueSandbox.GameServer.Content
             throw new ContentNotFoundException($"No map data found for map with id: {mapId}");
         }
 
-        public MapSpawns GetMapSpawns(int mapId)
+        public Dictionary<string, JArray> GetMapSpawns(int mapId)
         {
             foreach (var dataPackage in _loadedPackages)
             {

--- a/GameServerLib/Content/Package.cs
+++ b/GameServerLib/Content/Package.cs
@@ -270,11 +270,11 @@ namespace LeagueSandbox.GameServer.Content
             return mapObject;
         }
 
-        public MapSpawns GetMapSpawns(int mapId)
+        public Dictionary<string, JArray> GetMapSpawns(int mapId)
         {
             var mapName = $"Map{mapId}";
             var contentType = "Maps";
-            var toReturnMapSpawns = new MapSpawns();
+            var toReturnMapSpawns = new Dictionary<string, JArray>();
 
 
             if (!_content.ContainsKey(contentType) || !_content[contentType].ContainsKey(mapName))
@@ -302,11 +302,10 @@ namespace LeagueSandbox.GameServer.Content
             {
                 var team = teamSpawn.Name;
                 var spawnsByPlayerCount = (JArray)teamSpawn.Value;
-                for (var i = 0; i < spawnsByPlayerCount.Count; i++)
-                {
-                    var playerSpawns = new PlayerSpawns((JArray)spawnsByPlayerCount[i]);
-                    toReturnMapSpawns.SetSpawns(team, playerSpawns, i);
-                }
+                
+                    //var playerSpawns = new PlayerSpawns((JArray)spawnsByPlayerCount[i]);
+                    toReturnMapSpawns.Add(team, spawnsByPlayerCount);
+        
             }
 
             return toReturnMapSpawns;

--- a/GameServerLib/Content/Package.cs
+++ b/GameServerLib/Content/Package.cs
@@ -302,10 +302,7 @@ namespace LeagueSandbox.GameServer.Content
             {
                 var team = teamSpawn.Name;
                 var spawnsByPlayerCount = (JArray)teamSpawn.Value;
-                
-                    //var playerSpawns = new PlayerSpawns((JArray)spawnsByPlayerCount[i]);
-                    toReturnMapSpawns.Add(team, spawnsByPlayerCount);
-        
+                toReturnMapSpawns.Add(team, spawnsByPlayerCount);
             }
 
             return toReturnMapSpawns;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -127,46 +127,31 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             return _playerId;
         }
 
-        public Vector2 GetSpawnPosition()
+        public Vector2 GetSpawnPosition(int index)
         {
-            var config = _game.Config;
-            var playerIndex = GetPlayerIndex();
-            var playerTeam = "";
             var teamSize = GetTeamSize();
 
-            if (config.Players.ContainsKey(playerIndex))
+            if (_game.Map.PlayerSpawnPoints[Team].ContainsKey(teamSize))
             {
-                var p = config.Players[playerIndex];
-                playerTeam = p.Team;
+                return _game.Map.PlayerSpawnPoints[Team][teamSize][index];
             }
 
-            var spawnsByTeam = new Dictionary<TeamId, Dictionary<int, PlayerSpawns>>
+            if(_game.Map.PlayerSpawnPoints[Team].ContainsKey(1) && _game.Map.PlayerSpawnPoints[Team][1][1] != null)
             {
-                {TeamId.TEAM_BLUE, config.MapSpawns.Blue},
-                {TeamId.TEAM_PURPLE, config.MapSpawns.Purple}
-            };
-
-            if (teamSize > config.MapSpawns.Blue.Count || teamSize > config.MapSpawns.Purple.Count)
-            {
-                var spawns1 = spawnsByTeam[Team];
-                return spawns1[0].GetCoordsForPlayer(0);
+                return _game.Map.PlayerSpawnPoints[Team][1][1];
             }
 
-            var spawns = spawnsByTeam[Team];
-            return spawns[teamSize - 1].GetCoordsForPlayer((int)_playerTeamSpecialId);
+            if (_game.Map.FountainList.ContainsKey(Team))
+            {
+                return _game.Map.FountainList[Team].Position;
+            }
+
+            return Vector2.Zero;
         }
 
         public Vector2 GetRespawnPosition()
         {
-            var config = _game.Config;
-
-            var spawnsByTeam = new Dictionary<TeamId, Dictionary<int, PlayerSpawns>>
-            {
-                {TeamId.TEAM_BLUE, config.MapSpawns.Blue},
-                {TeamId.TEAM_PURPLE, config.MapSpawns.Purple}
-            };
-            var spawns1 = spawnsByTeam[Team];
-            return spawns1[0].GetCoordsForPlayer(0);
+            return _game.Map.FountainList[Team].Position;
         }
 
         public override ISpell LevelUpSpell(byte slot)

--- a/GameServerLib/Maps/MapScriptHandler.cs
+++ b/GameServerLib/Maps/MapScriptHandler.cs
@@ -62,18 +62,21 @@ namespace LeagueSandbox.GameServer.Maps
         /// </summary>
         public List<IAnnounce> AnnouncerEvents { get; private set; }
 
-        private int _minionNumber;
-        private int _cannonMinionCount;
-        public List<INexus> NexusList { get; set; } = new List<INexus>();
-        public Dictionary<string, IMapObject> SpawnBarracks { get; set; }
-        public Dictionary<TeamId, IFountain> FountainList { get; set; } = new Dictionary<TeamId, IFountain>();
-        private readonly Dictionary<TeamId, SurrenderHandler> _surrenders = new Dictionary<TeamId, SurrenderHandler>();
-        public Dictionary<TeamId, Dictionary<LaneID, List<IInhibitor>>> InhibitorList { get; set; }
-        public Dictionary<TeamId, Dictionary<LaneID, List<ILaneTurret>>> TurretList { get; set; }
-        public List<IMapObject> InfoPoints { get; set; } = new List<IMapObject>();
-        public Dictionary<TeamId, IGameObject> ShopList { get; set; } = new Dictionary<TeamId, IGameObject>();
+
         public Dictionary<LaneID, List<Vector2>> BlueMinionPathing;
         public Dictionary<LaneID, List<Vector2>> PurpleMinionPathing;
+        public Dictionary<string, IMapObject> SpawnBarracks { get; set; }
+        public List<INexus> NexusList { get; set; } = new List<INexus>();
+        public List<IMapObject> InfoPoints { get; set; } = new List<IMapObject>();
+        public Dictionary<TeamId, Dictionary<LaneID, List<ILaneTurret>>> TurretList { get; set; }
+        public Dictionary<TeamId, Dictionary<LaneID, List<IInhibitor>>> InhibitorList { get; set; }
+        public Dictionary<TeamId, IFountain> FountainList { get; set; } = new Dictionary<TeamId, IFountain>();
+        public Dictionary<TeamId, IGameObject> ShopList { get; set; } = new Dictionary<TeamId, IGameObject>();
+        public Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>> PlayerSpawnPoints { get; set; } = new Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>>();
+
+        private int _minionNumber;
+        private int _cannonMinionCount;
+        private readonly Dictionary<TeamId, SurrenderHandler> _surrenders = new Dictionary<TeamId, SurrenderHandler>();
 
         /// <summary>
         /// Instantiates map related game settings such as collision handler, navigation grid, announcer events, and map properties.
@@ -111,6 +114,15 @@ namespace LeagueSandbox.GameServer.Maps
             if (game.Config.MapData.SpawnBarracks != null)
             {
                 SpawnBarracks = game.Config.MapData.SpawnBarracks;
+            }
+
+            if (MapScript.PlayerSpawnPoints != null && MapScript.MapScriptMetadata.OverrideSpawnPoints)
+            {
+                PlayerSpawnPoints = MapScript.PlayerSpawnPoints;
+            }
+            else
+            {
+                PlayerSpawnPoints = _game.Config.GetMapSpawns();
             }
         }
 

--- a/GameServerLib/Players/PlayerManager.cs
+++ b/GameServerLib/Players/PlayerManager.cs
@@ -58,7 +58,7 @@ namespace LeagueSandbox.GameServer.Players
             );
             var c = new Champion(_game, p.Value.Champion, (uint)player.PlayerId, _userIdsPerTeam[teamId]++, p.Value.Runes, player, 0, teamId);
 
-            var pos = c.GetSpawnPosition();
+            var pos = c.GetSpawnPosition(_players.Count + 1);
             c.SetPosition(pos, false);
             c.StopMovement();
             c.UpdateMoveOrder(OrderType.Stop);

--- a/GameServerLib/Players/PlayerManager.cs
+++ b/GameServerLib/Players/PlayerManager.cs
@@ -58,7 +58,7 @@ namespace LeagueSandbox.GameServer.Players
             );
             var c = new Champion(_game, p.Value.Champion, (uint)player.PlayerId, _userIdsPerTeam[teamId]++, p.Value.Runes, player, 0, teamId);
 
-            var pos = c.GetSpawnPosition(_players.Count + 1);
+            var pos = c.GetSpawnPosition((int)_userIdsPerTeam[teamId]);
             c.SetPosition(pos, false);
             c.StopMovement();
             c.UpdateMoveOrder(OrderType.Stop);

--- a/GameServerLib/Scripting/CSharp/EmptyMapScript.cs
+++ b/GameServerLib/Scripting/CSharp/EmptyMapScript.cs
@@ -17,12 +17,14 @@ namespace MapScripts
         {
             MinionPathingOverride = true,
         };
+        private IMapScriptHandler _map;
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
         public bool HasFirstBloodHappened { get; set; } = false;
         public long NextSpawnTime { get; set; } = 90 * 1000;
         public string LaneMinionAI { get; set; } = "LaneMinionAI";
         public string LaneTurretAI { get; set; } = "TurretAI";
-        private IMapScriptHandler _map;
+
+        public Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>> PlayerSpawnPoints { get; }
 
         //Tower type enumeration might vary slightly from map to map, so we set that up here
         public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)

--- a/GameServerLib/Scripting/CSharp/MapScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/MapScriptMetadata.cs
@@ -23,5 +23,6 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         public int RecallSpellItemId { get; set; } = 2001;
         public long FirstGoldTime { get; set; } = 90 * 1000;
         public bool EnableFountainHealing { get; set; } = true;
+        public bool OverrideSpawnPoints { get; set; } = false;
     }
 }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -1033,7 +1033,7 @@ namespace PacketDefinitions420
         /// <param name="inhibitor">Inhibitor to check.</param>
         /// <param name="killer">Killer of the inhibitor (if applicable).</param>
         /// <param name="assists">Assists of the killer (if applicable).</param>
-        public void NotifyInhibitorState(IInhibitor inhibitor, IDeathData deathData, List<IChampion> assists = null)
+        public void NotifyInhibitorState(IInhibitor inhibitor, IDeathData deathData = null, List<IChampion> assists = null)
         {
             UnitAnnounce announce;
             switch (inhibitor.InhibitorState)
@@ -1046,7 +1046,7 @@ namespace PacketDefinitions420
 
                     break;
                 case InhibitorState.ALIVE:
-                    announce = new UnitAnnounce(UnitAnnounces.INHIBITOR_SPAWNED, inhibitor, deathData.Killer, assists);
+                    announce = new UnitAnnounce(UnitAnnounces.INHIBITOR_SPAWNED, inhibitor, null, assists);
                     _packetHandlerManager.BroadcastPacket(announce, Channel.CHL_S2C);
                     break;
             }


### PR DESCRIPTION
* Config
    -Removed `MapSpawns` and `PlayerSpawns` from `Config.cs`.

    - Both `GetMapSpawns` in `Package.cs` and in `ContentManager.cs` now return a 
     `Dictionary<string, JArray>` instead of the removed `MapSpawns`.

    - Introduced `GetMapSpawns` Function to `Config` to load the SpawnPositions 
     files.

* MapScriptHandler
    - Spawn Positions are now loaded to `MapScriptHandler`.

    - Spawn Positions are organized in the following method: Team -> Ammount of 
     players in the team -> Number in order which the player was created within 
     their team.

* MapScriptMetaData
    - Introduced `OverrideSpawnPoints` as a simple check to use the overriden spawnpoints.

* MapScripts
    - Now MapScripts have an extra `PlayerSpawnPoints` variable to be used to 
     override the SpawnPoints from our files.

    - Updated Map8's(Crystal Scar) Script to make use of this new variable and fix it's 
     spawn position outside of base.