### PR TITLE
Progress #1281 -- ObjectManager.Update, vision and spawn rewrite

### DIFF
--- a/Content/LeagueSandbox-Scripts/AiScripts/LaneMinionAi.cs
+++ b/Content/LeagueSandbox-Scripts/AiScripts/LaneMinionAi.cs
@@ -111,7 +111,7 @@ namespace AIScripts
                 && !u.IsDead
                 && u.Team != LaneMinion.Team
                 && UnitInRange(u, LaneMinion.Stats.AcquisitionRange.Total)
-                && TeamHasVision(LaneMinion.Team, u)
+                && u.IsVisibleByTeam(LaneMinion.Team)
                 && u.Status.HasFlag(StatusFlags.Targetable)
                 && !UnitIsProtectionActive(u)
             );

--- a/Content/LeagueSandbox-Scripts/AiScripts/MinionAI.cs
+++ b/Content/LeagueSandbox-Scripts/AiScripts/MinionAI.cs
@@ -48,7 +48,7 @@ namespace AIScripts
                     || u.IsDead
                     || u.Team == minion.Team
                     || Vector2.DistanceSquared(minion.Position, u.Position) > DETECT_RANGE * DETECT_RANGE
-                    || !TeamHasVision(minion.Team, u)
+                    || !u.IsVisibleByTeam(minion.Team)
                     || !u.Status.HasFlag(StatusFlags.Targetable)
                     || UnitIsProtectionActive(u))
                 {

--- a/GameServerCore/Domain/GameObjects/IGameObject.cs
+++ b/GameServerCore/Domain/GameObjects/IGameObject.cs
@@ -124,6 +124,11 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="visible">true/false; networked or not</param>
         void SetVisibleByTeam(TeamId team, bool visible);
 
+        void SetVisibleByTeams(uint teams);
+
+        bool IsSpawned();
+        void SetAsSpawned();
+
         /// <summary>
         /// Sets the position of this GameObject to the specified position.
         /// </summary>

--- a/GameServerCore/Domain/GameObjects/IGameObject.cs
+++ b/GameServerCore/Domain/GameObjects/IGameObject.cs
@@ -124,7 +124,7 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="visible">true/false; networked or not</param>
         void SetVisibleByTeam(TeamId team, bool visible);
 
-        void SetVisibleByTeams(uint teams);
+        void SetVisibleByTeams(TeamIdFlags teams);
 
         bool IsSpawned();
         void SetAsSpawned();

--- a/GameServerCore/Enums/TeamId.cs
+++ b/GameServerCore/Enums/TeamId.cs
@@ -2,8 +2,13 @@
 {
     public enum TeamId
     {
-        TEAM_BLUE = 0x64,
-        TEAM_PURPLE = 0xC8,
-        TEAM_NEUTRAL = 0x12C
+        TEAM_BLUE = 0x64, //100
+        TEAM_PURPLE = 0xC8, //200
+        TEAM_NEUTRAL = 0x12C //300
     }
+/*
+    001100100 ^ 1101100 = 000001000
+    011001000 ^ 1101100 = 010100100
+    100101100 ^ 1101100 = 101000000
+*/
 }

--- a/GameServerCore/Enums/TeamId.cs
+++ b/GameServerCore/Enums/TeamId.cs
@@ -1,6 +1,9 @@
-﻿namespace GameServerCore.Enums
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace GameServerCore.Enums
 {
-    public enum TeamId
+    public enum TeamId: ushort
     {
         TEAM_BLUE = 0x64, //100
         TEAM_PURPLE = 0xC8, //200
@@ -11,4 +14,32 @@
     011001000 ^ 1101100 = 010100100
     100101100 ^ 1101100 = 101000000
 */
+    [Flags]
+    public enum TeamIdFlags: ushort
+    {
+        NONE = 0,
+        TEAM_BLUE = 100 ^ 108,
+        TEAM_PURPLE = 200 ^ 108,
+        TEAM_NEUTRAL = 300 ^ 108,
+        TEAMS_BLUE_AND_PURPLE = (100 ^ 108) | (200 ^ 108),
+        TEAMS_BLUE_AND_NEUTRAL = (100 ^ 108) | (300 ^ 108),
+        TEAMS_PURPLE_AND_NEUTRAL = (200 ^ 108) | (300 ^ 108),
+        TEAMS_ALL = (100 ^ 108) | (200 ^ 108) | (300 ^ 108)
+    }
+    public static class TeamIdFlagsExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool HasTeam(this TeamIdFlags teams, TeamId team)
+        {
+            TeamIdFlags t = (TeamIdFlags)((ushort)team ^ 108);
+            return (teams & t) == t;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetTeam(ref this TeamIdFlags teams, TeamId team, bool value)
+        {
+            TeamIdFlags t = (TeamIdFlags)((ushort)team ^ 108);
+            teams = value ? (teams | t) : (teams & ~t);
+        }
+    }
 }

--- a/GameServerCore/IObjectManager.cs
+++ b/GameServerCore/IObjectManager.cs
@@ -42,46 +42,6 @@ namespace GameServerCore
         void RemoveObject(IGameObject o);
 
         /// <summary>
-        /// Adds a GameObject of type AttackableUnit to the list of Vision Units in ObjectManager. *NOTE*: Naming conventions of VisionUnits will change to AttackableUnits.
-        /// </summary>
-        /// <param name="unit">AttackableUnit to add.</param>
-        void AddVisionUnit(IAttackableUnit unit);
-
-        /// <summary>
-        /// Gets a new Dictionary containing all GameObjects of type AttackableUnit contained in the list of Vision Units in ObjectManager.
-        /// </summary>
-        /// <returns>Dictionary of (NetID, AttackableUnit) pairs.</returns>
-        Dictionary<uint, IAttackableUnit> GetVisionUnits();
-
-        /// <summary>
-        /// Gets a new Dictionary containing all GameObjects of type AttackableUnit of the specified team contained in the list of Vision Units in ObjectManager.
-        /// </summary>
-        /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
-        /// <returns>Dictionary of NetID,AttackableUnit pairs that belong to the specified team.</returns>
-        Dictionary<uint, IAttackableUnit> GetVisionUnits(TeamId team);
-
-        /// <summary>
-        /// Whether or not a specified GameObject is being networked to the specified team.
-        /// </summary>
-        /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
-        /// <param name="o">GameObject to check.</param>
-        /// <returns>true/false; networked or not.</returns>
-        bool TeamHasVisionOn(TeamId team, IGameObject o);
-
-        /// <summary>
-        /// Removes a GameObject of type AttackableUnit from the list of Vision Units in ObjectManager. *NOTE*: Naming conventions of VisionUnits will change to AttackableUnits.
-        /// </summary>
-        /// <param name="unit">AttackableUnit to remove.</param>
-        void RemoveVisionUnit(IAttackableUnit unit);
-
-        /// <summary>
-        /// Removes a GameObject of type AttackableUnit from the list of Vision Units in ObjectManager via the AttackableUnit's NetID and team.
-        /// </summary>
-        /// <param name="team">Team of the AttackableUnit.</param>
-        /// <param name="netId">NetID of the AttackableUnit.</param>
-        void RemoveVisionUnit(TeamId team, uint netId);
-
-        /// <summary>
         /// Gets a list of all GameObjects of type AttackableUnit that are within a certain distance from a specified position.
         /// </summary>
         /// <param name="checkPos">Vector2 position to check.</param>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -962,5 +962,7 @@ namespace GameServerCore.Packets.Interfaces
         /// TODO: Verify if this is the correct implementation.
         /// TODO: Fix LeaguePackets Typos.
         void NotifyWorld_SendCamera_Server_Acknologment(int userId, ViewRequest request);
+
+        void NotifyTeamVisibilityChange(IGameObject obj, TeamId team, bool becameVisible);
     }
 }

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -946,16 +946,6 @@ namespace LeagueSandbox.GameServer.API
             };
         }
         /// <summary>
