### PR TITLE
Resolve #1289 -- Introduced Support to PropAnimations on Maps and Update to Crystal Scar

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Global/OdinPlayerBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/OdinPlayerBuff.cs
@@ -1,0 +1,50 @@
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+
+namespace Buffs
+{
+    internal class OdinPlayerBuff : IBuffGameScript
+    {
+        public IBuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffType = BuffType.COMBAT_ENCHANCER,
+            BuffAddType = BuffAddType.REPLACE_EXISTING
+        };
+
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
+
+        IChampion Champion;
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell = null)
+        {
+            if(unit is IChampion ch)
+            {
+                Champion = ch;
+            }
+
+            //TODO: Add 2% mana regeneration per 1% missing mana
+            if(unit.Stats.ParType == PrimaryAbilityResourceType.Energy)
+            {
+                StatsModifier.ManaRegeneration.FlatBonus += 2.0f;
+            }
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+        }
+        float XpCounter = 0;
+        public void OnUpdate(float diff)
+        {
+            XpCounter += diff;
+            if(XpCounter > 1000 && Champion != null)
+            {
+                Champion.AddExperience(7.2f, false);
+                XpCounter = 0;
+            }
+        }
+    }
+}
+

--- a/Content/LeagueSandbox-Scripts/Buffs/OdinSpeedShrine/OdinSpeedShrineBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/OdinSpeedShrine/OdinSpeedShrineBuff.cs
@@ -3,6 +3,7 @@ using GameServerCore.Enums;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.Stats;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace Buffs
@@ -12,25 +13,29 @@ namespace Buffs
         public IBuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
         {
             BuffType = BuffType.COMBAT_ENCHANCER,
-            BuffAddType = BuffAddType.REPLACE_EXISTING
+            BuffAddType = BuffAddType.RENEW_EXISTING
         };
-
         public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
+        IParticle p1;
+        IParticle p2;
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             //TODO: Make it decay over the duration of the buff
+            p1 = AddParticleTarget(buff.SourceUnit, unit, "Odin_Speed_Shrine_buf", unit, buff.Duration);
+            p2 = AddParticleTarget(buff.SourceUnit, unit, "invis_runes_01", unit, buff.Duration);
             StatsModifier.MoveSpeed.PercentBonus += 0.3f;
             unit.AddStatModifier(StatsModifier);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
+            RemoveParticle(p1);
+            RemoveParticle(p2);
         }
 
         public void OnUpdate(float diff)
         {
-
         }
     }
 }

