### PR TITLE
Progress #1281 -- ObjectManager.UpdateVision + PacketNotifier.NotifyTeamAboutVisibilityChange

### DIFF
--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using GameServerCore.Domain;
@@ -612,6 +612,13 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="sourceNetID">Not yet know it's use.</param>
         void NotifyS2C_OnEventWorld(IEvent mapEvent, uint sourceNetId = 0);
         /// <summary>
+        /// Sends a packet to either all players with vision of the specified GameObject or a specified user.
+        /// The packet contains details of which team lost visibility of the GameObject and should only be used after it is first initialized into vision (NotifyEnterVisibility).
+        /// </summary>
+        /// <param name="o">GameObject going out of vision.</param>
+        /// <param name="userId">User to send the packet to.</param>
+        void NotifyS2C_OnLeaveTeamVisibility(IGameObject o, TeamId team, int userId = 0);
+        /// <summary>
         /// Sends a packet to all players detailing that the specified object's current animations have been paused/unpaused.
         /// </summary>
         /// <param name="obj">GameObject that is playing the animation.</param>
@@ -900,6 +907,14 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="itemInstance">Item instance housing all information about the item that has been used.</param>
         void NotifyUseItemAns(int userId, IObjAiBase ai, IItem itemInstance);
         /// <summary>
+        /// Sends a packet to the specified team detailing that an object's visibility has changed.
+        /// General function which will send the needed vision packet for the specific object type.
+        /// </summary>
+        /// <param name="obj">GameObject which had their visibility changed.</param>
+        /// <param name="team">Team which is affected by this visibility change.</param>
+        /// <param name="becameVisible">Whether or not the change was an entry into vision.</param>
+        void NotifyVisibilityChange(IGameObject obj, TeamId team, bool becameVisible);
+        /// <summary>
         /// Sends a packet to all players that have vision of the specified unit that it has made a movement.
         /// </summary>
         /// <param name="u">AttackableUnit that is moving.</param>
@@ -955,7 +970,5 @@ namespace GameServerCore.Packets.Interfaces
         /// TODO: Verify if this is the correct implementation.
         /// TODO: Fix LeaguePackets Typos.
         void NotifyWorld_SendCamera_Server_Acknologment(int userId, ViewRequest request);
-
-        void NotifyTeamAboutVisibilityChange(IGameObject obj, TeamId team, bool becameVisible);
     }
 }

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -955,5 +955,7 @@ namespace GameServerCore.Packets.Interfaces
         /// TODO: Verify if this is the correct implementation.
         /// TODO: Fix LeaguePackets Typos.
         void NotifyWorld_SendCamera_Server_Acknologment(int userId, ViewRequest request);
+
+        void NotifyTeamAboutVisibilityChange(IGameObject obj, TeamId team, bool becameVisible);
     }
 }

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -193,7 +193,7 @@ namespace LeagueSandbox.GameServer
                         if (isVisibleByTeam != teamHasVision)
                         {
                             obj.SetVisibleByTeam(team, teamHasVision);
-                            _game.PacketNotifier.NotifyTeamAboutVisibilityChange(obj, team, teamHasVision);
+                            _game.PacketNotifier.NotifyVisibilityChange(obj, team, teamHasVision);
                         }
                     }
                 }

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -83,8 +83,6 @@ namespace LeagueSandbox.GameServer
 
                 if (_queuedObjects.ContainsKey(obj.NetId))
                 {
-                    bool doVis = true;
-
                     if (obj is ILaneTurret turret)
                     {
                         _game.PacketNotifier.NotifySpawn(turret);
@@ -98,64 +96,24 @@ namespace LeagueSandbox.GameServer
                                 _game.PacketNotifier.NotifyBuyItem((int)turret.NetId, turret, item as IItem);
                             }
                         }
-
-                        _queuedObjects.Remove(obj.NetId);
                     }
                     else 
                     {
-                        if (obj is ILevelProp || obj is ISpellMissile)
-                        {
-                            doVis = false;
-                        }
+                        bool doVis = !(obj is ILevelProp || obj is ISpellMissile);
                         _game.PacketNotifier.NotifySpawn(obj, 0, doVis, _game.GameTime);
-
-                        _queuedObjects.Remove(obj.NetId);
                     }