-        /// Returns whether or not the designed team has vision over an unit or not
-        /// </summary>
-        /// <param name="team"></param>
-        /// <param name="unit"></param>
-        /// <returns></returns>
-        public static bool TeamHasVision(TeamId team, IGameObject unit)
-        {
-            return _game.ObjectManager.TeamHasVisionOn(team, unit);
-        }
-        /// <summary>
         /// Returns wether or not an unit is protected from attacks (Monstly used to check tower protection)
         /// </summary>
         /// <param name="unit"></param>

--- a/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
+++ b/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
@@ -390,7 +390,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                 return;
             }
 
-            List<IAttackableUnit> minions = new List<IAttackableUnit>(_game.ObjectManager.GetVisionUnits().Values.ToList().Where(x => x is IMinion));
+            var minions = new List<IMinion>(_game.ObjectManager.GetObjects().Values.OfType<IMinion>());
 
             // Same method as DebugSelf just for every champion
             foreach (var minion in minions)

--- a/GameServerLib/Content/Navigation/NavigationGridCell.cs
+++ b/GameServerLib/Content/Navigation/NavigationGridCell.cs
@@ -19,12 +19,12 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         /// Index of this cell.
         /// </summary>
         public int ID { get; private set; }
-        /// <summary>
-        /// Whether or not this cell is open for pathing. Usually false when the cell is occupied by actors.
-        /// </summary>
         public float CenterHeight { get; private set; }
         public int SessionId { get; private set; }
         public float ArrivalCost { get; private set; }
