### PR TITLE
Progress #1281 -- The return of meaning to the `_visionUnits`

### DIFF
--- a/GameServerCore/IObjectManager.cs
+++ b/GameServerCore/IObjectManager.cs
@@ -42,44 +42,20 @@ namespace GameServerCore
         void RemoveObject(IGameObject o);
 
         /// <summary>
-        /// Adds a GameObject of type AttackableUnit to the list of Vision Units in ObjectManager. *NOTE*: Naming conventions of VisionUnits will change to AttackableUnits.
+        /// Adds a GameObject to the list of Vision Providers in ObjectManager.
         /// </summary>
-        /// <param name="unit">AttackableUnit to add.</param>
-        void AddVisionUnit(IAttackableUnit unit);
+        /// <param name="obj">GameObject to add.</param>
+        /// <param name="team">The team that GameObject can provide vision to.</param>
+        public void AddVisionProvider(IGameObject obj, TeamId team);
 
         /// <summary>
-        /// Gets a new Dictionary containing all GameObjects of type AttackableUnit contained in the list of Vision Units in ObjectManager.
+        /// Removes a GameObject from the list of Vision Providers in ObjectManager.
         /// </summary>
-        /// <returns>Dictionary of (NetID, AttackableUnit) pairs.</returns>
-        Dictionary<uint, IAttackableUnit> GetVisionUnits();
+        /// <param name="obj">GameObject to remove.</param>
+        /// <param name="team">The team that GameObject provided vision to.</param>
+        public void RemoveVisionProvider(IGameObject obj, TeamId team);
 
-        /// <summary>
-        /// Gets a new Dictionary containing all GameObjects of type AttackableUnit of the specified team contained in the list of Vision Units in ObjectManager.
-        /// </summary>
-        /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
-        /// <returns>Dictionary of NetID,AttackableUnit pairs that belong to the specified team.</returns>
-        Dictionary<uint, IAttackableUnit> GetVisionUnits(TeamId team);
-
-        /// <summary>
-        /// Whether or not a specified GameObject is being networked to the specified team.
-        /// </summary>
-        /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
-        /// <param name="o">GameObject to check.</param>
-        /// <returns>true/false; networked or not.</returns>
         bool TeamHasVisionOn(TeamId team, IGameObject o);
-
-        /// <summary>
-        /// Removes a GameObject of type AttackableUnit from the list of Vision Units in ObjectManager. *NOTE*: Naming conventions of VisionUnits will change to AttackableUnits.
-        /// </summary>
-        /// <param name="unit">AttackableUnit to remove.</param>
-        void RemoveVisionUnit(IAttackableUnit unit);
-
-        /// <summary>
-        /// Removes a GameObject of type AttackableUnit from the list of Vision Units in ObjectManager via the AttackableUnit's NetID and team.
-        /// </summary>
-        /// <param name="team">Team of the AttackableUnit.</param>
-        /// <param name="netId">NetID of the AttackableUnit.</param>
-        void RemoveVisionUnit(TeamId team, uint netId);
 
         /// <summary>
         /// Gets a list of all GameObjects of type AttackableUnit that are within a certain distance from a specified position.

--- a/GameServerCore/IObjectManager.cs
+++ b/GameServerCore/IObjectManager.cs
@@ -46,14 +46,14 @@ namespace GameServerCore
         /// </summary>
         /// <param name="obj">GameObject to add.</param>
         /// <param name="team">The team that GameObject can provide vision to.</param>
-        public void AddVisionProvider(IGameObject obj, TeamId team);
+        void AddVisionProvider(IGameObject obj, TeamId team);
 
         /// <summary>
         /// Removes a GameObject from the list of Vision Providers in ObjectManager.
         /// </summary>
         /// <param name="obj">GameObject to remove.</param>
         /// <param name="team">The team that GameObject provided vision to.</param>
-        public void RemoveVisionProvider(IGameObject obj, TeamId team);
+        void RemoveVisionProvider(IGameObject obj, TeamId team);
 
         bool TeamHasVisionOn(TeamId team, IGameObject o);
 

