### PR TITLE
Resolve #1199, Resolve #1082, Resolve #977 -- Implement Normal Channels

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/MasterYi/Meditate.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/MasterYi/Meditate.cs
@@ -1,0 +1,109 @@
+﻿using GameServerCore.Enums;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using GameServerCore.Scripting.CSharp;
+using System;
+using LeagueSandbox.GameServer.API;
+using GameServerCore.Domain;
+
+namespace Buffs
+{
+    internal class Meditate : IBuffGameScript
+    {
+        public BuffType BuffType => BuffType.HEAL;
+        public BuffAddType BuffAddType => BuffAddType.RENEW_EXISTING;
+        public int MaxStacks => 1;
+        public bool IsHidden => false;
+
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
+
+        float[] healthTick =
+        {
+            15f,
+            25f,
+            35f,
+            45f,
+            55f
+        };
+
+        float[] flatArmorMod =
+        {
+            100.0f,
+            150.0f,
+            200.0f,
+            250.0f,
+            300.0f
+        };
+
+        float[] flatSpellBlockMod =
+        {
+            100.0f,
+            150.0f,
+            200.0f,
+            250.0f,
+            300.0f
+        };
+
+        IObjAiBase owner;
+        float tickTime;
+        float trueHeal;
+        int spellLevel;
+        IParticle buffParticle;
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            owner = ownerSpell.CastInfo.Owner;
+            spellLevel = ownerSpell.CastInfo.SpellLevel - 1;
+
+            StatsModifier.Armor.FlatBonus = flatArmorMod[spellLevel];
+            StatsModifier.MagicResist.FlatBonus = flatSpellBlockMod[spellLevel];
+
+            owner.AddStatModifier(StatsModifier);
+
+            ApiEventManager.OnTakeDamage.AddListener(this, unit, TakeDamage, false);
+
+            buffParticle = AddParticleTarget(unit, unit, "masteryi_base_w_buf", unit, 4.0f, flags: 0);
+        }
+
+        public void TakeDamage(IDamageData dmg)
+        {
+            var unit = dmg.Target;
+            AddParticleTarget(unit, unit, "masteryi_base_w_dmg", unit, flags: 0);
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            var missingHealthBonus = healthTick[spellLevel] * ((owner.Stats.HealthPoints.Total - owner.Stats.CurrentHealth) / owner.Stats.HealthPoints.Total);
+            var apBonus = owner.Stats.AbilityPower.Total * 0.3f;
+            trueHeal = healthTick[spellLevel] + missingHealthBonus + apBonus;
+
+            var newHealth = owner.Stats.CurrentHealth + trueHeal;
+            owner.Stats.CurrentHealth = Math.Min(newHealth, owner.Stats.HealthPoints.Total);
+
+            ApiEventManager.RemoveAllListenersForOwner(this);
+
+            if (buffParticle != null)
+            {
+                buffParticle.SetToRemove();
+            }
+        }
+
+        public void OnUpdate(float diff)
+        {
+            if (tickTime >= 500.0f)
+            {
+                var missingHealthBonus = healthTick[spellLevel] * ((owner.Stats.HealthPoints.Total - owner.Stats.CurrentHealth) / owner.Stats.HealthPoints.Total);
+                var apBonus = owner.Stats.AbilityPower.Total * 0.3f;
+                trueHeal = healthTick[spellLevel] + missingHealthBonus + apBonus;
+
+                var newHealth = owner.Stats.CurrentHealth + trueHeal;
+                owner.Stats.CurrentHealth = Math.Min(newHealth, owner.Stats.HealthPoints.Total);
+                tickTime = 0;
+            }
+
+            tickTime += diff;
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Characters/Aatrox/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Aatrox/R.cs
@@ -78,7 +78,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Akali/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Akali/E.cs
@@ -73,7 +73,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Akali/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Akali/Q.cs
@@ -61,7 +61,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Akali/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Akali/R.cs
@@ -62,7 +62,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Akali/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Akali/W.cs
@@ -4,6 +4,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -56,7 +57,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Anivia/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Anivia/R.cs
@@ -102,7 +102,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Annie/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Annie/E.cs
@@ -4,6 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -39,7 +40,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Annie/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Annie/Q.cs
@@ -67,7 +67,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Annie/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Annie/W.cs
@@ -71,7 +71,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Blitzcrank/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Blitzcrank/Q.cs
@@ -46,7 +46,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -122,7 +122,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Blitzcrank/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Blitzcrank/W.cs
@@ -4,6 +4,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -39,7 +40,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Caitlyn/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Caitlyn/E.cs
@@ -67,7 +67,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Caitlyn/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Caitlyn/Q.cs
@@ -63,7 +63,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Caitlyn/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Caitlyn/R.cs
@@ -55,7 +55,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Ezreal/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Ezreal/E.cs
@@ -72,7 +72,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -126,7 +126,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Ezreal/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Ezreal/Q.cs
@@ -66,7 +66,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -137,7 +137,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Ezreal/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Ezreal/R.cs
@@ -65,7 +65,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Ezreal/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Ezreal/W.cs
@@ -73,7 +73,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Gangplank/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Gangplank/E.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Numerics;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -57,7 +58,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Gangplank/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Gangplank/Q.cs
@@ -72,7 +72,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Gangplank/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Gangplank/W.cs
@@ -1,5 +1,6 @@
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System;
@@ -41,7 +42,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Garen/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Garen/E.cs
@@ -71,7 +71,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Garen/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Garen/R.cs
@@ -53,7 +53,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Global/SummonerDot.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Global/SummonerDot.cs
@@ -44,7 +44,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Global/SummonerExhaust.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Global/SummonerExhaust.cs
@@ -5,6 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -44,7 +45,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Global/SummonerFlash.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Global/SummonerFlash.cs
@@ -63,7 +63,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Global/SummonerHeal.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Global/SummonerHeal.cs
@@ -6,6 +6,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -88,7 +89,7 @@ namespace Spells
         { 
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Global/SummonerMana.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Global/SummonerMana.cs
@@ -5,6 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -59,7 +60,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Global/SummonerRevive.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Global/SummonerRevive.cs
@@ -5,6 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -47,7 +48,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Global/SummonerSmite.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Global/SummonerSmite.cs
@@ -44,7 +44,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Graves/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Graves/E.cs
@@ -5,6 +5,7 @@ using GameServerCore.Domain.GameObjects.Spell.Missile;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -53,7 +54,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Karthus/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Karthus/Q.cs
@@ -79,7 +79,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Karthus/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Karthus/R.cs
@@ -57,7 +57,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Kassadin/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Kassadin/Q.cs
@@ -60,7 +60,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/LeeSin/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/LeeSin/Q.cs
@@ -64,7 +64,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Leona/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Leona/Q.cs
@@ -46,7 +46,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -106,7 +106,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Lucian/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Lucian/E.cs
@@ -4,6 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -47,7 +48,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Lucian/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Lucian/Q.cs
@@ -79,7 +79,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Lucian/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Lucian/W.cs
@@ -4,6 +4,7 @@ using LeagueSandbox.GameServer.Scripting.CSharp;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -52,7 +53,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Lulu/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Lulu/R.cs
@@ -4,6 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -39,7 +40,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Lulu/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Lulu/W.cs
@@ -6,6 +6,7 @@ using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -70,7 +71,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Lux/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Lux/R.cs
@@ -47,7 +47,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -134,7 +134,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/MasterYi/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/MasterYi/R.cs
@@ -5,6 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -40,7 +41,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/MasterYi/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/MasterYi/W.cs
@@ -1,20 +1,33 @@
-using GameServerCore.Domain.GameObjects;
+﻿using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using System;
 using GameServerCore.Enums;
 
 namespace Spells
 {
-    public class SummonerHaste : ISpellScript
+    public class Meditate : ISpellScript
     {
         public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
-            // TODO
+            NotSingleTargetSpell = true,
+            TriggersSpellCasts = true,
+            ChannelDuration = 4f,
+            AutoCooldownByLevel = new float[]
+            {
+                50f,
+                50f,
+                50f,
+                50f,
+                50f
+            }
         };
+
+        IObjAiBase Owner;
 
         public void OnActivate(IObjAiBase owner, ISpell spell)
         {
@@ -26,18 +39,12 @@ namespace Spells
 
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
-            AddBuff("SummonerHasteBuff", 10.0f, 1, spell, owner, owner);
-            var p1 = AddParticleTarget(owner, target, "Global_SS_Ghost", target);
-            var p2 = AddParticleTarget(owner, target, "Global_SS_Ghost_cas", target);
-            CreateTimer(10.0f, () =>
-            {
-                RemoveParticle(p1);
-                RemoveParticle(p2);
-            });
+            Owner = owner;
         }
 
         public void OnSpellCast(ISpell spell)
         {
+            AddParticleTarget(Owner, Owner, "masteryi_base_w_cas", Owner, flags: 0);
         }
 
         public void OnSpellPostCast(ISpell spell)
@@ -46,14 +53,26 @@ namespace Spells
 
         public void OnSpellChannel(ISpell spell)
         {
+            AddBuff("Meditate", 4.0f, 1, spell, Owner, Owner);
         }
 
         public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
+            RemoveBuff(Owner, "Meditate");
         }
 
         public void OnSpellPostChannel(ISpell spell)
         {
+            //float[] finalHeal = new float[]
+            //{
+            //    25f,
+            //    50f,
+            //    83.3f,
+            //    125f,
+            //    183.3f
+            //};
+            //Owner.Stats.CurrentHealth = Math.Min(Owner.Stats.CurrentHealth, finalHeal[spell.CastInfo.SpellLevel]);
+            RemoveBuff(Owner, "Meditate");
         }
 
         public void OnUpdate(float diff)
@@ -61,4 +80,3 @@ namespace Spells
         }
     }
 }