+        /// <summary>
+        /// Whether or not this cell is open for pathing. Usually false when the cell is occupied by actors.
+        /// </summary>
         public bool IsOpen { get; private set; }
         public float Heuristic { get; private set; }
         /// <summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -129,12 +129,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             BuffList = new List<IBuff>();
         }
 
-        public override void OnAdded()
-        {
-            base.OnAdded();
-            _game.ObjectManager.AddVisionUnit(this);
-        }
-
         /// <summary>
         /// Gets the HashString for this unit's model. Used for packets so clients know what data to load.
         /// </summary>
@@ -229,12 +223,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
 
             UpdateStatus();
-        }
-
-        public override void OnRemoved()
-        {
-            base.OnRemoved();
-            _game.ObjectManager.RemoveVisionUnit(this);
         }
 
         /// <summary>
@@ -513,7 +501,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
 
             // TODO: send this in one place only
-            _game.PacketNotifier.NotifyUpdatedStats(this, false);
+            //_game.PacketNotifier.NotifyUpdatedStats(this, false);
 
             // Get health from lifesteal/spellvamp
             if (regain > 0)
@@ -521,7 +509,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 attackerStats.CurrentHealth = Math.Min(attackerStats.HealthPoints.Total,
                     attackerStats.CurrentHealth + regain * postMitigationDamage);
                 // TODO: send this in one place only (preferably a central EventHandler class)
-                _game.PacketNotifier.NotifyUpdatedStats(attacker, false);
+                //_game.PacketNotifier.NotifyUpdatedStats(attacker, false);
             }
         }
 
@@ -645,7 +633,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
 
             // TODO: send this in one place only
-            _game.PacketNotifier.NotifyUpdatedStats(this, false);
+            //_game.PacketNotifier.NotifyUpdatedStats(this, false);
 
             // Get health from lifesteal/spellvamp
             if (regain > 0)
@@ -653,7 +641,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 attackerStats.CurrentHealth = Math.Min(attackerStats.HealthPoints.Total,
                     attackerStats.CurrentHealth + regain * postMitigationDamage);
                 // TODO: send this in one place only (preferably a central EventHandler class)
-                _game.PacketNotifier.NotifyUpdatedStats(attacker, false);
+                //_game.PacketNotifier.NotifyUpdatedStats(attacker, false);
             }
         }
 

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -22,7 +22,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         // Function Vars
         protected bool _toRemove;
         protected bool _movementUpdated;
-        private uint _bisibleByTeam = 0;
+        private TeamIdFlags _visibleByTeam = 0;
         private bool _isSpawned = false;
 
         /// <summary>
