### PR TITLE
Resolve #1222, Resolve #1304 -- Dash Events, Region Vision Fix, Attack Cancel Keep Target

### DIFF
--- a/Content/LeagueSandbox-Scripts/AiScripts/LaneMinionAi.cs
+++ b/Content/LeagueSandbox-Scripts/AiScripts/LaneMinionAi.cs
@@ -278,10 +278,11 @@ namespace AIScripts
             }
             
             LaneMinion.CancelAutoAttack(false, true);
-            
+            LaneMinion.SetTargetUnit(null, true);
+
             //Quote: Find a new valid target in the minion’s acquisition range to attack.
             //Quote: If multiple valid targets, prioritize based on “how hard is it for me to path there?”
-            if(FoundNewTarget())
+            if (FoundNewTarget())
             {
                 return OrderType.AttackTo;
             }

--- a/Content/LeagueSandbox-Scripts/AiScripts/MinionAI.cs
+++ b/Content/LeagueSandbox-Scripts/AiScripts/MinionAI.cs
@@ -91,6 +91,7 @@ namespace AIScripts
             // If target is dead or out of range
             {
                 minion.CancelAutoAttack(false, true);
+                minion.SetTargetUnit(null, true);
             }
         }
     }

--- a/Content/LeagueSandbox-Scripts/Characters/Kalista/CharScriptKalista.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Kalista/CharScriptKalista.cs
@@ -41,6 +41,48 @@ namespace CharScripts
 
             if (!owner.IsPathEnded())
             {
+                var baseDistance = 250f;
+
+                // Boots increase speed. Tier 1 = +75, Tier 2 = +60, (speculative) Tier 3 = +45.
+                // Boots increase dash distance. Tier 1 = +15, Tier 2 = +30, (speculative) Tier 3 = +45
+                // TODO: Decrease speed based on percent movespeed mods (that are negative).
+                var speed = 1025f;
+
+                if (owner.Inventory.HasItemWithID(1001))
+                {
+                    speed += 75;
+                    baseDistance += 15f;
+                }
+                else if (owner.Inventory.HasItemWithID(3006)
+                    || owner.Inventory.HasItemWithID(3009)
+                    || owner.Inventory.HasItemWithID(3020)
+                    || owner.Inventory.HasItemWithID(3047)
+                    || owner.Inventory.HasItemWithID(3111)
+                    || owner.Inventory.HasItemWithID(3117)
+                    || owner.Inventory.HasItemWithID(3158))
+                {
+                    speed += 135;
+                    baseDistance += 30f;
+                }
+                else
+                {
+                    var boots = false;
+                    for (int i = 3250; i < 3285; i++)
+                    {
+                        if (owner.Inventory.HasItemWithID(i))
+                        {
+                            boots = true;
+                            break;
+                        }
+                    }
+
+                    if (boots)
+                    {
+                        speed += 180;
+                        baseDistance += 45f;
+                    }
+                }
+
                 StopAnimation(owner, "", false, true, true);
                 owner.SetSpell("KalistaPassiveDashSpellActual", (int)SpellSlotType.ExtraSlots, true);
                 //SpellCast(owner, 0, SpellSlotType.ExtraSlots, dashPos, dashPos, true, Vector2.Zero);
@@ -73,44 +115,8 @@ namespace CharScripts
                     angleMod /= 9;
                 }
 
-                var distance = 250f - (100 * angleMod);
+                var distance = baseDistance - (100 * angleMod);
                 LogDebug("Dashing. finalDir: " + finalDir + " distance: " + distance);