+
+                    _queuedObjects.Remove(obj.NetId);
+                    continue; // Object just created, no need to update
                 }
 
                 obj.Update(diff);
-
-                //TODO: Implement visibility checks for projectiles here (should be similar to particles below)
-                //Make sure to account for server only projectiles, globally visible (everyone sees it) projectiles, and normal projectiles:
-                //1. Nidalee Q is affected by visibility checks, but is server only 
-                //2. Ezreal R is globally visible, and is server only
-                //3. Every other projectile that is not server only, and is affected by visibility checks (normal projectiles)
-
-                // Only if the particle is affected by vision.
-                if (obj is IParticle particle && particle.VisionAffected)
-                {
-                    foreach (var team in Teams)
-                    {
-                        // Only remove or re-send the particle to the specified team.
-                        if (particle.SpecificTeam == TeamId.TEAM_NEUTRAL || particle.SpecificTeam == team)
-                        {
-                            var visionUnitsTeam = GetVisionUnits(particle.Team);
-                            var teamHasVision = TeamHasVisionOn(team, particle);
-                            if (visionUnitsTeam.ContainsKey(particle.NetId) && teamHasVision)
-                            {
-                                particle.SetVisibleByTeam(team, true);
-                                _game.PacketNotifier.NotifyFXEnterTeamVisibility(particle, team);
-                            }
-                            else {
-                                var isVisibleByTeam = particle.IsVisibleByTeam(team);
-                                if (!isVisibleByTeam && teamHasVision)
-                                {
-                                    particle.SetVisibleByTeam(team, true);
-                                    _game.PacketNotifier.NotifyFXEnterTeamVisibility(particle, team);
-                                }
-                                else if (isVisibleByTeam && !teamHasVision)
-                                {
-                                    particle.SetVisibleByTeam(team, false);
-                                    _game.PacketNotifier.NotifyFXLeaveTeamVisibility(particle, team);
-                                }
-                            }
-                        }
-                    }
-                }
+                
+                UpdateVision(obj);
 
                 // Destroy any missiles which are targeting an untargetable unit.
                 // TODO: Verify if this should apply to SpellSector.
