### PR TITLE
Fix AutoAttack ExtraSpells

### DIFF
--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -427,7 +427,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 if (CastInfo.SpellSlot >= 45 && CastInfo.SpellSlot <= 60)
                 {
                     // Extra Spells which UseAttackCastTime just use the base auto attack's cast time.
-                    index = 64;
+                    index = 0;
                 }
 
                 float autoAttackTotalTime = CastInfo.Owner.CharData.GlobalCharData.AttackDelay * (1.0f + CastInfo.Owner.CharData.AttackDelayOffsetPercent[0]);
@@ -634,7 +634,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 if (CastInfo.SpellSlot >= 45 && CastInfo.SpellSlot <= 60)
                 {
                     // Extra Spells which UseAttackCastTime just use the base auto attack's cast time.
-                    index = 64;
+                    index = 0;
                 }
 
                 float autoAttackTotalTime = CastInfo.Owner.CharData.GlobalCharData.AttackDelay * (1.0f + CastInfo.Owner.CharData.AttackDelayOffsetPercent[0]);


### PR DESCRIPTION
* Spell.cs
    - Changed Indexes in lines 430 and 637 from `64` to `0`