-
-                // TODO: Boots increase speed. Tier 1 = +75, Tier 2 = +60, (speculative) Tier 3 = +45.
-                // Decrease speed based on percent movespeed mods (that are negative).
-                var speed = 1025f;
-
-                if (owner.Inventory.HasItemWithID(1001))
-                {
-                    speed += 75;
-                }
-                else if (owner.Inventory.HasItemWithID(3006)
-                    || owner.Inventory.HasItemWithID(3009)
-                    || owner.Inventory.HasItemWithID(3020)
-                    || owner.Inventory.HasItemWithID(3047)
-                    || owner.Inventory.HasItemWithID(3111)
-                    || owner.Inventory.HasItemWithID(3117)
-                    || owner.Inventory.HasItemWithID(3158))
-                {
-                    speed += 135;
-                }
-                else
-                {
-                    var boots = false;
-                    for (int i = 3250; i < 3285; i++)
-                    {
-                        if (owner.Inventory.HasItemWithID(i))
-                        {
-                            boots = true;
-                            break;
-                        }
-                    }
-
-                    if (boots)
-                    {
-                        speed += 180;
-                    }
-                }
 
                 FaceDirection(dashPos, owner, true);
 

--- a/Content/LeagueSandbox-Scripts/Characters/Kalista/CharScriptKalista.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Kalista/CharScriptKalista.cs
@@ -1,4 +1,5 @@
-﻿using GameServerCore.Domain;
+﻿using GameServerCore;
+using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Enums;
@@ -6,6 +7,7 @@ using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.API;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Text;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
@@ -14,9 +16,13 @@ namespace CharScripts
 {
     internal class CharScriptKalista : ICharScript
     {
+        IAttackableUnit lastTarget;
+
         public void OnActivate(IObjAiBase owner, ISpell spell = null)
         {
             ApiEventManager.OnPreAttack.AddListener(this, owner, OnPreAttack, false);
+            ApiEventManager.OnLaunchAttack.AddListener(this, owner, OnLaunchAttack, false);
+            ApiEventManager.OnMoveEnd.AddListener(this, owner, OnMoveEnd, false);
         }
 
         public void OnPreAttack(ISpell spell)
@@ -25,6 +31,102 @@ namespace CharScripts
             {
                 var target = spell.CastInfo.Targets[0].Unit;
                 FaceDirection(target.Position, target, true);
+            }
+        }
+
+        public void OnLaunchAttack(ISpell spell)
+        {
+            var owner = spell.CastInfo.Owner;
+            lastTarget = spell.CastInfo.Targets[0].Unit;
+
+            if (!owner.IsPathEnded())
+            {
+                StopAnimation(owner, "", false, true, true);
+                owner.SetSpell("KalistaPassiveDashSpellActual", (int)SpellSlotType.ExtraSlots, true);
+                //SpellCast(owner, 0, SpellSlotType.ExtraSlots, dashPos, dashPos, true, Vector2.Zero);
+
+                // KalistaPassiveDashSpellActual code below
+
+                // Minimum distance. No boots. Going towards attack direction.
+                var dashPos = owner.Waypoints[owner.Waypoints.Count - 1];
+                var angleDir = Extensions.UnitVectorToAngle(new Vector2(owner.Direction.X, owner.Direction.Z));
+
+                // Decrease distance based on direction (backwards = farther, opposite behavior from Q dash)
+                var finalDir = MathF.Abs(MathF.Abs(owner.Position.AngleTo(dashPos, owner.Position) - angleDir) - 180f);
+                // TODO: Increase max distance based on boots Tier
+                var angleMod = (finalDir / 180f);
+
+                if (finalDir <= 165f && finalDir > 150f)
+                {
+                    angleMod /= 3;
+                }
+                else if (finalDir <= 150f && finalDir > 135f)
+                {
+                    angleMod /= 4;
+                }
+                else if (finalDir <= 135f && finalDir > 90f)
+                {
+                    angleMod /= 6;
+                }
+                else if (finalDir <= 90f)
+                {
+                    angleMod /= 9;
+                }
+
+                var distance = 250f - (100 * angleMod);
+                LogDebug("Dashing. finalDir: " + finalDir + " distance: " + distance);
+
+                // TODO: Boots increase speed. Tier 1 = +75, Tier 2 = +60, (speculative) Tier 3 = +45.
+                // Decrease speed based on percent movespeed mods (that are negative).
+                var speed = 1025f;
+
+                if (owner.Inventory.HasItemWithID(1001))
+                {
+                    speed += 75;
+                }
+                else if (owner.Inventory.HasItemWithID(3006)
+                    || owner.Inventory.HasItemWithID(3009)
+                    || owner.Inventory.HasItemWithID(3020)
+                    || owner.Inventory.HasItemWithID(3047)
+                    || owner.Inventory.HasItemWithID(3111)
+                    || owner.Inventory.HasItemWithID(3117)
+                    || owner.Inventory.HasItemWithID(3158))
+                {
+                    speed += 135;
+                }
+                else
+                {
+                    var boots = false;
+                    for (int i = 3250; i < 3285; i++)
+                    {
+                        if (owner.Inventory.HasItemWithID(i))
+                        {
+                            boots = true;
+                            break;
+                        }
+                    }
+
+                    if (boots)
+                    {
+                        speed += 180;
+                    }
+                }
+
+                FaceDirection(dashPos, owner, true);
+
+                var targetPos = GetPointFromUnit(owner, distance);
+                // TODO: Verify flags.
+                PlayAnimation(owner, "Attack1_Dash", 0.0f, 0.0f, 1.0f, flags: AnimationFlags.Unknown8 | AnimationFlags.UniqueOverride);
+                owner.CancelAutoAttack(false, true);
+                ForceMovement(owner, "", targetPos, speed, 0.0f, 0.0f, 0.0f, ForceMovementType.FIRST_WALL_HIT, ForceMovementOrdersType.POSTPONE_CURRENT_ORDER, ForceMovementOrdersFacing.FACE_MOVEMENT_DIRECTION);
+            }
+        }
+
+        public void OnMoveEnd(IAttackableUnit owner)
+        {
+            if (owner is IObjAiBase ai)
+            {
+                ai.SetTargetUnit(lastTarget);
             }
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/Kalista/KalistaPassiveDashSpellActual.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Kalista/KalistaPassiveDashSpellActual.cs
@@ -1,0 +1,60 @@
+﻿using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using System.Numerics;
+using LeagueSandbox.GameServer.API;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using GameServerCore.Enums;
+
+namespace Spells
+{
+    public class KalistaPassiveDashSpellActual : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            NotSingleTargetSpell = true,
+            DoesntBreakShields = true,
+            TriggersSpellCasts = true,
+            CastingBreaksStealth = true,
+            IsDamagingSpell = true
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}
+

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -279,7 +279,7 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         /// <param name="state">State to set. True = dashing, false = not dashing.</param>
         /// TODO: Implement ForcedMovement methods and enumerators to handle different kinds of dashes.
-        void SetDashingState(bool state);
+        void SetDashingState(bool state, MoveStopReason reason = MoveStopReason.Finished);
         /// <summary>
         /// Sets this unit's animation states to the given set of states.
         /// Given state pairs are expected to follow a specific structure:

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -148,8 +148,9 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="name">Internal name of the spell to set.</param>
         /// <param name="slot">Slot of the spell to replace.</param>
         /// <param name="enabled">Whether or not the new spell should be enabled.</param>
+        /// <param name="networkOld">Whether or not to notify clients of this change using an older packet method.</param>
         /// <returns>Newly created spell set.</returns>
-        ISpell SetSpell(string name, byte slot, bool enabled);
+        ISpell SetSpell(string name, byte slot, bool enabled, bool networkOld = false);
         /// <summary>
         /// Sets the spell that this unit will cast when it gets in range of the spell's target.
         /// Overrides auto attack spell casting.

--- a/GameServerCore/Domain/IInventoryManager.cs
+++ b/GameServerCore/Domain/IInventoryManager.cs
@@ -9,6 +9,7 @@ namespace GameServerCore.Domain
     {
         IItem GetItem(byte slot);
         IItem GetItem(string ItemSpellName);
+        bool HasItemWithID(int ItemID);
         byte GetItemSlot(IItem item);
         bool RemoveItem(byte slot, IObjAiBase owner = null, int stacksToRemove = 1);
         bool RemoveItem(IItem item, IObjAiBase owner = null, int stacksToRemove = 1);

--- a/GameServerCore/Enums/MoveStopReason.cs
+++ b/GameServerCore/Enums/MoveStopReason.cs
@@ -1,0 +1,14 @@
+﻿namespace GameServerCore.Enums
+{
+    public enum MoveStopReason
+    {
+        Finished,
+        LostTarget,
+        CrowdControl,
+        Death,
+        HeroReincarnate,
+        ForceMovement,
+        UnitCollision,
+        WallCollision
+    }
+}

--- a/GameServerLib/API/ApiEventManager.cs
+++ b/GameServerLib/API/ApiEventManager.cs
@@ -92,6 +92,9 @@ namespace LeagueSandbox.GameServer.API
             OnLaunchMissile.RemoveListener(owner);
             OnLevelUp.RemoveListener(owner);
             OnLevelUpSpell.RemoveListener(owner);
+            OnMoveEnd.RemoveListener(owner);
+            OnMoveFailure.RemoveListener(owner);
+            OnMoveSuccess.RemoveListener(owner);
             OnPreAttack.RemoveListener(owner);
             OnPreDealDamage.RemoveListener(owner);
             OnPreTakeDamage.RemoveListener(owner);
@@ -121,6 +124,9 @@ namespace LeagueSandbox.GameServer.API
         public static EventOnLaunchMissile OnLaunchMissile = new EventOnLaunchMissile();
         public static EventOnLevelUp OnLevelUp = new EventOnLevelUp();
         public static EventOnLevelUpSpell OnLevelUpSpell = new EventOnLevelUpSpell();
+        public static EventOnMoveEnd OnMoveEnd = new EventOnMoveEnd();
+        public static EventOnMoveFailure OnMoveFailure = new EventOnMoveFailure();
+        public static EventOnMoveSuccess OnMoveSuccess = new EventOnMoveSuccess();
         public static EventOnPreAttack OnPreAttack = new EventOnPreAttack();
         public static EventOnPreDealDamage OnPreDealDamage = new EventOnPreDealDamage();
         public static EventOnPreTakeDamage OnPreTakeDamage = new EventOnPreTakeDamage();
@@ -634,6 +640,133 @@ namespace LeagueSandbox.GameServer.API
             }
         }
     }