-                else if (obj is ISpellMissile m)
+                if (obj is ISpellMissile m)
                 {
                     if (m.TargetUnit != null && !m.TargetUnit.Status.HasFlag(StatusFlags.Targetable))
                     {
@@ -165,37 +123,6 @@ namespace LeagueSandbox.GameServer
 
                 else if (obj is IAttackableUnit u)
                 {
-                    foreach (var team in Teams)
-                    {
-                        if (u.Team == team)
-                            continue;
-
-                        var visionUnitsTeam = GetVisionUnits(u.Team);
-                        var teamHasVision = TeamHasVisionOn(team, u);
-                        if (visionUnitsTeam.ContainsKey(u.NetId) && teamHasVision)
-                        {
-                            u.SetVisibleByTeam(team, true);
-                            // Might not be necessary, but just for good measure.
-                            _game.PacketNotifier.NotifyS2C_OnEnterTeamVisibility(u, team);
-                            _game.PacketNotifier.NotifyEnterVisibilityClient(u, useTeleportID: true);
-                            RemoveVisionUnit(u);
-                        }
-                        else {
-                            var isVisibleByTeam = u.IsVisibleByTeam(team);
-                            if (!isVisibleByTeam && teamHasVision && !u.IsDead)
-                            {
-                                u.SetVisibleByTeam(team, true);
-                                _game.PacketNotifier.NotifyS2C_OnEnterTeamVisibility(u, team);
-                                _game.PacketNotifier.NotifyEnterVisibilityClient(u, useTeleportID: true);
-                            }
-                            else if (isVisibleByTeam && (u.IsDead || !teamHasVision) && !(u is IBaseTurret || u is ILevelProp || u is IObjBuilding))
-                            {
-                                u.SetVisibleByTeam(team, false);
-                                _game.PacketNotifier.NotifyLeaveVisibilityClient(u, team);
-                            }
-                        }
-                    }
-
                     if (u is IObjAiBase ai)
                     {
                         var tempBuffs = new List<IBuff>(ai.GetBuffs());
@@ -233,6 +160,41 @@ namespace LeagueSandbox.GameServer
                         // TODO: Verify if we want to use TeleportID.
                         _game.PacketNotifier.NotifyWaypointGroup(u, false);
                         u.ClearMovementUpdated();
+                    }
+                }
+            }
+        }
+
+        void UpdateVision(IGameObject obj)
+        {
+            //TODO: Implement visibility checks for projectiles here (should be similar to particles below)
+            //Make sure to account for server only projectiles, globally visible (everyone sees it) projectiles, and normal projectiles:
+            //1. Nidalee Q is affected by visibility checks, but is server only 
+            //2. Ezreal R is globally visible, and is server only
+            //3. Every other projectile that is not server only, and is affected by visibility checks (normal projectiles)
+
+            // Only if the particle is affected by vision.
+            IParticle particle = null;
+            IAttackableUnit u = null;
+            if (
+                ((particle = obj as IParticle) != null && particle.VisionAffected)
+                || ((u = obj as IAttackableUnit) != null)
+            ) {
+                foreach (var team in Teams)
+                {
+                    if (
+                        // Only remove or re-send the particle to the specified team.
+                        (particle != null && (particle.SpecificTeam == TeamId.TEAM_NEUTRAL || particle.SpecificTeam == team))
+                        || (u != null && u.Team != team)
+                    ) {
+                        bool teamHasVision = (u == null || !u.IsDead) && TeamHasVisionOn(team, obj);
+                        bool alwaysVisible = u is IBaseTurret || u is ILevelProp || u is IObjBuilding;
+                        bool isVisibleByTeam = alwaysVisible || obj.IsVisibleByTeam(team);
+                        if (isVisibleByTeam != teamHasVision)
+                        {
+                            obj.SetVisibleByTeam(team, teamHasVision);
+                            _game.PacketNotifier.NotifyTeamAboutVisibilityChange(obj, team, teamHasVision);
+                        }
                     }
                 }
             }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -1,4 +1,4 @@
-﻿using ENet;
+using ENet;
 using GameServerCore;
 using GameServerCore.Content;
 using GameServerCore.Domain;
@@ -2542,7 +2542,7 @@ namespace PacketDefinitions420
 
         /// <summary>
         /// Sends a packet to either all players with vision of the specified GameObject or a specified user.
-        /// The packet contains details of which team gained visibility of the GameObject and is meant for after it is first initialized into vision.
+        /// The packet contains details of which team gained visibility of the GameObject and should only be used after it is first initialized into vision (NotifyEnterVisibility).
         /// </summary>
         /// <param name="o">GameObject coming into vision.</param>
         /// <param name="userId">User to send the packet to.</param>
@@ -2586,6 +2586,31 @@ namespace PacketDefinitions420
                 }
             };
             _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
+        }
+
+        /// <summary>
+        /// Sends a packet to either all players with vision of the specified GameObject or a specified user.
+        /// The packet contains details of which team lost visibility of the GameObject and should only be used after it is first initialized into vision (NotifyEnterVisibility).
+        /// </summary>
+        /// <param name="o">GameObject going out of vision.</param>
+        /// <param name="userId">User to send the packet to.</param>
+        public void NotifyS2C_OnLeaveTeamVisibility(IGameObject o, TeamId team, int userId = 0)
+        {
+            var enterTeamVis = new S2C_OnLeaveTeamVisibility()
+            {
+                SenderNetID = o.NetId,
+                VisibilityTeam = (byte)team
+            };
+
+            if (userId == 0)
+            {
+                // TODO: Verify if we should use BroadcastPacketTeam instead.
+                _packetHandlerManager.BroadcastPacket(enterTeamVis.GetBytes(), Channel.CHL_S2C);
+            }
+            else
+            {
+                _packetHandlerManager.SendPacket(userId, enterTeamVis.GetBytes(), Channel.CHL_S2C);
+            }
         }
 
         /// <summary>
@@ -3548,6 +3573,42 @@ namespace PacketDefinitions420
         }
 
         /// <summary>