--- a/GameServerLib/Chatbox/Commands/TpCommand.cs
+++ b/GameServerLib/Chatbox/Commands/TpCommand.cs
@@ -30,7 +30,16 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
             if (split.Length > 3 && uint.TryParse(split[1], out targetNetID) && float.TryParse(split[2], out x) && float.TryParse(split[3], out y))
             {
-                Game.ObjectManager.GetObjectById(targetNetID).TeleportTo(x, y);
+                var obj = Game.ObjectManager.GetObjectById(targetNetID);
+                if (obj != null)
+                {
+                    obj.TeleportTo(x, y);
+                }
+                else
+                {
+                    ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.SYNTAXERROR, "An object with the netID: " + targetNetID + " was not found.");
+                    ShowSyntax();
+                }
             }
             else if (float.TryParse(split[1], out x) && float.TryParse(split[2], out y))
             {

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -132,7 +132,20 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public override void OnAdded()
         {
             base.OnAdded();
-            _game.ObjectManager.AddVisionUnit(this);
+            _game.ObjectManager.AddVisionProvider(this, Team);
+        }
+
+        public override void OnRemoved()
+        {
+            base.OnRemoved();
+            _game.ObjectManager.RemoveVisionProvider(this, Team);
+        }
+
+        public override void SetTeam(TeamId team)
+        {
+            _game.ObjectManager.RemoveVisionProvider(this, Team);
+            base.SetTeam(team);
+            _game.ObjectManager.AddVisionProvider(this, Team);
         }
 
         /// <summary>
@@ -229,12 +242,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
 
             UpdateStatus();
-        }
-
-        public override void OnRemoved()
-        {
-            base.OnRemoved();
-            _game.ObjectManager.RemoveVisionUnit(this);
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -228,7 +228,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// Sets the object's team.
         /// </summary>
         /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
-        public void SetTeam(TeamId team)
+        public virtual void SetTeam(TeamId team)
         {
             _visibleByTeam[Team] = false;
             Team = team;

--- a/GameServerLib/GameObjects/Region.cs
+++ b/GameServerLib/GameObjects/Region.cs
@@ -119,9 +119,52 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         public override void OnAdded()
         {
+            RegisterVision();
             if (HasCollision)
             {
                 _game.Map.CollisionHandler.AddObject(this);
+            }
+        }
+
+        public override void OnRemoved()
+        {
+            UnregisterVision();
+            if(HasCollision)
+            {
+                _game.Map.CollisionHandler.RemoveObject(this);
+            }
+        }
+
+        public override void SetTeam(TeamId team)
+        {
+            UnregisterVision();
+            base.SetTeam(team);
+            RegisterVision();
+        }
+
+        void RegisterVision()
+        {
+            if(Team == TeamId.TEAM_NEUTRAL)
+            {
+                _game.ObjectManager.AddVisionProvider(this, TeamId.TEAM_BLUE);
+                _game.ObjectManager.AddVisionProvider(this, TeamId.TEAM_PURPLE);
+            }
+            else
+            {
+                _game.ObjectManager.AddVisionProvider(this, Team);
+            }
+        }
+
+        void UnregisterVision()
+        {
+            if(Team == TeamId.TEAM_NEUTRAL)
+            {
+                _game.ObjectManager.RemoveVisionProvider(this, TeamId.TEAM_BLUE);
+                _game.ObjectManager.RemoveVisionProvider(this, TeamId.TEAM_PURPLE);
+            }
+            else
+            {
+                _game.ObjectManager.RemoveVisionProvider(this, Team);
             }
         }
 

--- a/GameServerLib/GameObjects/Region.cs
+++ b/GameServerLib/GameObjects/Region.cs
@@ -144,7 +144,8 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         void RegisterVision()
         {
-            if(Team == TeamId.TEAM_NEUTRAL)
+            // NEUTRAL Regions give global vision.
+            if (Team == TeamId.TEAM_NEUTRAL)
             {
                 _game.ObjectManager.AddVisionProvider(this, TeamId.TEAM_BLUE);
                 _game.ObjectManager.AddVisionProvider(this, TeamId.TEAM_PURPLE);
@@ -157,7 +158,7 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         void UnregisterVision()
         {
-            if(Team == TeamId.TEAM_NEUTRAL)
+            if (Team == TeamId.TEAM_NEUTRAL)
             {
                 _game.ObjectManager.RemoveVisionProvider(this, TeamId.TEAM_BLUE);
                 _game.ObjectManager.RemoveVisionProvider(this, TeamId.TEAM_PURPLE);


### PR DESCRIPTION
During the optimizations, `_visionUnits` and all the infrastructure associated with them were left unused, probably due to the fact that they were not used as originally intended from the very beginning. Instead, the concept of `_visionProviders` has been introduced - units that can, under certain circumstances, provide a view of the unit to their team. Now they are used when determining whether a command can see a unit, which reduces the cost of iterating over all `_objects`. The right to provide vision is assigned to `IAttackableUnit`s and `Region`s, with the proviso that `TEAM_NEUTRAL` regions provide vision to both teams