+
+    public class EventOnMoveEnd
+    {
+        private readonly List<Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>> _listeners = new List<Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>>();
+        public void AddListener(object owner, IAttackableUnit unit, Action<IAttackableUnit> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>(owner, unit, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+
+        public void RemoveListener(object owner, IAttackableUnit unit)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner && listener.Item2 == unit);
+        }
+
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner);
+        }
+
+        public void Publish(IAttackableUnit unit)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == unit)
+                {
+                    _listeners[i].Item3(unit);
+                    if (_listeners[i].Item4 == true)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
+                }
+            }
+        }
+    }
+
+    public class EventOnMoveFailure
+    {
+        private readonly List<Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>> _listeners = new List<Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>>();
+        public void AddListener(object owner, IAttackableUnit unit, Action<IAttackableUnit> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>(owner, unit, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+
+        public void RemoveListener(object owner, IAttackableUnit unit)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner && listener.Item2 == unit);
+        }
+
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner);
+        }
+
+        public void Publish(IAttackableUnit unit)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == unit)
+                {
+                    _listeners[i].Item3(unit);
+                    if (_listeners[i].Item4 == true)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
+                }
+            }
+        }
+    }
+
+    public class EventOnMoveSuccess
+    {
+        private readonly List<Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>> _listeners = new List<Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>>();
+        public void AddListener(object owner, IAttackableUnit unit, Action<IAttackableUnit> callback, bool singleInstance)
+        {
+            var listenerTuple = new Tuple<object, IAttackableUnit, Action<IAttackableUnit>, bool>(owner, unit, callback, singleInstance);
+            _listeners.Add(listenerTuple);
+        }
+
+        public void RemoveListener(object owner, IAttackableUnit unit)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner && listener.Item2 == unit);
+        }
+
+        public void RemoveListener(object owner)
+        {
+            _listeners.RemoveAll(listener => listener.Item1 == owner);
+        }
+
+        public void Publish(IAttackableUnit unit)
+        {
+            var count = _listeners.Count;
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if (_listeners[i].Item2 == unit)
+                {
+                    _listeners[i].Item3(unit);
+                    if (_listeners[i].Item4 == true)
+                    {
+                        _listeners.RemoveAt(i);
+                    }
+                }
+            }
+        }
+    }
+
     public class EventOnPreAttack
     {
         private readonly List<Tuple<object, IObjAiBase, Action<ISpell>, bool>> _listeners = new List<Tuple<object, IObjAiBase, Action<ISpell>, bool>>();

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -130,6 +130,73 @@ namespace LeagueSandbox.GameServer.API
             return _game.ObjectManager.Teams;
         }
 