+        /// Sends a packet to the specified team detailing that an object's visibility has changed.
+        /// General function which will send the needed vision packet for the specific object type.
+        /// </summary>
+        /// <param name="obj">GameObject which had their visibility changed.</param>
+        /// <param name="team">Team which is affected by this visibility change.</param>
+        /// <param name="becameVisible">Whether or not the change was an entry into vision.</param>
+        public void NotifyVisibilityChange(IGameObject obj, TeamId team, bool becameVisible)
+        {
+            if (obj is IParticle particle)
+            {
+                if (becameVisible)
+                {
+                    NotifyFXEnterTeamVisibility(particle, team);
+                }
+                else
+                {
+                    NotifyFXLeaveTeamVisibility(particle, team);
+                }
+            }
+            else if (obj is IAttackableUnit u)
+            {
+                if (becameVisible)
+                {
+                    // Might not be necessary, but just for good measure.
+                    NotifyS2C_OnEnterTeamVisibility(u, team);
+                    NotifyEnterVisibilityClient(obj, useTeleportID: true);
+                }
+                else
+                {
+                    NotifyS2C_OnLeaveTeamVisibility(u, team);
+                    NotifyLeaveVisibilityClient(obj, team);
+                }
+            }
+        }
+
+        /// <summary>
         /// Sends a packet to all players that have vision of the specified unit that it has made a movement.
         /// </summary>
         /// <param name="u">AttackableUnit that is moving.</param>
@@ -3712,34 +3773,6 @@ namespace PacketDefinitions420
                 SyncID = request.RequestNo
             };
             _packetHandlerManager.SendPacket(userId, answer.GetBytes(), Channel.CHL_S2C, PacketFlags.None);
-        }
-
-        public void NotifyTeamAboutVisibilityChange(IGameObject obj, TeamId team, bool becameVisible)
-        {
-            if(obj is IParticle particle)
-            {
-                if(becameVisible)
-                {
-                    NotifyFXEnterTeamVisibility(particle, team);
-                }
-                else
-                {
-                    NotifyFXLeaveTeamVisibility(particle, team);
-                }
-            }
-            else if(obj is IAttackableUnit u)
-            {
-                if (becameVisible)
-                {
-                    // Might not be necessary, but just for good measure.
-                    NotifyS2C_OnEnterTeamVisibility(u, team);
-                    NotifyEnterVisibilityClient(obj, useTeleportID: true);
-                }
-                else
-                {
-                    NotifyLeaveVisibilityClient(obj, team);
-                }
-            }
         }
     }
 }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3713,5 +3713,33 @@ namespace PacketDefinitions420
             };
             _packetHandlerManager.SendPacket(userId, answer.GetBytes(), Channel.CHL_S2C, PacketFlags.None);
         }
+
+        public void NotifyTeamAboutVisibilityChange(IGameObject obj, TeamId team, bool becameVisible)
+        {
+            if(obj is IParticle particle)
+            {
+                if(becameVisible)
+                {
+                    NotifyFXEnterTeamVisibility(particle, team);
+                }
+                else
+                {
+                    NotifyFXLeaveTeamVisibility(particle, team);
+                }
+            }
+            else if(obj is IAttackableUnit u)
+            {
+                if (becameVisible)
+                {
+                    // Might not be necessary, but just for good measure.
+                    NotifyS2C_OnEnterTeamVisibility(u, team);
+                    NotifyEnterVisibilityClient(obj, useTeleportID: true);
+                }
+                else
+                {
+                    NotifyLeaveVisibilityClient(obj, team);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Started splitting https://github.com/LeagueSandbox/GameServer/pull/1290 into separate pull requests, this is the first.

`PacketNotifier` now has a function `NotifyVisibilityChange` (when we talked about it, it was called `NotifyVision`), which sends the appropriate packet about changing visibility depending on the type of object. Visibility updates for attacked units and particles are merged and moved to a separate function `UpdateVision` that calls `NotifyVision`.

In fact, this is just the implementation of the idea [described in the message](https://discord.com/channels/166860156506865665/167010397428121601/937137082999119944)

I also fixed a bug that I myself created by negligence: objects are no longer updated immediately after creation (because time has not passed since their creation) :sweat_smile: