### PR TITLE
Resolve #1299, Progress #1300 -- Attack and Spell Cancelling

### DIFF
--- a/Content/LeagueSandbox-Scripts/Characters/Kalista/BasicAttack.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Kalista/BasicAttack.cs
@@ -1,0 +1,60 @@
+﻿using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using System.Numerics;
+using LeagueSandbox.GameServer.API;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
+
+namespace Spells
+{
+    public class KalistaBasicAttack : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            MissileParameters = new MissileParameters
+            {
+                Type = MissileType.Target
+            }
+            // TODO
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}
+

--- a/Content/LeagueSandbox-Scripts/Characters/Kalista/CharScriptKalista.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Kalista/CharScriptKalista.cs
@@ -1,0 +1,38 @@
+﻿using GameServerCore.Domain;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Enums;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+
+namespace CharScripts
+{
+    internal class CharScriptKalista : ICharScript
+    {
+        public void OnActivate(IObjAiBase owner, ISpell spell = null)
+        {
+            ApiEventManager.OnPreAttack.AddListener(this, owner, OnPreAttack, false);
+        }
+
+        public void OnPreAttack(ISpell spell)
+        {
+            if (spell.CastInfo.Targets.Count > 0)
+            {
+                var target = spell.CastInfo.Targets[0].Unit;
+                FaceDirection(target.Position, target, true);
+            }
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell = null)
+        {
+        }
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}

--- a/GameServerCore/Domain/GameObjects/IGameObject.cs
+++ b/GameServerCore/Domain/GameObjects/IGameObject.cs
@@ -21,6 +21,10 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         float CollisionRadius { get; }
         /// <summary>
+        /// Radius of the circle which is used for pathfinding around objects and terrain.
+        /// </summary>
+        float PathfindingRadius { get; }
+        /// <summary>
         /// Position of this GameObject from a top-down view.
         /// </summary>
         Vector2 Position { get; }

--- a/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
@@ -2,6 +2,7 @@
 using GameServerCore.Domain.GameObjects.Spell.Sector;
 using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
+using System.Collections.Generic;
 using System.Numerics;
 
 namespace GameServerCore.Domain.GameObjects.Spell
@@ -64,6 +65,12 @@ namespace GameServerCore.Domain.GameObjects.Spell
         /// Called by projectiles when they land / hit, this is where we apply damage/slows etc.
         /// </summary>
         void ApplyEffects(IAttackableUnit u, ISpellMissile p = null, ISpellSector s = null);
+
+        /// <summary>
+        /// Whether or not this spell can be cancelled during cast.
+        /// </summary>
+        /// <returns></returns>
+        bool CastCancelCheck();
 
         /// <summary>
         /// Called when the character casts this spell. Initializes the CastInfo for this spell and begins casting.
@@ -132,6 +139,7 @@ namespace GameServerCore.Domain.GameObjects.Spell
         /// </summary>
         /// <param name="toggle">True/False.</param>
         void SetSpellToggle(bool toggle);
+        void SetTargetUnits(List<ICastTarget> targets);
         void SetToolTipVar<T>(int tipIndex, T value) where T : struct;
 
         /// <summary>

--- a/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
+++ b/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
@@ -190,10 +190,10 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         public void DebugSelf(int userId)
         {
             // Arbitrary ratio is required for the DebugCircle particle to look accurate
-            var circlesize = (1f / 100f) * _userChampion.CollisionRadius;
+            var circlesize = (1f / 100f) * _userChampion.PathfindingRadius;
 
-            _logger.Debug($"Started debugging self. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.CollisionRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.CollisionRadius + " = " + circlesize);
-            var startdebugmsg = $"Started debugging self. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.CollisionRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.CollisionRadius + " = " + circlesize;
+            _logger.Debug($"Started debugging self. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.PathfindingRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.PathfindingRadius + " = " + circlesize);
+            var startdebugmsg = $"Started debugging self. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.PathfindingRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.PathfindingRadius + " = " + circlesize;
             ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.NORMAL, startdebugmsg);
 
             // Creates a blue flashing highlight around your unit
@@ -208,7 +208,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             }
 
             // Arbitrary ratio is required for the DebugCircle particle to look accurate
-            var circlesize = (1f / 100f) * _userChampion.CollisionRadius;
+            var circlesize = (1f / 100f) * _userChampion.PathfindingRadius;
 
             // Clear circle particles every draw in case the unit changes its position
             if (_circleParticles.ContainsKey(_userChampion.NetId))
@@ -275,12 +275,12 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         public void DebugChampions(int userId)
         {
             // Arbitrary ratio is required for the DebugCircle particle to look accurate
-            var circlesize = (1f / 100f) * _userChampion.CollisionRadius;
+            var circlesize = (1f / 100f) * _userChampion.PathfindingRadius;
 
             var champions = Game.ObjectManager.GetAllChampions();
 
-            _logger.Debug($"Started debugging " + champions.Count + " champions. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.CollisionRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.CollisionRadius + " = " + circlesize);
-            var startdebugmsg = $"Started debugging " + champions.Count + " champions. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.CollisionRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.CollisionRadius + " = " + circlesize;
+            _logger.Debug($"Started debugging " + champions.Count + " champions. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.PathfindingRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.PathfindingRadius + " = " + circlesize);
+            var startdebugmsg = $"Started debugging " + champions.Count + " champions. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.PathfindingRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.PathfindingRadius + " = " + circlesize;
             ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.NORMAL, startdebugmsg);
 
             // Creates a blue flashing highlight around your unit
@@ -300,9 +300,9 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             foreach (var champion in champions)
             {
                 // Arbitrary ratio is required for the DebugCircle particle to look accurate
-                var circlesize = (1f / 100f) * champion.CollisionRadius;
+                var circlesize = (1f / 100f) * champion.PathfindingRadius;
 
-                if (champion.CollisionRadius < 5)
+                if (champion.PathfindingRadius < 5)
                 {
                     circlesize = (1f / 100f) * 35;
                 }
@@ -373,10 +373,10 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         public void DebugMinions(int userId)
         {
             // Arbitrary ratio is required for the DebugCircle particle to look accurate
-            var circlesize = (1f / 100f) * _userChampion.CollisionRadius;
+            var circlesize = (1f / 100f) * _userChampion.PathfindingRadius;
 
-            _logger.Debug($"Started debugging minions. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.CollisionRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.CollisionRadius + " = " + circlesize);
-            var startdebugmsg = $"Started debugging minions. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.CollisionRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.CollisionRadius + " = " + circlesize;
+            _logger.Debug($"Started debugging minions. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.PathfindingRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.PathfindingRadius + " = " + circlesize);
+            var startdebugmsg = $"Started debugging minions. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.PathfindingRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.PathfindingRadius + " = " + circlesize;
             ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.NORMAL, startdebugmsg);
 
             // Creates a blue flashing highlight around your unit
@@ -396,9 +396,9 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                 if (obj is IMinion minion)
                 {
                     // Arbitrary ratio is required for the DebugCircle particle to look accurate
-                    var circlesize = (1f / 100f) * minion.CollisionRadius;
+                    var circlesize = (1f / 100f) * minion.PathfindingRadius;
 
-                    if (minion.CollisionRadius < 5)
+                    if (minion.PathfindingRadius < 5)
                     {
                         circlesize = (1f / 100f) * 35;
                     }
@@ -689,10 +689,10 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         public void DebugAll(int userId)
         {
             // Arbitrary ratio is required for the DebugCircle particle to look accurate
-            var circlesize = (1f / 100f) * _userChampion.CollisionRadius;
+            var circlesize = (1f / 100f) * _userChampion.PathfindingRadius;
 
-            _logger.Debug($"Started debugging all. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.CollisionRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.CollisionRadius + " = " + circlesize);
-            var startdebugmsg = $"Started debugging all. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.CollisionRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.CollisionRadius + " = " + circlesize;
+            _logger.Debug($"Started debugging all. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.PathfindingRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.PathfindingRadius + " = " + circlesize);
+            var startdebugmsg = $"Started debugging all. Your Debug Circle Radius: " + "(1 / 100) * " + _userChampion.PathfindingRadius + " = " + "(" + (1f / 100f) + ") * " + _userChampion.PathfindingRadius + " = " + circlesize;
             ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.NORMAL, startdebugmsg);
 
             // Creates a blue flashing highlight around your unit
@@ -711,9 +711,9 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             foreach (IGameObject obj in tempObjects.Values)
             {
                 // Arbitrary ratio is required for the DebugCircle particle to look accurate
-                var circlesize = (1f / 100f) * obj.CollisionRadius;
+                var circlesize = (1f / 100f) * obj.PathfindingRadius;
 
-                if (obj.CollisionRadius < 5)
+                if (obj.PathfindingRadius < 5)
                 {
                     circlesize = (1f / 100f) * 35;
                 }

--- a/GameServerLib/Content/Navigation/NavigationGrid.cs
+++ b/GameServerLib/Content/Navigation/NavigationGrid.cs
@@ -861,13 +861,13 @@ namespace LeagueSandbox.GameServer.Content.Navigation
             if (a is IObjBuilding)
             {
                 double rayDist = Math.Sqrt((CastRay(b.Position, a.Position, !checkVision, checkVision).Value - b.Position).SqrLength());
-                rayDist += a.CollisionRadius;
+                rayDist += a.PathfindingRadius;
                 return (rayDist * rayDist) < (b.Position - a.Position).SqrLength();
             }
             if (b is IObjBuilding)
             {
                 double rayDist = Math.Sqrt((CastRay(a.Position, b.Position, !checkVision, checkVision).Value - a.Position).SqrLength());
-                rayDist += b.CollisionRadius;
+                rayDist += b.PathfindingRadius;
                 return (rayDist * rayDist) < (b.Position - a.Position).SqrLength();
             }
             return !CastRay(a.Position, b.Position, !checkVision, checkVision).Key;

--- a/GameServerLib/GameObjects/LevelProp.cs
+++ b/GameServerLib/GameObjects/LevelProp.cs
@@ -33,7 +33,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             byte type = 2,
             uint netId = 64
 
-        ) : base(game, position, 0, 0, netId)
+        ) : base(game, position, 0, 0, 0, netId)
         {
             NetNodeID = netNodeId;
             SkinID = skinId;

--- a/GameServerLib/GameObjects/Particle.cs
+++ b/GameServerLib/GameObjects/Particle.cs
@@ -95,7 +95,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="teamOnly">The only team that should be able to see this particle.</param>
         /// <param name="flags">Flags which determine how the particle behaves. Refer to FXFlags enum.</param>
         public Particle(Game game, IGameObject caster, IGameObject bindObj, IGameObject target, string particleName, float scale = 1.0f, string boneName = "", string targetBoneName = "", uint netId = 0, Vector3 direction = new Vector3(), bool followGroundTilt = false, float lifetime = 0, bool reqVision = true, bool autoSend = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL, FXFlags flags = FXFlags.GivenDirection)
-               : base(game, target.Position, 0, 0, netId)
+               : base(game, target.Position, 0, 0, 0, netId)
         {
             Caster = caster;
             BindObject = bindObj;
@@ -149,7 +149,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="teamOnly">The only team that should be able to see this particle.</param>
         /// <param name="flags">Flags which determine how the particle behaves. Refer to FXFlags enum.</param>
         public Particle(Game game, IGameObject caster, IGameObject bindObj, Vector2 targetPos, string particleName, float scale = 1.0f, string boneName = "", string targetBoneName = "", uint netId = 0, Vector3 direction = new Vector3(), bool followGroundTilt = false, float lifetime = 0, bool reqVision = true, bool autoSend = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL, FXFlags flags = FXFlags.GivenDirection)
-               : base(game, targetPos, 0, 0, netId, teamOnly)
+               : base(game, targetPos, 0, 0, 0, netId, teamOnly)
         {
             Caster = caster;
 
@@ -209,7 +209,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="teamOnly">The only team that should be able to see this particle.</param>
         /// <param name="flags">Flags which determine how the particle behaves. Refer to FXFlags enum.</param>
         public Particle(Game game, IGameObject caster, Vector2 startPos, Vector2 endPos, string particleName, float scale = 1.0f, string boneName = "", string targetBoneName = "", uint netId = 0, Vector3 direction = new Vector3(), bool followGroundTilt = false, float lifetime = 0, bool reqVision = true, bool autoSend = true, TeamId teamOnly = TeamId.TEAM_NEUTRAL, FXFlags flags = FXFlags.GivenDirection)
-               : base(game, startPos, 0, 0, netId, teamOnly)
+               : base(game, startPos, 0, 0, 0, netId, teamOnly)
         {
             Caster = caster;
 

--- a/GameServerLib/GameObjects/Region.cs
+++ b/GameServerLib/GameObjects/Region.cs
@@ -72,7 +72,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             float addedSize = 0,
             float lifetime = 0,
             int clientId = 0
-        ): base(game, pos, collisionRadius, visionRadius, team: team)
+        ): base(game, pos, 0, collisionRadius, visionRadius, team: team)
         {
             Type = (int)type;
             CollisionUnit = collisionUnit;
@@ -96,13 +96,13 @@ namespace LeagueSandbox.GameServer.GameObjects
 
             if (Scale > 0)
             {
-                CollisionRadius *= Scale;
+                PathfindingRadius *= Scale;
                 VisionRadius *= Scale;
             }
 
             if (AdditionalSize > 0)
             {
-                CollisionRadius += AdditionalSize;
+                PathfindingRadius += AdditionalSize;
                 VisionRadius += AdditionalSize;
             }
 

--- a/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
+++ b/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
@@ -45,7 +45,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Missile
             SpellDataFlags overrideFlags = 0, // TODO: Find a use for these
             uint netId = 0,
             bool serverOnly = false
-        ) : base(game, new Vector2(castInfo.SpellCastLaunchPosition.X, castInfo.SpellCastLaunchPosition.Z), collisionRadius, 0, netId)
+        ) : base(game, new Vector2(castInfo.SpellCastLaunchPosition.X, castInfo.SpellCastLaunchPosition.Z), collisionRadius, 0, 0, netId)
         {
             _moveSpeed = moveSpeed;
             _timeSinceCreation = 0.0f;

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSector.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSector.cs
@@ -50,7 +50,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             ISpell originSpell,
             ICastInfo castInfo,
             uint netId = 0
-        ) : base(game, new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z), Math.Max(parameters.Length, parameters.Width), 0, netId)
+        ) : base(game, new Vector2(castInfo.TargetPositionEnd.X, castInfo.TargetPositionEnd.Z), Math.Max(parameters.Length, parameters.Width), 0, 0, netId)
         {
             _timeSinceCreation = 0.0f;
             _lastTickTime = 0.0f;

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -87,7 +87,7 @@ namespace LeagueSandbox.GameServer
                     {
                         _game.PacketNotifier.NotifySpawn(turret);
 
-                        new Region(_game, turret.Team, turret.Position, RegionType.Default, turret, turret, true, 800f, true, true, turret.CollisionRadius, lifetime: 25000.0f);
+                        new Region(_game, turret.Team, turret.Position, RegionType.Default, turret, turret, true, 800f, true, true, turret.PathfindingRadius, lifetime: 25000.0f);
 
                         foreach (var item in turret.Inventory)
                         {

--- a/GameServerLib/Packets/PacketHandlers/HandleMove.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleMove.cs
@@ -27,7 +27,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
         {
             var peerInfo = _playerManager.GetPeerInfo(userId);
             var champion = peerInfo?.Champion;
-            if (peerInfo == null || !champion.CanMove())
+            if (peerInfo == null)
             {
                 return true;
             }
@@ -50,8 +50,8 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 {
                     Vector2 exit = nav.GetClosestTerrainExit(translatedWaypoints[lastindex]);
 
-                    // prevent player pathing within their collision radius
-                    if (Vector2.DistanceSquared(champion.Position, exit) < (champion.CollisionRadius * champion.CollisionRadius))
+                    // prevent player pathing within their pathing radius
+                    if (Vector2.DistanceSquared(champion.Position, exit) < (champion.PathfindingRadius * champion.PathfindingRadius))
                     {
                         return true;
                     }
@@ -69,7 +69,6 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 case OrderType.AttackTo:
                     translatedWaypoints[0] = champion.Position;
                     champion.UpdateMoveOrder(OrderType.AttackTo, true);
-                    // TODO: Verify if stopping movement is the correct thing to do.
                     champion.SetWaypoints(translatedWaypoints);
                     break;
                 case OrderType.Stop:

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -73,7 +73,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 }
                 else if (kv.Value is ILaneTurret turret)
                 {
-                    new Region(_game, turret.Team, turret.Position, RegionType.Default, turret, turret, true, 800f, true, true, turret.CollisionRadius, lifetime: 25000.0f);
+                    new Region(_game, turret.Team, turret.Position, RegionType.Default, turret, turret, true, 800f, true, true, turret.PathfindingRadius, lifetime: 25000.0f);
                     _game.PacketNotifier.NotifyS2C_CreateTurret(turret, userId);
                 }
                 else if (kv.Value is INexus nexus)


### PR DESCRIPTION
* Scripting:
  * Setup scaffolds for Kalista CharScript and BasicAttack scripts.
* Spell:
  * CastCancelCheck has a return value for checking if a spell can be canceled.
  * Added SetTargetUnits for overriding a spell's targets mid-cast/channel.
  * UnitSetLookAt is now performed after attacks, but still before spells (reflecting replays).
* GameObject:
  * Added PathfindingRadius to separate between GameplayCollisionRadius and PathfindingCollisionRadius CharData variables.
* ObjAiBase:
  * Uncancellable attacks block movement, but do not block changes to waypoints (waypoint changes are no longer limited by CanMove()).
  * UpdateTarget updates regardless of CanMove
  * UpdateTarget automatically cancels auto attacks based on death, targetability, range, and spell casts.
* Packets:
  * HandleMove is no longer limited by CanMove
  * Basic_Attack & Basic_Attack_Pos utilize a dynamic ExtraTime variable (used for attack re-targeting during windup).