+        public static int ConvertAPISlot(SpellSlotType slotType, int slot)
+        {
+            if ((slotType == SpellSlotType.SpellSlots && (slot < 0 || slot > 3))
+                || (slotType == SpellSlotType.InventorySlots && (slot < 0 || slot > 6))
+                || (slotType == SpellSlotType.ExtraSlots && (slot < 0 || slot > 15)))
+            {
+                return -1;
+            }
+
+            if (slotType == SpellSlotType.SummonerSpellSlots)
+            {
+                slot += (int)SpellSlotType.SummonerSpellSlots;
+            }
+            else if (slotType == SpellSlotType.InventorySlots)
+            {
+                slot += (int)SpellSlotType.InventorySlots;
+            }
+            else if (slotType == SpellSlotType.TempItemSlot)
+            {
+                slot = (int)SpellSlotType.TempItemSlot;
+            }
+            else if (slotType == SpellSlotType.ExtraSlots)
+            {
+                slot += (int)SpellSlotType.ExtraSlots;
+            }
+
+            return slot;
+        }
+
+        public static int ConvertAPISlot(SpellbookType spellbookType, SpellSlotType slotType, int slot)
+        {
+            if (spellbookType == SpellbookType.SPELLBOOK_UNKNOWN
+                || spellbookType == SpellbookType.SPELLBOOK_SUMMONER && (slotType != SpellSlotType.SummonerSpellSlots)
+                || (spellbookType == SpellbookType.SPELLBOOK_CHAMPION
+                    && ((slotType == SpellSlotType.SpellSlots && (slot < 0 || slot > 3))
+                        || (slotType == SpellSlotType.InventorySlots && (slot < 0 || slot > 6))
+                        || (slotType == SpellSlotType.ExtraSlots && (slot < 0 || slot > 15)))))
+            {
+                return -1;
+            }
+
+            if (spellbookType == SpellbookType.SPELLBOOK_CHAMPION)
+            {
+                if (slotType == SpellSlotType.InventorySlots)
+                {
+                    slot += (int)SpellSlotType.InventorySlots;
+                }
+                else if (slotType == SpellSlotType.TempItemSlot)
+                {
+                    slot = (int)SpellSlotType.TempItemSlot;
+                }
+                else if (slotType == SpellSlotType.ExtraSlots)
+                {
+                    slot += (int)SpellSlotType.ExtraSlots;
+                }
+            }
+            else if (spellbookType == SpellbookType.SPELLBOOK_SUMMONER)
+            {
+                if (slotType == SpellSlotType.SummonerSpellSlots)
+                {
+                    slot += (int)SpellSlotType.SummonerSpellSlots;
+                }
+            }
+
+            return slot;
+        }
+
         /// <summary>
         /// Teleports an AI unit to the specified coordinates.
         /// Instant.