@@ -219,11 +219,9 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
         public void SetTeam(TeamId team)
         {
-            uint t = (uint)team ^ 108;
-            _bisibleByTeam &= ~t;
+            _visibleByTeam.SetTeam(Team, false);
             Team = team;
-            _bisibleByTeam |= t;
-
+            _visibleByTeam.SetTeam(Team, true);
 
             if (_game.IsRunning)
             {
@@ -237,8 +235,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="team">A team which could have vision of this object.</param>
         public bool IsVisibleByTeam(TeamId team)
         {
-            uint t = (uint)team ^ 108;
-            return team == Team || (_bisibleByTeam & t) == t;
+            return team == Team || _visibleByTeam.HasTeam(team);
         }
 
         /// <summary>
@@ -248,11 +245,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="visible">true/false; networked or not</param>
         public void SetVisibleByTeam(TeamId team, bool visible)
         {
-            uint t = (uint)team ^ 108;
-            if(visible)
-                _bisibleByTeam |= t;
-            else
-                _bisibleByTeam &= ~t;
+            _visibleByTeam.SetTeam(team, visible);
             /*
             if (this is IAttackableUnit)
             {
@@ -262,9 +255,9 @@ namespace LeagueSandbox.GameServer.GameObjects
             */
         }
 
-        public void SetVisibleByTeams(uint teams)
+        public void SetVisibleByTeams(TeamIdFlags teams)
         {
-            _bisibleByTeam = teams;
+            _visibleByTeam = teams;
             /*
             if (this is IAttackableUnit)
             {

--- a/GameServerLib/GameObjects/Particle.cs
+++ b/GameServerLib/GameObjects/Particle.cs
@@ -240,7 +240,10 @@ namespace LeagueSandbox.GameServer.GameObjects
 
             if (autoSend)
             {
-                _game.PacketNotifier.NotifyFXCreateGroup(this);
+                // Broken because PacketNotifierManager won't be able to determine who is seeing the particle,
+                // because GameObject.IsVisibleByTeam is now updated no more than once per frame.
+                // Therefore, the particle spawns along with the rest of the objects at the end of the frame.
+                //_game.PacketNotifier.NotifyFXCreateGroup(this);
             }
         }
 

--- a/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
+++ b/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
@@ -69,6 +69,8 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Missile
 
         public override void Update(float diff)
         {
+            // Destroy any missiles which are targeting an untargetable unit.
+            // TODO: Verify if this should apply to SpellSector.
             if (!HasTarget())
             {
                 Direction = new Vector3();
@@ -209,7 +211,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Missile
         /// <returns>True/False.</returns>
         public bool HasTarget()
         {
-            return TargetUnit != null;
+            return TargetUnit != null && TargetUnit.Status.HasFlag(StatusFlags.Targetable);
         }
 
         /// <summary>

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -151,7 +151,7 @@ namespace LeagueSandbox.GameServer
                                 || particle.SpecificTeam == TeamId.TEAM_NEUTRAL
                                 || particle.SpecificTeam == team
                             )
-                            && (kv.Value is not IAttackableUnit unit || !unit.IsDead)
+                            && !(kv.Value is IAttackableUnit unit && unit.IsDead)
                             && Vector2.DistanceSquared(kv.Value.Position, obj.Position)
                                         <= kv.Value.VisionRadius * kv.Value.VisionRadius
                             && !_game.Map.NavigationGrid.IsAnythingBetween(kv.Value, obj, true))

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -130,22 +130,23 @@ namespace LeagueSandbox.GameServer
                 )
             ) {
 
-                bool isAlwaysVisible = lp != null || u is IBaseTurret || u is IObjBuilding;
-
-                uint teamsWithVision = 0;
-                foreach (var team in Teams)
-                {
-                    if(isAlwaysVisible || team == obj.Team)
-                        teamsWithVision |= (uint)team ^ 108;
-                }
                 
+                TeamIdFlags teamsWithVision = 0;
+
+                // If is always visible
+                if(lp != null || u is IBaseTurret || u is IObjBuilding)
                 {
+                    teamsWithVision = TeamIdFlags.TEAMS_ALL;
+                }
+                else
+                {
+                    teamsWithVision.SetTeam(obj.Team, true);
+                    
                     foreach (var kv in _objects)
                     {
                         var team = kv.Value.Team;
-                        uint t = (uint)team ^ 108;
                         if(
-                            (teamsWithVision & t) != t // The team has already got a vision
+                            !teamsWithVision.HasTeam(team) // The team has already got a vision
                             && (
                                 particle == null
                                 || particle.SpecificTeam == TeamId.TEAM_NEUTRAL
@@ -156,7 +157,7 @@ namespace LeagueSandbox.GameServer
                                         <= kv.Value.VisionRadius * kv.Value.VisionRadius
                             && !_game.Map.NavigationGrid.IsAnythingBetween(kv.Value, obj, true))
                         {
-                            teamsWithVision |= t;
+                            teamsWithVision.SetTeam(team, true);
                         }
                     }
                 }
@@ -165,8 +166,7 @@ namespace LeagueSandbox.GameServer
                 {
                     foreach (var team in Teams)
                     {
-                        uint t = (uint)team ^ 108;
-                        bool teamHasVision = (teamsWithVision & t) == t;
+                        bool teamHasVision = teamsWithVision.HasTeam(team);
                         bool isVisibleByTeam = obj.IsVisibleByTeam(team);
                         if (isVisibleByTeam != teamHasVision)
                         {

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -248,7 +248,7 @@ namespace PacketDefinitions420
                     continue;
                 }
 
-                if (_game.ObjectManager.TeamHasVisionOn(team, o))
+                if (o.IsVisibleByTeam(team))
                 {
                     BroadcastPacketTeam(team, data, channelNo, flag);
                 }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3676,5 +3676,35 @@ namespace PacketDefinitions420
             };
             _packetHandlerManager.SendPacket(userId, answer.GetBytes(), Channel.CHL_S2C, PacketFlags.None);
         }
+
+        public void NotifyTeamVisibilityChange(IGameObject obj, TeamId team, bool becameVisible)
+        {
+            if(obj is IParticle particle)
+            {
+                if(becameVisible)
+                {
+                    NotifyFXEnterTeamVisibility(particle, team);
+                }
+                else
+                {
+                    NotifyFXLeaveTeamVisibility(particle, team);
+                }
+            }
+            else if(obj is IAttackableUnit u)
+            {
+                if (becameVisible)
+                {
+                    //TODO: Probably should be used instead
+                    //NotifyS2C_OnEnterTeamVisibility(u, team);
+                    
+                    //TODO: Broadcast only to team
+                    NotifyEnterVisibilityClient(obj, useTeleportID: true);
+                }
+                else
+                {
+                    NotifyLeaveVisibilityClient(obj, team);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Changes (in no order):
- Objects spawn at the end of the frame, after updating existing objects and after updating visibility. Visibility is now updated once per frame after updating objects.
- Disabled `autospawn` for particles.
- `TeamHasVision` - DEPRECATED, `obj.IsVisibleByTeam(team)` should be used instead.
`//TODO: Leave the option to force a vision update and a warning that it's not efficient?`
- Added private function `UpdateVisibilityAndSpawnIfNecessary` to `ObjectManager`
- `lock`s have been commented out as unnecessary
- Improved documentation in `NavGridCell`
- Changed the implementation of the `IsVisibleByTeam` function in `GameObject`, now it uses `uint` and bitwise operations to store a list of teams that we can see the object with, which is more efficient.
- The `IsSpawned` and `SetAsSpawned` functions have been added to the `GameObject`, replacing the `_visionUnits` list in the `ObjectManager`. In the future, they will allow to determine for clients from which teams the object has already been spawned, which will allow to spawn objects only when they first enter the visibility zone, reducing the likelihood of cheating (individual objects will spawn for everyone, for example, minions, the time and position of the appearance of which for no one secret), and also allow to solve the existing problem that if the particle was created outside the command's visibility zone, it will not be created when entering the visibility zone, as happens with attacked objects that have a `NotifyEnterVisibilityClient`.
- Everything related to `*VisionUnits` - removed
- Lines marked with `// TODO: send this in one place only` are commented out because syncing everything and everything is done in `GameManager.Update`, but this may change in the future if a way is found to transmit only changes.
- The logic of updating buffs and checking the target for correctness has been moved from `ObjectManager` to `ObjAiBase` and `SpellMissile`.
- The `NotifyTeamVisibilityChange` function has been added to `PacketNotifier`, which sends the appropriate packet based on the type of the object passed to it.
- Visibility of dead AI no longer changes, they just don't get updates