--- a/Content/LeagueSandbox-Scripts/Characters/Global/OdinRecall.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Global/OdinRecall.cs
@@ -1,0 +1,76 @@
+using GameServerCore.Domain.GameObjects;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using System.Numerics;
+using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
+
+namespace Spells
+{
+    public class OdinRecall : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            CastingBreaksStealth = true,
+            ChannelDuration = 4.5f,
+            TriggersSpellCasts = false,
+            NotSingleTargetSpell = true
+        };
+
+        IParticle recallParticle;
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnTakeDamage(IAttackableUnit unit, IAttackableUnit attacker)
+        {
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+            var owner = spell.CastInfo.Owner;
+            recallParticle = AddParticleTarget(owner, owner, "teleporthome_shortimproved", owner, 4.5f, flags: 0);
+            //TODO: Find out what's the proper buff name, i couldnt find it. But i at least found it's icon, "RecallHome.dds"
+            AddBuff("RecallHome", 4.4f, 1, spell, owner, owner);
+        }
+
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
+        {
+            recallParticle.SetToRemove();
+            RemoveBuff(spell.CastInfo.Owner, "RecallHome");
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+            var owner = spell.CastInfo.Owner as IChampion;
+
+            owner.Recall();
+
+            AddParticleTarget(owner, owner, "TeleportArrive", owner, flags: 0);
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}
+

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/CLASSIC.cs
@@ -14,7 +14,7 @@ namespace MapScripts.Map1
 {
     public class CLASSIC : IMapScript
     {
-        public IMapScriptMetadata MapScriptMetadata { get; set; } = new MapScriptMetadata
+        public virtual IMapScriptMetadata MapScriptMetadata { get; set; } = new MapScriptMetadata
         {
             MinionPathingOverride = true,
             EnableBuildingProtection = true

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/URF.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/URF.cs
@@ -3,11 +3,19 @@ using GameServerCore.Domain;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Maps;
 using LeagueSandbox.GameServer.Content;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace MapScripts.Map1
 {
     public class URF : CLASSIC
     {
+        public override IMapScriptMetadata MapScriptMetadata { get; set; } = new MapScriptMetadata
+        {
+            MinionPathingOverride = true,
+            EnableBuildingProtection = true,
+            MaxLevel = 30
+        };
         public override IGlobalData GlobalData { get; set; } = new GlobalData { PercentCooldownModMinimun = 0.8f};
         public override void Init(IMapScriptHandler map)
         {

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/CLASSIC.cs
@@ -20,7 +20,6 @@ namespace MapScripts.Map12
         {
             StartingGold = 1375.0f,
             GoldPerSecond = 5.0f,
-            //TODO: Figure out what to do with the recall spell, if ARAM has an special item or just Seals it
             RecallSpellItemId = 2007,
             EnableFountainHealing = false,
             EnableBuildingProtection = true

--- a/GameServerCore/Domain/GameObjects/IChampion.cs
+++ b/GameServerCore/Domain/GameObjects/IChampion.cs
@@ -15,7 +15,7 @@ namespace GameServerCore.Domain.GameObjects
         // basic
         void UpdateSkin(int skinNo);
         uint GetPlayerId();
-        void AddExperience(float experience);
+        void AddExperience(float experience, bool notify = true);
         bool LevelUp(bool force = false);
         void Recall();
         void Respawn();

--- a/GameServerCore/Maps/IMapScriptHandler.cs
+++ b/GameServerCore/Maps/IMapScriptHandler.cs
@@ -5,6 +5,7 @@ using GameServerCore.Content;
 using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
+using LeaguePackets.Game.Common;
 
 namespace GameServerCore.Maps
 {
@@ -134,7 +135,8 @@ namespace GameServerCore.Maps
         /// <param name="model"></param>
         /// <param name="skin"></param>
         /// <param name="NetId"></param>
-        void AddLevelProp(string name, string model, Vector2 position, float height, Vector3 direction, Vector3 posOffset, Vector3 scale, int skinId = 0, byte skillLevel = 0, byte rank = 0, byte type = 2, uint netId = 0, byte netNodeId = 64);
+        ILevelProp AddLevelProp(string name, string model, Vector2 position, float height, Vector3 direction, Vector3 posOffset, Vector3 scale, int skinId = 0, byte skillLevel = 0, byte rank = 0, byte type = 2, uint netId = 0, byte netNodeId = 64);
+        void NotifyPropAnimation(ILevelProp prop, string animation, AnimationFlags animationFlag, float duration, bool destroyPropAfterAnimation);
         /// <summary>
         /// Sets up the surrender functionality
         /// </summary>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -11,6 +11,7 @@ using GameServerCore.Packets.Enums;
 using GameServerCore.Packets.PacketDefinitions.Requests;
 using LeaguePackets.Game;
 using LeaguePackets;
+using LeaguePackets.Game.Common;
 
 namespace GameServerCore.Packets.Interfaces
 {
@@ -122,7 +123,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="newDisplayRange">New max display range for the spell to set.</param>
         /// <param name="newIconIndex">New index of an icon for the spell to set.</param>
         /// <param name="offsetTargets">New target netids for the spell to set.</param>
-        void NotifyChangeSlotSpellData(int userId, IObjAiBase owner, byte slot, ChangeSlotSpellDataType changeType, bool isSummonerSpell = false, TargetingType targetingType = TargetingType.Invalid, string newName = "", float newRange = 0, float newMaxCastRange = 0, float newDisplayRange = 0, byte newIconIndex = 0x0, List<uint> offsetTargets = null);
+        void NotifyChangeSlotSpellData(int userId, IObjAiBase owner, byte slot, GameServerCore.Enums.ChangeSlotSpellDataType changeType, bool isSummonerSpell = false, TargetingType targetingType = TargetingType.Invalid, string newName = "", float newRange = 0, float newMaxCastRange = 0, float newDisplayRange = 0, byte newIconIndex = 0x0, List<uint> offsetTargets = null);
         /// <summary>
         /// Sends a packet to all players with vision of a specified ObjAiBase explaining that their specified spell's cooldown has been set.
         /// </summary>
@@ -890,6 +891,7 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// TODO: Verify if this works and if not, then finish it.
         void NotifyUnpauseGame();
+        void NotifyUpdateLevelPropS2C(UpdateLevelPropData propData);
         /// <summary>
         /// Sends a packet to all players with vision of the specified unit detailing that the specified unit's stats have been updated.
         /// </summary>

--- a/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
+++ b/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
@@ -47,11 +47,7 @@ namespace GameServerCore.Scripting.CSharp
         /// </summary>
         bool OverrideSpawnPoints { get; set; }
         /// <summary>
-        /// Wether or not the Map's EXP should get overriden by the MapScript
-        /// </summary>
-        bool OverrideEXPCurve { get; set; }
-        /// <summary>
-        /// The level All players start the game
+        /// The level of all players at the start of the game
         /// </summary>
         int InitialLevel { get; set; }
         /// <summary>

--- a/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
+++ b/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
@@ -37,7 +37,7 @@ namespace GameServerCore.Scripting.CSharp
         /// <summary>
         /// Time when all players should start generating gold (Default: 90 Seconds)
         /// </summary>
-        long FirstGoldTime { get; set; }
+        float FirstGoldTime { get; set; }
         /// <summary>
         /// Whether or not the fountain should heal the players (Default = true)
         /// </summary>
@@ -46,5 +46,17 @@ namespace GameServerCore.Scripting.CSharp
         /// Wether or not the map's position is to be overriden
         /// </summary>
         bool OverrideSpawnPoints { get; set; }
+        /// <summary>
+        /// Wether or not the Map's EXP should get overriden by the MapScript
+        /// </summary>
+        bool OverrideEXPCurve { get; set; }
+        /// <summary>
+        /// The level All players start the game
+        /// </summary>
+        int InitialLevel { get; set; }
+        /// <summary>
+        /// Maximum level a player can reach
+        /// </summary>
+        int MaxLevel { get; set; }
     }
 }

--- a/GameServerLib/Chatbox/Commands/LevelCommand.cs
+++ b/GameServerLib/Chatbox/Commands/LevelCommand.cs
@@ -9,18 +9,21 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
         public override string Command => "level";
         public override string Syntax => $"{Command} level";
-        private readonly IMapData _mapData;
+        private readonly Game _game;
 
         public LevelCommand(ChatCommandManager chatCommandManager, Game game)
             : base(chatCommandManager, game)
         {
             _playerManager = game.PlayerManager;
-            _mapData = game.Config.MapData;
+            _game = game;
         }
 
         public override void Execute(int userId, bool hasReceivedArguments, string arguments = "")
         {
             var split = arguments.ToLower().Split(' ');
+            var champ = _playerManager.GetPeerInfo(userId).Champion;
+            var maxLevel = _game.Map.MapScript.MapScriptMetadata.MaxLevel;
+
             if (split.Length < 2)
             {
                 ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.SYNTAXERROR);
@@ -28,12 +31,11 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             }
             else if (byte.TryParse(split[1], out var lvl))
             {
-                if (lvl < 1 || lvl > 18)
+                if (lvl <= champ.Stats.Level || lvl > maxLevel)
                 {
+                    ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.ERROR, $"The level must be higher than current and smaller or equal to what the gamemode allows({maxLevel})!");
                     return;
                 }
-
-                var champ = _playerManager.GetPeerInfo(userId).Champion;
 
                 while (champ.Stats.Level < lvl)
                 {

--- a/GameServerLib/Game.cs
+++ b/GameServerLib/Game.cs
@@ -390,6 +390,7 @@ namespace LeagueSandbox.GameServer
         public void Start()
         {
             IsRunning = true;
+            Map.MapScript.OnMatchStart();
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -62,8 +62,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             Spells[(int)SpellSlotType.SummonerSpellSlots + 1] = new Spell.Spell(game, this, clientInfo.SummonerSkills[1], (int)SpellSlotType.SummonerSpellSlots + 1);
             Spells[(int)SpellSlotType.SummonerSpellSlots + 1].LevelUp();
 
-            Spells[(int)SpellSlotType.BluePillSlot] = new Spell.Spell(game, this, "Recall", (int)SpellSlotType.BluePillSlot);
-            Stats.SetSpellEnabled((byte)SpellSlotType.BluePillSlot, true);
+            Spells[(int)SpellSlotType.BluePillSlot] = new Spell.Spell(game, this,
+                _game.ItemManager.GetItemType(_game.Map.MapScript.MapScriptMetadata.RecallSpellItemId).SpellName, (int)SpellSlotType.BluePillSlot);
 
             Replication = new ReplicationHero(this);
 
@@ -136,7 +136,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 return _game.Map.PlayerSpawnPoints[Team][teamSize][index];
             }
 
-            if(_game.Map.PlayerSpawnPoints[Team].ContainsKey(1) && _game.Map.PlayerSpawnPoints[Team][1][1] != null)
+            if (_game.Map.PlayerSpawnPoints[Team].ContainsKey(1) && _game.Map.PlayerSpawnPoints[Team][1][1] != null)
             {
                 return _game.Map.PlayerSpawnPoints[Team][1][1];
             }
@@ -228,10 +228,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             TeleportTo(spawnPos.X, spawnPos.Y);
         }
 
-        public void AddExperience(float experience)
+        public void AddExperience(float experience, bool notify = true)
         {
             Stats.Experience += experience;
-            _game.PacketNotifier.NotifyUnitAddEXP(this, experience);
+            if(Stats.Experience > 0 && notify)
+            {
+                _game.PacketNotifier.NotifyUnitAddEXP(this, experience);
+            }
 
             while (Stats.Experience >= _game.Config.MapData.ExpCurve[Stats.Level - 1] && LevelUp()) ;
         }
@@ -241,9 +244,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             var stats = Stats;
             var expMap = _game.Config.MapData.ExpCurve;
 
-            //Ideally we'd use "stats.Level < expMap.Count + 1", but since we still don't have gamemodes implemented yet, i'll be hardcoding the EXP level to cap at lvl 18,
-            //Since the SR Map has 30 levels in total because of URF
-            if (stats.Level < 18 && (stats.Level < 1 || (stats.Experience >= expMap[stats.Level - 1] || force))) //The + and - 1s are there because the XP files don't have level 1
+            if (force && stats.Level > 0)
+            {
+                Stats.Experience = expMap[Stats.Level - 1];
+            }
+
+            if (stats.Level < _game.Map.MapScript.MapScriptMetadata.MaxLevel && (stats.Level < 1 || (stats.Experience >= expMap[stats.Level - 1]))) //The - 1s is there because the XP files don't have level 1
             {
                 Stats.LevelUp();
                 Logger.Debug("Champion " + Model + " leveled up to " + stats.Level);

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -64,6 +64,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             Spells[(int)SpellSlotType.BluePillSlot] = new Spell.Spell(game, this,
                 _game.ItemManager.GetItemType(_game.Map.MapScript.MapScriptMetadata.RecallSpellItemId).SpellName, (int)SpellSlotType.BluePillSlot);
+            Stats.SetSpellEnabled((byte)SpellSlotType.BluePillSlot, true);
 
             Replication = new ReplicationHero(this);
 

--- a/GameServerLib/Maps/MapScriptHandler.cs
+++ b/GameServerLib/Maps/MapScriptHandler.cs
@@ -14,6 +14,7 @@ using GameServerCore.Enums;
 using GameServerCore.Maps;
 using GameServerCore.NetInfo;
 using GameServerLib.GameObjects;
+using LeaguePackets.Game.Common;
 using LeagueSandbox.GameServer.Content;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
@@ -614,11 +615,25 @@ namespace LeagueSandbox.GameServer.Maps
             AnnouncerEvents.Add(new Announce(_game, time, ID, isMapSpecific));
         }
 
-        public void AddLevelProp(string name, string model, Vector2 position, float height, Vector3 direction, Vector3 posOffset, Vector3 scale, int skinId = 0, byte skillLevel = 0, byte rank = 0, byte type = 2, uint netId = 0, byte netNodeId = 64)
+        public ILevelProp AddLevelProp(string name, string model, Vector2 position, float height, Vector3 direction, Vector3 posOffset, Vector3 scale, int skinId = 0, byte skillLevel = 0, byte rank = 0, byte type = 2, uint netId = 0, byte netNodeId = 64)
         {
-            _game.ObjectManager.AddObject(new LevelProp(_game, netNodeId, name, model, position, height, direction, posOffset, scale, skinId, skillLevel, rank, type, netId));
+            var prop = new LevelProp(_game, netNodeId, name, model, position, height, direction, posOffset, scale, skinId, skillLevel, rank, type, netId);
+            _game.ObjectManager.AddObject(prop);
+            return prop;
         }
-
+        public void NotifyPropAnimation(ILevelProp prop, string animation, AnimationFlags animationFlag, float duration, bool destroyPropAfterAnimation)
+        {
+            var animationData = new UpdateLevelPropDataPlayAnimation
+            {
+                AnimationName = animation,
+                AnimationFlags = (uint)animationFlag,
+                Duration = duration,
+                DestroyPropAfterAnimation = destroyPropAfterAnimation,
+                StartMissionTime = _game.GameTime,
+                NetID = prop.NetId
+            };
+            _game.PacketNotifier.NotifyUpdateLevelPropS2C(animationData);
+        }
         public void AddSurrender(float time, float restTime, float length)
         {
             _surrenders.Add(TeamId.TEAM_BLUE, new SurrenderHandler(_game, TeamId.TEAM_BLUE, time, restTime, length));

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -58,7 +58,6 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             // TODO: Verify if ^ is still true! Commenting it out does not seem to cause any damage.
             _game.PacketNotifier.NotifyNPC_UpgradeSpellAns(userId, peerInfo.Champion.NetId, 13, 1, peerInfo.Champion.SkillPoints);
 
-            peerInfo.Champion.Stats.SetSpellEnabled(13, true);
             peerInfo.Champion.Stats.SetSummonerSpellEnabled(0, true);
             peerInfo.Champion.Stats.SetSummonerSpellEnabled(1, true);
 

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -95,8 +95,6 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 }
             }
 
-            _game.Map.MapScript.OnMatchStart();
-
             // TODO shop map specific?
             // Level props are just models, we need button-object minions to allow the client to interact with it
             if (peerInfo != null)

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -52,7 +52,12 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                     }
 
                     _game.PacketNotifier.NotifySpawn(player.Item2.Champion, userId, false);
-                    player.Item2.Champion.LevelUp();
+                    
+                    while(player.Item2.Champion.Stats.Level < _game.Map.MapScript.MapScriptMetadata.InitialLevel)
+                    {
+                        player.Item2.Champion.LevelUp(true);
+                    }
+
                     // TODO: send this in one place only
                     _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int) player.Item2.PlayerId, "Welcome to League Sandbox!",
                         "This is a WIP project.", "", 0, player.Item2.Champion.NetId,

--- a/GameServerLib/Scripting/CSharp/MapScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/MapScriptMetadata.cs
@@ -12,17 +12,22 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         public bool EnableBuildingProtection { get; set; } = false;
 
         //Stuff about minions
-        public bool MinionSpawnEnabled { get; set; } = false;
-        public long SpawnInterval { get; set; } = 30 * 1000;
+        public bool EnableFountainHealing { get; set; } = true;
+        public float FirstGoldTime { get; set; } = 90 * 1000;
+        public float GoldPerSecond { get; set; } = 1.9f;
+        public int InitialLevel { get; set; } = 1;
+        public bool IsKillGoldRewardReductionActive { get; set; } = true;
+        public int MaxLevel { get; set; } = 18;
         public bool MinionPathingOverride { get; set; } = false;
+        public bool MinionSpawnEnabled { get; set; } = false;
+        public bool OverrideEXPCurve { get; set; } = false;
+        public bool OverrideSpawnPoints { get; set; } = false;
+        public int RecallSpellItemId { get; set; } = 2001;
+        public long SpawnInterval { get; set; } = 30 * 1000;
+        public float StartingGold { get; set; } = 475.0f;
+
 
         //General things that will affect players globaly, such as default gold per-second, Starting gold....
-        public float GoldPerSecond { get; set; } = 1.9f;
-        public float StartingGold { get; set; } = 475.0f;
-        public bool IsKillGoldRewardReductionActive { get; set; } = true;
-        public int RecallSpellItemId { get; set; } = 2001;
-        public long FirstGoldTime { get; set; } = 90 * 1000;
-        public bool EnableFountainHealing { get; set; } = true;
-        public bool OverrideSpawnPoints { get; set; } = false;
+
     }
 }

--- a/GameServerLib/Scripting/CSharp/MapScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/MapScriptMetadata.cs
@@ -10,8 +10,6 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
     public class MapScriptMetadata : IMapScriptMetadata
     {
         public bool EnableBuildingProtection { get; set; } = false;
-
-        //Stuff about minions
         public bool EnableFountainHealing { get; set; } = true;
         public float FirstGoldTime { get; set; } = 90 * 1000;
         public float GoldPerSecond { get; set; } = 1.9f;
@@ -20,14 +18,9 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         public int MaxLevel { get; set; } = 18;
         public bool MinionPathingOverride { get; set; } = false;
         public bool MinionSpawnEnabled { get; set; } = false;
-        public bool OverrideEXPCurve { get; set; } = false;
         public bool OverrideSpawnPoints { get; set; } = false;
         public int RecallSpellItemId { get; set; } = 2001;
         public long SpawnInterval { get; set; } = 30 * 1000;
         public float StartingGold { get; set; } = 475.0f;
-
-
-        //General things that will affect players globaly, such as default gold per-second, Starting gold....
-
     }
 }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3463,7 +3463,15 @@ namespace PacketDefinitions420
             // TODO: currently unpause disabled cause it shouldn't handled like this
             _packetHandlerManager.UnpauseGame();
         }