@@ -707,26 +774,11 @@ namespace LeagueSandbox.GameServer.API
 
         public static void SealSpellSlot(IObjAiBase target, SpellSlotType slotType, int slot, SpellbookType spellbookType, bool seal)
         {
-            if (spellbookType == SpellbookType.SPELLBOOK_UNKNOWN
-                || spellbookType == SpellbookType.SPELLBOOK_SUMMONER && (slotType != SpellSlotType.SummonerSpellSlots)
-                || (spellbookType == SpellbookType.SPELLBOOK_CHAMPION
-                    && ((slotType == SpellSlotType.SpellSlots && (slot < 0 || slot > 3))
-                        || (slotType == SpellSlotType.InventorySlots && (slot < 0 || slot > 6))
-                        || (slotType == SpellSlotType.ExtraSlots && (slot < 0 || slot > 15)))))
+            slot = ConvertAPISlot(spellbookType, slotType, slot);
+
+            if (slot == -1)
             {
                 return;
-            }
-
-            if (spellbookType == SpellbookType.SPELLBOOK_CHAMPION)
-            {
-                if (slotType == SpellSlotType.InventorySlots)
-                {
-                    slot += (int)SpellSlotType.InventorySlots;
-                }
-                if (slotType == SpellSlotType.ExtraSlots)
-                {
-                    slot += (int)SpellSlotType.ExtraSlots;
-                }
             }
 
             if (spellbookType == SpellbookType.SPELLBOOK_SUMMONER)
@@ -782,29 +834,14 @@ namespace LeagueSandbox.GameServer.API
 
         public static void SetTargetingType(IObjAiBase target, SpellSlotType slotType, int slot, TargetingType newType)
         {
-            if ((slotType == SpellSlotType.SpellSlots && (slot < 0 || slot > 3))
-                || (slotType == SpellSlotType.InventorySlots && (slot < 0 || slot > 6))
-                || (slotType == SpellSlotType.ExtraSlots && (slot < 0 || slot > 15)))
+            slot = ConvertAPISlot(slotType, slot);
+
+            if (slot == -1)
             {
                 return;
             }
 
-            if (slotType == SpellSlotType.InventorySlots)
-            {
-                slot += (int)SpellSlotType.InventorySlots;
-            }
-
-            if (slotType == SpellSlotType.TempItemSlot)
-            {
-                slot = (int)SpellSlotType.TempItemSlot;
-            }
-
-            if (slotType == SpellSlotType.ExtraSlots)
-            {
-                slot += (int)SpellSlotType.ExtraSlots;
-            }
-
-            ISpell spell = target.GetSpell((byte)slot);
+            var spell = target.GetSpell((byte)slot);
 
             spell.SpellData.SetTargetingType(newType);
 
@@ -826,27 +863,7 @@ namespace LeagueSandbox.GameServer.API
         {
             if (unit is IChampion champ)
             {
-                if ((slotType == SpellSlotType.SpellSlots && (slot < 0 || slot > 3))
-                || (slotType == SpellSlotType.InventorySlots && (slot < 0 || slot > 6))
-                || (slotType == SpellSlotType.ExtraSlots && (slot < 0 || slot > 15)))
-                {
-                    return;
-                }
-
-                if (slotType == SpellSlotType.InventorySlots)
-                {
-                    slot += (int)SpellSlotType.InventorySlots;
-                }
-
-                if (slotType == SpellSlotType.TempItemSlot)
-                {
-                    slot = (int)SpellSlotType.TempItemSlot;
-                }
-
-                if (slotType == SpellSlotType.ExtraSlots)
-                {
-                    slot += (int)SpellSlotType.ExtraSlots;
-                }
+                slot = (byte)ConvertAPISlot(book, slotType, slot);
 
                 champ.GetSpell(slot).SetToolTipVar(tipIndex, value);
             }
@@ -860,27 +877,7 @@ namespace LeagueSandbox.GameServer.API
 
         public static void SpellCast(IObjAiBase caster, int slot, SpellSlotType slotType, Vector2 pos, Vector2 endPos, bool fireWithoutCasting, Vector2 overrideCastPos, List<ICastTarget> targets = null, bool isForceCastingOrChanneling = false, int overrideForceLevel = -1, bool updateAutoAttackTimer = false, bool useAutoAttackSpell = false)
         {
-            if ((slotType == SpellSlotType.SpellSlots && (slot < 0 || slot > 3))
-                || (slotType == SpellSlotType.InventorySlots && (slot < 0 || slot > 6))
-                || (slotType == SpellSlotType.ExtraSlots && (slot < 0 || slot > 15)))
-            {
-                return;
-            }
-
-            if (slotType == SpellSlotType.InventorySlots)
-            {
-                slot += (int)SpellSlotType.InventorySlots;
-            }
-
-            if (slotType == SpellSlotType.TempItemSlot)
-            {
-                slot = (int)SpellSlotType.TempItemSlot;
-            }
-
-            if (slotType == SpellSlotType.ExtraSlots)
-            {
-                slot += (int)SpellSlotType.ExtraSlots;
-            }
+            slot = ConvertAPISlot(slotType, slot);
 
             ISpell spell = caster.GetSpell((byte)slot);
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
@@ -37,6 +37,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// Supposed to be the NetID for the visual counterpart of this turret. Used only for packets.
         /// </summary>
         public uint ParentNetId { get; private set; }
+        /// <summary>
+        /// Region assigned to this turret for vision and collision.
+        /// </summary>
+        public IRegion BubbleRegion { get; private set; }
 
         public BaseTurret(
             Game game,
@@ -105,6 +109,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             base.OnAdded();
             _game.ObjectManager.AddTurret(this);
+
+            // TODO: Handle this via map script for LaneTurret and via CharScript for AzirTurret.
+            BubbleRegion = new Region(_game, Team, Position, RegionType.Default, this, this, true, 800f, true, true, PathfindingRadius, lifetime: 25000.0f);
         }
 
         public override void OnCollision(IGameObject collider, bool isTerrain = false)

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -1633,7 +1633,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// </summary>
         /// <param name="state">State to set. True = dashing, false = not dashing.</param>
         /// TODO: Implement ForcedMovement methods and enumerators to handle different kinds of dashes.
-        public virtual void SetDashingState(bool state)
+        public virtual void SetDashingState(bool state, MoveStopReason reason = MoveStopReason.Finished)
         {
             if (MovementParameters != null && state == false)
             {
@@ -1641,13 +1641,24 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 
                 var animPairs = new Dictionary<string, string> { { "RUN", "" } };
                 SetAnimStates(animPairs);
+
+                ApiEventManager.OnMoveEnd.Publish(this);
+
+                if (reason == MoveStopReason.Finished)
+                {
+                    ApiEventManager.OnMoveSuccess.Publish(this);
+                }
+                else if (reason != MoveStopReason.Finished)
+                {
+                    ApiEventManager.OnMoveFailure.Publish(this);
+                }
             }
 
             // TODO: Implement this as a parameter.
-            Stats.SetActionState(ActionState.CAN_ATTACK, !state);
-            Stats.SetActionState(ActionState.CAN_NOT_ATTACK, state);
-            Stats.SetActionState(ActionState.CAN_MOVE, !state);
-            Stats.SetActionState(ActionState.CAN_NOT_MOVE, state);
+            SetStatus(StatusFlags.CanAttack, !state);
+            // TODO: Verify if changing cast status is correct.
+            SetStatus(StatusFlags.CanCast, !state);
+            SetStatus(StatusFlags.CanMove, !state);
         }
 
         /// <summary>

--- a/GameServerLib/Items/InventoryManager.cs
+++ b/GameServerLib/Items/InventoryManager.cs
@@ -52,6 +52,12 @@ namespace LeagueSandbox.GameServer.Items
         {
             return _inventory.GetItem(itemSpellName);
         }
+
+        public bool HasItemWithID(int ItemID)
+        {
+            return _inventory.HasItemWithID(ItemID);
+        }
+
         public bool RemoveItem(byte slot, IObjAiBase owner = null, int stacksToRemove = 1)
         {
             var item = _inventory.Items[slot];

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -99,8 +99,6 @@ namespace LeagueSandbox.GameServer
                     {
                         _game.PacketNotifier.NotifySpawn(turret);
 
-                        new Region(_game, turret.Team, turret.Position, RegionType.Default, turret, turret, true, 800f, true, true, turret.PathfindingRadius, lifetime: 25000.0f);
-
                         foreach (var item in turret.Inventory)
                         {
                             if (item != null)
@@ -316,12 +314,16 @@ namespace LeagueSandbox.GameServer
                 foreach (var kv in _objects)
                 {
                     // NEUTRAL Regions give global vision.
-                    if (((kv.Value.Team == team) || (kv.Value is IRegion region && region.Team == TeamId.TEAM_NEUTRAL))
+                    if (((kv.Value.Team == team) || (kv.Value is IRegion && kv.Value.Team == TeamId.TEAM_NEUTRAL))
                         && Vector2.DistanceSquared(kv.Value.Position, o.Position) < kv.Value.VisionRadius * kv.Value.VisionRadius
                         && !_game.Map.NavigationGrid.IsAnythingBetween(kv.Value, o, true))
                     {
                         var unit = kv.Value as IAttackableUnit;
                         if (unit == null || !unit.IsDead)
+                        {
+                            return true;
+                        }
+                        else if (kv.Value is IRegion region)
                         {
                             return true;
                         }

--- a/GameServerLib/Packets/PacketHandlers/HandleMove.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleMove.cs
@@ -27,7 +27,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
         {
             var peerInfo = _playerManager.GetPeerInfo(userId);
             var champion = peerInfo?.Champion;
-            if (peerInfo == null)
+            if (peerInfo == null || champion.MovementParameters != null)
             {
                 return true;
             }

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -73,7 +73,6 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 }
                 else if (kv.Value is ILaneTurret turret)
                 {
-                    new Region(_game, turret.Team, turret.Position, RegionType.Default, turret, turret, true, 800f, true, true, turret.PathfindingRadius, lifetime: 25000.0f);
                     _game.PacketNotifier.NotifyS2C_CreateTurret(turret, userId);
                 }
                 else if (kv.Value is INexus nexus)

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -788,7 +788,7 @@ namespace PacketDefinitions420
                 BuffCount = buffCountList,
                 LookAtPosition = new Vector3(1, 0, 0),
                 // TODO: Verify
-                UnknownIsHero = isChampion,
+                IsHero = isChampion,
                 MovementData = md
             };
 


### PR DESCRIPTION
Dash Events, Region Vision Fix, Attack Cancel Keep Target
* Scripting:
  * Kalista CharScript has been made more in-depth, supporting almost full dash functionality.
  * OnMoveEnd, OnMoveFailure, and OnMoveSuccess events added.
  * Cleaned ApiFunctionManager, moved slot conversions to ConvertAPISlot.
* AttackableUnit:
  * SetDashingState supports a stop reason.
* ObjAiBase:
  * CancelAutoAttack no longer clears target unit when full canceling.
  * SetSpell has had the networked packet changed to match replays (SetSpellData is not used unless the Champion can transform, although there may be other cases).
* Inventory:
  * HasItemWithID has been exposed.
* Region:
  * Actually gives vision now.
  * Is now only created in BaseTurret and via API.
* Packets:
  * Updated LeaguePackets with latest commits. Refer to [LeaguePackets/commits](https://github.com/LeagueSandbox/LeaguePackets/commits/master)
  * HandleMove is now limited by dash state (should really make up my mind about where we centralize these dumb checks).