-

--- a/Content/LeagueSandbox-Scripts/Characters/Nasus/BasicAttack.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Nasus/BasicAttack.cs
@@ -4,6 +4,7 @@ using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using LeagueSandbox.GameServer.API;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -44,7 +45,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -94,7 +95,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Nidalee/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Nidalee/Q.cs
@@ -78,7 +78,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Olaf/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Olaf/Q.cs
@@ -67,7 +67,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Shaco/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Shaco/W.cs
@@ -97,7 +97,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Sion/Passive Ability.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Sion/Passive Ability.cs
@@ -8,7 +8,7 @@ using LeagueSandbox.GameServer.API;
 using GameServerCore.Domain;
 using GameServerLib.GameObjects.AttackableUnits;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
-
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -39,7 +39,7 @@ namespace Spells
         public void OnSpellChannel(ISpell spell)
         {
         }
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
         public void OnSpellPostChannel(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Characters/Sion/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Sion/W.cs
@@ -9,6 +9,7 @@ using GameServerCore.Domain;
 using GameServerLib.GameObjects.AttackableUnits;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.GameObjects.Stats;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -68,7 +69,7 @@ namespace Spells
         public void OnSpellChannel(ISpell spell)
         {
         }
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
         public void OnSpellPostChannel(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Characters/Sivir/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Sivir/W.cs
@@ -45,7 +45,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -101,7 +101,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -172,7 +172,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Taric/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Taric/E.cs
@@ -79,7 +79,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Taric/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Taric/Q.cs
@@ -6,6 +6,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -82,7 +83,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Taric/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Taric/R.cs
@@ -92,7 +92,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Taric/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Taric/W.cs
@@ -77,7 +77,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Teemo/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Teemo/Q.cs
@@ -52,7 +52,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Yasuo/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Yasuo/E.cs
@@ -5,6 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
@@ -50,7 +51,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Yasuo/Q1.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Yasuo/Q1.cs
@@ -84,7 +84,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Yasuo/Q2.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Yasuo/Q2.cs
@@ -86,7 +86,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Yasuo/Q3.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Yasuo/Q3.cs
@@ -90,7 +90,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Zed/W.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Zed/W.cs
@@ -51,7 +51,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -126,7 +126,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -170,7 +170,7 @@ namespace Spells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Items/Actives/DeathfireGrasp.cs
+++ b/Content/LeagueSandbox-Scripts/Items/Actives/DeathfireGrasp.cs
@@ -44,7 +44,7 @@ namespace ItemSpells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 
@@ -101,7 +101,7 @@ namespace ItemSpells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Items/Actives/RegenerationPotion.cs
+++ b/Content/LeagueSandbox-Scripts/Items/Actives/RegenerationPotion.cs
@@ -5,6 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace ItemSpells
 {
@@ -40,7 +41,7 @@ namespace ItemSpells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Items/Actives/YoumusBlade.cs
+++ b/Content/LeagueSandbox-Scripts/Items/Actives/YoumusBlade.cs
@@ -5,6 +5,7 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using System.Numerics;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace ItemSpells
 {
@@ -40,7 +41,7 @@ namespace ItemSpells
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 

--- a/Content/LeagueSandbox-Scripts/Items/Passives/Malady.cs
+++ b/Content/LeagueSandbox-Scripts/Items/Passives/Malady.cs
@@ -59,7 +59,7 @@ namespace ItemSpells
 
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
 
         }

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -154,6 +154,11 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="s">Spell that is being cast.</param>
         void SetCastSpell(ISpell s);
         /// <summary>
+        /// Gets the spell this unit is currently casting.
+        /// </summary>
+        /// <returns>Spell that is being cast.</returns>
+        ISpell GetCastSpell();
+        /// <summary>
         /// Sets this AI's current target unit. This relates to both auto attacks as well as general spell targeting.
         /// </summary>
         /// <param name="target">Unit to target.</param>

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -149,6 +149,11 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="unit">Unit to cast the spell on.</param>
         void SetSpellToCast(ISpell s, Vector2 location, IAttackableUnit unit = null);
         /// <summary>
+        /// Sets the spell that this unit is currently casting.
+        /// </summary>
+        /// <param name="s">Spell that is being cast.</param>
+        void SetCastSpell(ISpell s);
+        /// <summary>
         /// Sets this AI's current target unit. This relates to both auto attacks as well as general spell targeting.
         /// </summary>
         /// <param name="target">Unit to target.</param>

--- a/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
@@ -138,7 +138,7 @@ namespace GameServerCore.Domain.GameObjects.Spell
         void LevelUp();
         string GetStringForSlot();
         float GetCooldown();
-        void ResetSpellDelay();
+        void ResetSpellCast();
         /// <summary>
         /// Overrides the normal cast range for this spell. Set to 0 to revert.
         /// </summary>

--- a/GameServerCore/Scripting/CSharp/ISpellScript.cs
+++ b/GameServerCore/Scripting/CSharp/ISpellScript.cs
@@ -1,6 +1,7 @@
 ﻿using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Enums;
 using System.Numerics;
 
 namespace GameServerCore.Scripting.CSharp
@@ -21,7 +22,7 @@ namespace GameServerCore.Scripting.CSharp
 
         void OnSpellChannel(ISpell spell);
 
-        void OnSpellChannelCancel(ISpell spell);
+        void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason);
 
         void OnSpellPostChannel(ISpell spell);
 

--- a/GameServerLib/API/ApiEventManager.cs
+++ b/GameServerLib/API/ApiEventManager.cs
@@ -605,10 +605,10 @@ namespace LeagueSandbox.GameServer.API
 
     public class EventOnSpellChannelCancel
     {
-        private readonly List<Tuple<object, ISpell, Action<ISpell>>> _listeners = new List<Tuple<object, ISpell, Action<ISpell>>>();
-        public void AddListener(object owner, ISpell spell, Action<ISpell> callback)
+        private readonly List<Tuple<object, ISpell, Action<ISpell, ChannelingStopSource>>> _listeners = new List<Tuple<object, ISpell, Action<ISpell, ChannelingStopSource>>>();
+        public void AddListener(object owner, ISpell spell, Action<ISpell, ChannelingStopSource> callback)
         {
-            var listenerTuple = new Tuple<object, ISpell, Action<ISpell>>(owner, spell, callback);
+            var listenerTuple = new Tuple<object, ISpell, Action<ISpell, ChannelingStopSource>>(owner, spell, callback);
             _listeners.Add(listenerTuple);
         }
         public void RemoveListener(object owner, ISpell spell)
@@ -619,7 +619,7 @@ namespace LeagueSandbox.GameServer.API
         {
             _listeners.RemoveAll((listener) => listener.Item1 == owner);
         }
-        public void Publish(ISpell spell)
+        public void Publish(ISpell spell, ChannelingStopSource reason)
         {
             var count = _listeners.Count;
 
@@ -632,7 +632,7 @@ namespace LeagueSandbox.GameServer.API
             {
                 if (_listeners[i].Item2 == spell)
                 {
-                    _listeners[i].Item3(spell);
+                    _listeners[i].Item3(spell, reason);
                 }
             }
         }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -25,6 +25,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         // Crucial Vars
         private float _autoAttackCurrentCooldown;
         private bool _skipNextAutoAttack;
+        private ISpell _castingSpell;
         private Random _random = new Random();
         private readonly CSharpScriptEngine _charScriptEngine;
         protected ItemManager _itemManager;
@@ -84,6 +85,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public ICharScript CharScript { get; private set; }
         public bool IsBot { get; set; }
         public IAIScript AIScript { get; protected set; }
+
         public ObjAiBase(Game game, string model, Stats.Stats stats, int collisionRadius = 40,
             Vector2 position = new Vector2(), int visionRadius = 0, int skinId = 0, uint netId = 0, TeamId team = TeamId.TEAM_NEUTRAL, string aiScript = "") :
             base(game, model, stats, collisionRadius, position, visionRadius, netId, team)
@@ -835,7 +837,16 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// <param name="s">Spell that is being cast.</param>
         public void SetCastSpell(ISpell s)
         {
-            SpellToCast = s;
+            _castingSpell = s;
+        }
+
+        /// <summary>
+        /// Gets the spell this unit is currently casting.
+        /// </summary>
+        /// <returns>Spell that is being cast.</returns>
+        public ISpell GetCastSpell()
+        {
+            return _castingSpell;
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -830,6 +830,15 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         }
 
         /// <summary>
+        /// Sets the spell that this unit is currently casting.
+        /// </summary>
+        /// <param name="s">Spell that is being cast.</param>
+        public void SetCastSpell(ISpell s)
+        {
+            SpellToCast = s;
+        }
+
+        /// <summary>
         /// Sets this AI's current target unit. This relates to both auto attacks as well as general spell targeting.
         /// </summary>
         /// <param name="target">Unit to target.</param>

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -1006,6 +1006,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
             else
             {
+                // TODO: Verify if there are any other cases we want to avoid.
                 if (TargetUnit != null && TargetUnit.Team != Team && MoveOrder != OrderType.CastSpell)
                 {
                     idealRange = Stats.Range.Total + TargetUnit.CollisionRadius;

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -676,9 +676,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 return;
             }
 
-            if (CastInfo.Owner.SpellToCast != null)
+            if (CastInfo.Owner.GetCastSpell() != null)
             {
-                var spellTarget = CastInfo.Owner.SpellToCast.CastInfo.Targets[0].Unit;
+                var spellTarget = CastInfo.Owner.GetCastSpell().CastInfo.Targets[0].Unit;
 
                 if (spellTarget != null
                 && !spellTarget.IsVisibleByTeam(CastInfo.Owner.Team))
@@ -733,8 +733,8 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 return;
             }
 
-            if (CastInfo.Owner.SpellToCast != null
-            && !CastInfo.Owner.SpellToCast.SpellData.DoesntBreakChannels
+            if (CastInfo.Owner.GetCastSpell() != null
+            && !CastInfo.Owner.GetCastSpell().SpellData.DoesntBreakChannels
             && (order == OrderType.CastSpell
             || order == OrderType.TempCastSpell))
             {
@@ -836,6 +836,11 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             if (CastInfo.Owner.SpellToCast != null)
             {
                 CastInfo.Owner.SetSpellToCast(null, Vector2.Zero);
+            }
+
+            if (CastInfo.Owner.GetCastSpell() != null)
+            {
+                CastInfo.Owner.SetCastSpell(null);
             }
 
             // Updates move order before script PostCast so teleports are sent to clients correctly (not sent if MoveOrder == CastSpell).

--- a/GameServerLib/Scripting/CSharp/SpellScriptEmpty.cs
+++ b/GameServerLib/Scripting/CSharp/SpellScriptEmpty.cs
@@ -1,6 +1,7 @@
 ﻿using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
+using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
 using System.Numerics;
 
@@ -34,7 +35,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         {
         }
 
-        public void OnSpellChannelCancel(ISpell spell)
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
         }
 


### PR DESCRIPTION
Stationary channels have been fully implemented.
Auto attacks are cancelled properly when casting/channeling. Weaving movements inbetween casts or channels has been made cleaner.

* Scripting:
  * Recall and MasterYi W (Meditate) have been re-implemented.
  * OnSpellChannelCancel function supports a reason variable.
* ObjAiBase:
  * Added SetCastSpell function for setting the currently casting spell. This is used for when a spell is cast during another spell channel.
  * CanMove and CanAttack functions take into account casting spells and channels.
  * TargetUnit is no longer forced to be used for auto attacks.
  * UpdateTarget function (previously UpdateAttackTarget) takes into account validating spell and attack target.
    * This fixes being able to target allies with auto attacks.
* Spell:
  * Cast functions take into account channel duration for spell cast packets.
  * Channeled spells now automatically stop movements when cast (regardless of TriggersSpellCasts).
  * Added ChannelCancelCheck function which is called every tick of the spell. This checks if the current spell channel should be cancelled.
  * Added CastCancelCheck for checking if a spell cast should be canceled (due to distance to target, visibility, CC, etc).
  * StopChannel function properly cancels the spell channel client-side by using the dedicated `InstantStop_Attack` packet. This is consistent with the method League uses as seen in replays.
 

-All Changes here are credited to Lizardy