-
+        public void NotifyUpdateLevelPropS2C(UpdateLevelPropData propData)
+        {
+            var packet = new UpdateLevelPropS2C
+            {
+                SenderNetID = 0,
+                UpdateLevelPropData = propData
+            };
+            _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
+        }
         /// <summary>
         /// Sends a packet to all players with vision of the specified unit detailing that the specified unit's stats have been updated.
         /// </summary>
@@ -3669,5 +3677,4 @@ namespace PacketDefinitions420
             _packetHandlerManager.SendPacket(userId, answer.GetBytes(), Channel.CHL_S2C, PacketFlags.None);
         }
     }
-
 }


### PR DESCRIPTION
* PacketNotifier
    - Introduced `NotifyUpdateLevelPropS2C`.

* MapScriptHandler
    - `AddLevelProp` now returns an `ILevelProp`.
    - Introduced `NotifyPropAnimation` , which makes use of the new `NotifyUpdateLevelPropS2C` packet

* Champion
    - Unhardcoded the Recall SpellSlot
    - Added the option to notify or not the client when receiving XP and removed the notifications when the XP added is 0.
    - UnhardCoded max Level 18 to use the Max Level defined by MapScripts.
    - The `force` parameter in `LevelUp` now causes the unit's XP to be set to the level's "XP-floor" instead of just leveling up and not changing the xp to match it.

* MapScripts
    - Reorganized MapScriptMetaData in alphabetical order and introduced `InitialLevel`, and `MaxLevel`.
    - Updated URF script to support level 30.
    - Removed Outdated comment in Map12's (Howling Abyss) ScripMetaData.
    - Updated A lot of wrong values on Map8's (Crystal Scar) to match the actual thing.
    - Introduced the full animations for each of the teams bases (the stairs being built and lasers shooting at the crystal).

* Scripts
    - Introduced `OdinRecall`, Crystal Scar's recall spell alongside it's buff (which i don't know the correct name, i couldnt find it anywhere).
    - Introduced `OdinPlayerBuff` Crystal Scar's buff that is applied to all players (it's still quite incomplete due to me not knowing how to correctly update stats constantly).
    - Addded particles to OdinSpeedShrineBuff and changed it's `BuffType` to `RENEW_EXISTING` due to the particle spamm when it was `REPLACE_EXISTING`

* Fixed an issue where OnMatchStart was getting executed for each player in the match by moving it's execution to within `Game.Start()`, from `HandleSpawn`.