### PR TITLE
Turret Cleanup

### DIFF
--- a/Content/LeagueSandbox-Scripts/Maps/Map1/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/CLASSIC.cs
@@ -263,9 +263,9 @@ namespace MapScripts.Map1
         }
 
         List<IMonsterCamp> MonsterCamps = new List<IMonsterCamp>();
-        Dictionary<TeamId, List<IChampion>> Players = new Dictionary<TeamId, List<IChampion>>();
         IStatsModifier TurretStatsModifier = new StatsModifier();
         IStatsModifier OuterTurretStatsModifier = new StatsModifier();
+        Dictionary<TeamId, List<IChampion>> Players = new Dictionary<TeamId, List<IChampion>>();
         public virtual void OnMatchStart()
         {
             foreach (var nexus in _map.NexusList)
@@ -276,6 +276,7 @@ namespace MapScripts.Map1
             Players.Add(TeamId.TEAM_BLUE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_BLUE));
             Players.Add(TeamId.TEAM_PURPLE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_PURPLE));
 
+            IStatsModifier TurretHealthModifier = new StatsModifier();
             foreach (var team in _map.TurretList.Keys)
             {
                 TeamId enemyTeam = TeamId.TEAM_BLUE;
@@ -293,15 +294,17 @@ namespace MapScripts.Map1
                         {
                             continue;
                         }
-
-                        var healthToAdd = 250.0f * Players[enemyTeam].Count;
-                        if (turret.Type == TurretType.NEXUS_TURRET)
+                        else if (turret.Type != TurretType.NEXUS_TURRET)
                         {
-                            healthToAdd /= 2;
+                            TurretHealthModifier.HealthPoints.BaseBonus = 250.0f * Players[enemyTeam].Count;
+                        }
+                        else
+                        {
+                            TurretHealthModifier.HealthPoints.BaseBonus = 125.0f * Players[enemyTeam].Count;
                         }
 
-                        turret.Stats.HealthPoints.BaseValue += healthToAdd;
-                        turret.Stats.CurrentHealth += healthToAdd;
+                        turret.AddStatModifier(TurretHealthModifier);
+                        turret.Stats.CurrentHealth += turret.Stats.HealthPoints.Total;
                     }
                 }
             }

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/CLASSIC.cs
@@ -9,6 +9,7 @@ using LeagueSandbox.GameServer.Content;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using LeagueSandbox.GameServer.API;
+using LeagueSandbox.GameServer.GameObjects.Stats;
 
 namespace MapScripts.Map1
 {
@@ -262,12 +263,57 @@ namespace MapScripts.Map1
         }
 
         List<IMonsterCamp> MonsterCamps = new List<IMonsterCamp>();
+        Dictionary<TeamId, List<IChampion>> Players = new Dictionary<TeamId, List<IChampion>>();
+        IStatsModifier TurretStatsModifier = new StatsModifier();
+        IStatsModifier OuterTurretStatsModifier = new StatsModifier();
         public virtual void OnMatchStart()
         {
             foreach (var nexus in _map.NexusList)
             {
                 ApiEventManager.OnDeath.AddListener(this, nexus, OnNexusDeath, true);
             }
+
+            Players.Add(TeamId.TEAM_BLUE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_BLUE));
+            Players.Add(TeamId.TEAM_PURPLE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_PURPLE));
+
+            foreach (var team in _map.TurretList.Keys)
+            {
+                TeamId enemyTeam = TeamId.TEAM_BLUE;
+
+                if (team == TeamId.TEAM_BLUE)
+                {
+                    enemyTeam = TeamId.TEAM_PURPLE;
+                }
+
+                foreach (var lane in _map.TurretList[team].Keys)
+                {
+                    foreach (var turret in _map.TurretList[team][lane])
+                    {
+                        if (turret.Type == TurretType.FOUNTAIN_TURRET)
+                        {
+                            continue;
+                        }
+
+                        var healthToAdd = 250.0f * Players[enemyTeam].Count;
+                        if (turret.Type == TurretType.NEXUS_TURRET)
+                        {
+                            healthToAdd /= 2;
+                        }
+
+                        turret.Stats.HealthPoints.BaseValue += healthToAdd;
+                        turret.Stats.CurrentHealth += healthToAdd;
+                    }
+                }
+            }
+
+            TurretStatsModifier.Armor.FlatBonus = 1;
+            TurretStatsModifier.MagicResist.FlatBonus = 1;
+            TurretStatsModifier.AttackDamage.FlatBonus = 4;
+
+            //Outer turrets dont get armor
+            OuterTurretStatsModifier.MagicResist.FlatBonus = 1;
+            OuterTurretStatsModifier.AttackDamage.FlatBonus = 4;
+
             SetupJungleCamps();
         }
 
@@ -297,10 +343,63 @@ namespace MapScripts.Map1
                 CheckInitialMapAnnouncements(gameTime);
             }
 
+            if (gameTime >= timeCheck && timesApplied < 30)
+            {
+                UpdateTowerStats();
+            }
+            if(gameTime >= outerTurretTimeCheck && outerTurretTimesApplied < 7)
+            {
+                UpdateOuterTurretStats();
+            }
+
             if (forceSpawn)
             {
                 forceSpawn = false;
             }
+        }
+
+        float timeCheck = 480.0f * 1000;
+        byte timesApplied = 0;
+        public void UpdateTowerStats()
+        {
+            foreach (var team in _map.TurretList.Keys)
+            {
+                foreach (var lane in _map.TurretList[team].Keys)
+                {
+                    foreach (var turret in _map.TurretList[team][lane])
+                    {
+                        if (turret.Type == TurretType.OUTER_TURRET || turret.Type == TurretType.FOUNTAIN_TURRET || (turret.Type == TurretType.INNER_TURRET && timesApplied >= 20))
+                        {
+                            continue;
+                        }
+
+                        turret.AddStatModifier(TurretStatsModifier);
+                    } 
+                }
+            }
+
+            timesApplied++;
+            timeCheck += 60.0f * 1000;
+        }
+
+        float outerTurretTimeCheck = 30.0f * 1000;
+        byte outerTurretTimesApplied = 0;
+        public void UpdateOuterTurretStats()
+        {
+            foreach (var team in _map.TurretList.Keys)
+            {
+                foreach (var lane in _map.TurretList[team].Keys)
+                {
+                    var turret = _map.TurretList[team][lane].Find(x => x.Type == TurretType.OUTER_TURRET);
+
+                    if(turret != null)
+                    {
+                        turret.AddStatModifier(OuterTurretStatsModifier);
+                    }
+                }
+            }
+            outerTurretTimesApplied++;
+            outerTurretTimeCheck += 60.0f * 1000;
         }
 
         public float GetRespawnTimer(IMonsterCamp monsterCamp)

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/CLASSIC.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/CLASSIC.cs
@@ -8,6 +8,7 @@ using GameServerCore.Maps;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.Content;
+using LeagueSandbox.GameServer.GameObjects.Stats;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 
 namespace MapScripts.Map10
@@ -223,6 +224,7 @@ namespace MapScripts.Map10
         }
 
         public List<IMonsterCamp> MonsterCamps = new List<IMonsterCamp>();
+        IStatsModifier TurretStatsModifier = new StatsModifier();
         public void OnMatchStart()
         {
             foreach (var nexus in _map.NexusList)
@@ -230,6 +232,10 @@ namespace MapScripts.Map10
                 ApiEventManager.OnDeath.AddListener(this, nexus, OnNexusDeath, true);
             }
             SetupJungleCamps();
+
+            TurretStatsModifier.Armor.FlatBonus = 1;
+            TurretStatsModifier.MagicResist.FlatBonus = 1;
+            TurretStatsModifier.AttackDamage.FlatBonus = 4;
         }
 
         //This function gets executed every server tick
@@ -248,15 +254,45 @@ namespace MapScripts.Map10
                 }
             }
 
+            float gameTime = _map.GameTime();
             if (!AllAnnouncementsAnnounced)
             {
-                CheckInitialMapAnnouncements(_map.GameTime());
+                CheckInitialMapAnnouncements(gameTime);
+            }
+
+            if (gameTime >= timeCheck && timesApplied < 30)
+            {
+                UpdateTowerStats();
             }
 
             if (forceSpawn)
             {
                 forceSpawn = false;
             }
+        }
+
+        float timeCheck = 480.0f * 1000;
+        byte timesApplied = 0;
+        public void UpdateTowerStats()
+        {
+            foreach (var team in _map.TurretList.Keys)
+            {
+                foreach (var lane in _map.TurretList[team].Keys)
+                {
+                    foreach (var turret in _map.TurretList[team][lane])
+                    {
+                        if (turret.Type == TurretType.FOUNTAIN_TURRET || ((turret.Type != TurretType.NEXUS_TURRET) && timesApplied >= 20))
+                        {
+                            continue;
+                        }
+
+                        turret.AddStatModifier(TurretStatsModifier);
+                    }
+                }
+            }
+
+            timesApplied++;
+            timeCheck += 60.0f * 1000;
         }
 
         public float GetRespawnTimer(IMonsterCamp monsterCamp)

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/ARAM.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/ARAM.cs
@@ -259,8 +259,8 @@ namespace MapScripts.Map12
         }
 
         public List<IMonsterCamp> HealthPacks = new List<IMonsterCamp>();
-        Dictionary<TeamId, List<IChampion>> Players = new Dictionary<TeamId, List<IChampion>>();
         IStatsModifier TurretStatsModifier = new StatsModifier();
+        Dictionary<TeamId, List<IChampion>> Players = new Dictionary<TeamId, List<IChampion>>();
         public void OnMatchStart()
         {
             foreach (var nexus in _map.NexusList)
@@ -271,6 +271,7 @@ namespace MapScripts.Map12
             Players.Add(TeamId.TEAM_BLUE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_BLUE));
             Players.Add(TeamId.TEAM_PURPLE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_PURPLE));
 
+            IStatsModifier TurretHealthModifier = new StatsModifier();
             foreach (var team in _map.TurretList.Keys)
             {
                 TeamId enemyTeam = TeamId.TEAM_BLUE;
@@ -279,6 +280,8 @@ namespace MapScripts.Map12
                 {
                     enemyTeam = TeamId.TEAM_PURPLE;
                 }
+
+                TurretHealthModifier.HealthPoints.BaseBonus = 250.0f * Players[enemyTeam].Count;
 
                 foreach (var lane in _map.TurretList[team].Keys)
                 {
@@ -289,10 +292,8 @@ namespace MapScripts.Map12
                             continue;
                         }
 
-                        var healthToAdd = 250.0f * Players[enemyTeam].Count;
-
-                        turret.Stats.HealthPoints.BaseValue += healthToAdd;
-                        turret.Stats.CurrentHealth += healthToAdd;
+                        turret.AddStatModifier(TurretHealthModifier);
+                        turret.Stats.CurrentHealth += turret.Stats.HealthPoints.Total;
                     }
                 }
             }

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/ARAM.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/ARAM.cs
@@ -8,6 +8,7 @@ using GameServerCore.Maps;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.Content;
+using LeagueSandbox.GameServer.GameObjects.Stats;
 using LeagueSandbox.GameServer.Logging;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using log4net;
@@ -78,16 +79,16 @@ namespace MapScripts.Map12
             {TeamId.TEAM_BLUE, new Dictionary<TurretType, string>
             {
                 {TurretType.FOUNTAIN_TURRET, "HA_AP_OrderShrineTurret" },
-                {TurretType.NEXUS_TURRET, "HA_AP_OrderTurret" },
+                {TurretType.NEXUS_TURRET, "HA_AP_OrderTurret3" },
                 {TurretType.INHIBITOR_TURRET, "HA_AP_OrderTurret2" },
-                {TurretType.INNER_TURRET, "HA_AP_OrderTurret3" },
+                {TurretType.INNER_TURRET, "HA_AP_OrderTurret" },
             } },
             {TeamId.TEAM_PURPLE, new Dictionary<TurretType, string>
             {
                 {TurretType.FOUNTAIN_TURRET, "HA_AP_ChaosTurretShrine" },
-                {TurretType.NEXUS_TURRET, "HA_AP_ChaosTurret" },
+                {TurretType.NEXUS_TURRET, "HA_AP_ChaosTurret3" },
                 {TurretType.INHIBITOR_TURRET, "HA_AP_ChaosTurret2" },
-                {TurretType.INNER_TURRET, "HA_AP_ChaosTurret3" },
+                {TurretType.INNER_TURRET, "HA_AP_ChaosTurret" },
             } }
         };
 
@@ -258,12 +259,47 @@ namespace MapScripts.Map12
         }
 
         public List<IMonsterCamp> HealthPacks = new List<IMonsterCamp>();
+        Dictionary<TeamId, List<IChampion>> Players = new Dictionary<TeamId, List<IChampion>>();
+        IStatsModifier TurretStatsModifier = new StatsModifier();
         public void OnMatchStart()
         {
             foreach (var nexus in _map.NexusList)
             {
                 ApiEventManager.OnDeath.AddListener(this, nexus, OnNexusDeath, true);
             }
+
+            Players.Add(TeamId.TEAM_BLUE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_BLUE));
+            Players.Add(TeamId.TEAM_PURPLE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_PURPLE));
+
+            foreach (var team in _map.TurretList.Keys)
+            {
+                TeamId enemyTeam = TeamId.TEAM_BLUE;
+
+                if (team == TeamId.TEAM_BLUE)
+                {
+                    enemyTeam = TeamId.TEAM_PURPLE;
+                }
+
+                foreach (var lane in _map.TurretList[team].Keys)
+                {
+                    foreach (var turret in _map.TurretList[team][lane])
+                    {
+                        if (turret.Type == TurretType.FOUNTAIN_TURRET)
+                        {
+                            continue;
+                        }
+
+                        var healthToAdd = 250.0f * Players[enemyTeam].Count;
+
+                        turret.Stats.HealthPoints.BaseValue += healthToAdd;
+                        turret.Stats.CurrentHealth += healthToAdd;
+                    }
+                }
+            }
+
+            TurretStatsModifier.Armor.FlatBonus = 1;
+            TurretStatsModifier.MagicResist.FlatBonus = 1;
+            TurretStatsModifier.AttackDamage.FlatBonus = 6;
 
             var purple_healthPacket1 = _map.CreateJungleCamp(new Vector3(7582.1f, 60.0f, 6785.5f), 1, TeamId.TEAM_NEUTRAL, "HealthPack", 190.0f * 1000f);
             _map.CreateJungleMonster("HA_AP_HealthRelic1.1.1", "HA_AP_HealthRelic", new Vector2(7582.1f, 6785.5f), new Vector3(7582.1f, -193.8f, 6785.5f), purple_healthPacket1);
@@ -322,15 +358,45 @@ namespace MapScripts.Map12
                 }
             }
 
+            var gameTime = _map.GameTime();
             if (!AllAnnouncementsAnnounced)
             {
-                CheckMapInitialAnnouncements(_map.GameTime());
+                CheckMapInitialAnnouncements(gameTime);
+            }
+
+            if (gameTime >= timeCheck && timesApplied < 10)
+            {
+                UpdateTowerStats();
             }
 
             if (forceSpawn)
             {
                 forceSpawn = false;
             }
+        }
+
+        float timeCheck = 0.0f * 1000;
+        byte timesApplied = 0;
+        public void UpdateTowerStats()
+        {
+            foreach (var team in _map.TurretList.Keys)
+            {
+                foreach (var lane in _map.TurretList[team].Keys)
+                {
+                    foreach (var turret in _map.TurretList[team][lane])
+                    {
+                        if (turret.Type == TurretType.NEXUS_TURRET || turret.Type == TurretType.FOUNTAIN_TURRET)
+                        {
+                            continue;
+                        }
+
+                        turret.AddStatModifier(TurretStatsModifier);
+                    }
+                }
+            }
+
+            timesApplied++;
+            timeCheck += 60.0f * 1000;
         }
 
         public void OnNexusDeath(IDeathData deathaData)

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/ARAM.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/ARAM.cs
@@ -364,7 +364,7 @@ namespace MapScripts.Map12
                 CheckMapInitialAnnouncements(gameTime);
             }
 
-            if (gameTime >= timeCheck && timesApplied < 10)
+            if (gameTime >= timeCheck && timesApplied < 8)
             {
                 UpdateTowerStats();
             }
@@ -385,7 +385,7 @@ namespace MapScripts.Map12
                 {
                     foreach (var turret in _map.TurretList[team][lane])
                     {
-                        if (turret.Type == TurretType.NEXUS_TURRET || turret.Type == TurretType.FOUNTAIN_TURRET)
+                        if (turret.Type == TurretType.FOUNTAIN_TURRET)
                         {
                             continue;
                         }

--- a/GameServerCore/Domain/GameObjects/IChampion.cs
+++ b/GameServerCore/Domain/GameObjects/IChampion.cs
@@ -10,6 +10,7 @@
         byte SkillPoints { get; set; }
 
         // basic
+        void AddGold(IAttackableUnit source, float gold, bool notify = true);
         void UpdateSkin(int skinNo);
         uint GetPlayerId();
         void AddExperience(float experience, bool notify = true);

--- a/GameServerCore/Domain/ICharData.cs
+++ b/GameServerCore/Domain/ICharData.cs
@@ -5,40 +5,43 @@ namespace GameServerCore.Domain
     public interface ICharData
     {
         IGlobalData GlobalCharData { get; }
-        float BaseHp { get; }
-        float BaseMp { get; }
-        float BaseDamage { get; }
-        float AttackRange { get; }
-        int MoveSpeed { get; }
+        float AcquisitionRange { get; }
         float Armor { get; }
-        float SpellBlock { get; }
-        float BaseStaticHpRegen { get; }
-        float BaseStaticMpRegen { get; }
-        float[] AttackDelayOffsetPercent { get; }
+        float ArmorPerLevel { get; }
         float[] AttackDelayCastOffsetPercent { get; }
         float[] AttackDelayCastOffsetPercentAttackSpeedRatio { get; }
-        float HpPerLevel { get; }
-        float MpPerLevel { get; }
-        float DamagePerLevel { get; }
-        float ArmorPerLevel { get; }
-        float SpellBlockPerLevel { get; }
-        float HpRegenPerLevel { get; }
-        float MpRegenPerLevel { get; }
-        float AttackSpeedPerLevel { get; }
-        bool IsMelee { get; } //Yes or no
-        float PathfindingCollisionRadius { get; }
-        float PerceptionBubbleRadius { get; }
-        float GameplayCollisionRadius { get; }
-        float AcquisitionRange { get; }
-        PrimaryAbilityResourceType ParType { get; }
-        string[] SpellNames { get; }
-        int[] MaxLevels { get; }
-        int[][] SpellsUpLevels { get; }
+        float[] AttackDelayOffsetPercent { get; }
         string[] AttackNames { get; }
         float[] AttackProbabilities { get; }
+        float AttackRange { get; }
+        float AttackSpeedPerLevel { get; }
+        float BaseDamage { get; }
+        float BaseHp { get; }
+        float BaseMp { get; }
+        float BaseStaticHpRegen { get; }
+        float BaseStaticMpRegen { get; }
+        float DamagePerLevel { get; }
+        float GameplayCollisionRadius { get; }
+        float GlobalExpGivenOnDeath { get; }
+        float GlobalGoldGivenOnDeath { get; }
+        float HpPerLevel { get; }
+        float HpRegenPerLevel { get; }
+        bool IsMelee { get; } //Yes or no
+        float LocalGoldGivenOnDeath { get; }
+        int MoveSpeed { get; }
+        float MpPerLevel { get; }
+        float MpRegenPerLevel { get; }
+        PrimaryAbilityResourceType ParType { get; }
+        IPassiveData PassiveData { get; }
+        float PathfindingCollisionRadius { get; }
+        float PerceptionBubbleRadius { get; }
+        float SpellBlock { get; }
+        float SpellBlockPerLevel { get; }
+        string[] SpellNames { get; }
+        int[][] SpellsUpLevels { get; }
+        int[] MaxLevels { get; }
         string[] ExtraSpells { get; }
         // TODO: Verify if we want this to be an array.
-        IPassiveData PassiveData { get; }
         void Load(string name);
     }
 }

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -1028,10 +1028,5 @@ namespace LeagueSandbox.GameServer.API
         {
             return _game.Map.NavigationGrid.GetPath(from, to, distanceThreshold);
         }
-
-        public static float GetGameTime()
-        {
-            return _game.GameTime;
-        }
     }
 }

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -646,15 +646,7 @@ namespace LeagueSandbox.GameServer.API
         //Consider changing this to take bots into account too
         public static List<IChampion> GetAllPlayersFromTeam(TeamId team)
         {
-            var toreturn = new List<IChampion>();
-            foreach (var player in _game.PlayerManager.GetPlayers(true))
-            {
-                if(player.Item2.Team == team)
-                {
-                    toreturn.Add(player.Item2.Champion);
-                }
-            }
-            return toreturn;
+            return _game.ObjectManager.GetAllChampionsFromTeam(team);
         }
 
         /// <summary>

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -549,7 +549,7 @@ namespace LeagueSandbox.GameServer.API
         {
             return _game.ObjectManager.GetChampionsInRange(targetPos, range, isAlive);
         }
-        
+
         /// <summary>
         /// Counts the number of units attacking a specified GameObject of type AttackableUnit.
         /// </summary>
@@ -572,6 +572,20 @@ namespace LeagueSandbox.GameServer.API
             foreach (var player in _game.PlayerManager.GetPlayers(true))
             {
                 toreturn.Add(player.Item2.Champion);
+            }
+            return toreturn;
+        }
+
+        //Consider changing this to take bots into account too
+        public static List<IChampion> GetAllPlayersFromTeam(TeamId team)
+        {
+            var toreturn = new List<IChampion>();
+            foreach (var player in _game.PlayerManager.GetPlayers(true))
+            {
+                if(player.Item2.Team == team)
+                {
+                    toreturn.Add(player.Item2.Champion);
+                }
             }
             return toreturn;
         }
@@ -1013,6 +1027,11 @@ namespace LeagueSandbox.GameServer.API
         public static List<Vector2> GetPath(Vector2 from, Vector2 to, float distanceThreshold = 0)
         {
             return _game.Map.NavigationGrid.GetPath(from, to, distanceThreshold);
+        }
+
+        public static float GetGameTime()
+        {
+            return _game.GameTime;
         }
     }
 }

--- a/GameServerLib/Content/CharData.cs
+++ b/GameServerLib/Content/CharData.cs
@@ -33,32 +33,35 @@ namespace LeagueSandbox.GameServer.Content
 
         public IGlobalData GlobalCharData { get; private set; } = new GlobalData();
 
-        public float BaseHp { get; private set; } = 100.0f;
-        public float BaseMp { get; private set; } = 100.0f;
-        public float BaseDamage { get; private set; } = 10.0f;
-        public float AttackRange { get; private set; } = 100.0f;
-        public int MoveSpeed { get; private set; } = 100;
+        public float AcquisitionRange { get; private set; } = 475;
         public float Armor { get; private set; } = 1.0f;
-        public float SpellBlock { get; private set; }
-        public float BaseStaticHpRegen { get; private set; } = 0.30000001f;
-        public float BaseStaticMpRegen { get; private set; } = 0.30000001f;
-        public float[] AttackDelayOffsetPercent { get; private set; } = new float[18];
+        public float ArmorPerLevel { get; private set; } = 1.0f;
         public float[] AttackDelayCastOffsetPercent { get; private set; } = new float[18];
         public float[] AttackDelayCastOffsetPercentAttackSpeedRatio { get; private set; } = new float[18];
-        public float HpPerLevel { get; private set; } = 10.0f;
-        public float MpPerLevel { get; private set; } = 10.0f;
-        public float DamagePerLevel { get; private set; } = 10.0f;
-        public float ArmorPerLevel { get; private set; } = 1.0f;
-        public float SpellBlockPerLevel { get; private set; }
-        public float HpRegenPerLevel { get; private set; }
-        public float MpRegenPerLevel { get; private set; }
+        public float[] AttackDelayOffsetPercent { get; private set; } = new float[18];
+        public float AttackRange { get; private set; } = 100.0f;
         public float AttackSpeedPerLevel { get; private set; }
+        public float BaseDamage { get; private set; } = 10.0f;
+        public float BaseHp { get; private set; } = 100.0f;
+        public float BaseMp { get; private set; } = 100.0f;
+        public float BaseStaticHpRegen { get; private set; } = 0.30000001f;
+        public float BaseStaticMpRegen { get; private set; } = 0.30000001f;
+        public float DamagePerLevel { get; private set; } = 10.0f;
+        public float GameplayCollisionRadius { get; private set; } = 65.0f;
+        public float GlobalExpGivenOnDeath { get; private set; } = 0.0f;
+        public float GlobalGoldGivenOnDeath { get; private set; } = 0.0f;
+        public float HpPerLevel { get; private set; } = 10.0f;
+        public float HpRegenPerLevel { get; private set; }
         public bool IsMelee { get; private set; } //Yes or no
+        public float LocalGoldGivenOnDeath { get; private set; } = 0.0f;
+        public int MoveSpeed { get; private set; } = 100;
+        public float MpPerLevel { get; private set; } = 10.0f;
+        public float MpRegenPerLevel { get; private set; }
+        public PrimaryAbilityResourceType ParType { get; private set; } = PrimaryAbilityResourceType.MANA;
         public float PathfindingCollisionRadius { get; private set; } = -1.0f;
         public float PerceptionBubbleRadius { get; private set; } = 0.0f;
-        public float GameplayCollisionRadius { get; private set; } = 65.0f;
-        public float AcquisitionRange { get; private set; } = 475;
-        public PrimaryAbilityResourceType ParType { get; private set; } = PrimaryAbilityResourceType.MANA;
+        public float SpellBlock { get; private set; }
+        public float SpellBlockPerLevel { get; private set; }
 
         public string[] SpellNames { get; private set; } = new string[4];
         public string[] ExtraSpells { get; private set; } = new string[16];
@@ -98,28 +101,32 @@ namespace LeagueSandbox.GameServer.Content
                 return;
             }
 
+            AcquisitionRange = file.GetFloat("Data", "AcquisitionRange", AcquisitionRange);
+            Armor = file.GetFloat("Data", "Armor", Armor);
+            ArmorPerLevel = file.GetFloat("Data", "ArmorPerLevel", ArmorPerLevel);
+            AttackRange = file.GetFloat("Data", "AttackRange", AttackRange);
+            AttackSpeedPerLevel = file.GetFloat("Data", "AttackSpeedPerLevel", AttackSpeedPerLevel);
+            BaseDamage = file.GetFloat("Data", "BaseDamage", BaseDamage);
             BaseHp = file.GetFloat("Data", "BaseHP", BaseHp);
             BaseMp = file.GetFloat("Data", "BaseMP", BaseMp);
-            BaseDamage = file.GetFloat("Data", "BaseDamage", BaseDamage);
-            AttackRange = file.GetFloat("Data", "AttackRange", AttackRange);
-            MoveSpeed = file.GetInt("Data", "MoveSpeed", MoveSpeed);
-            Armor = file.GetFloat("Data", "Armor", Armor);
-            SpellBlock = file.GetFloat("Data", "SpellBlock", SpellBlock);
             BaseStaticHpRegen = file.GetFloat("Data", "BaseStaticHPRegen", BaseStaticHpRegen);
             BaseStaticMpRegen = file.GetFloat("Data", "BaseStaticMPRegen", BaseStaticMpRegen);
-            HpPerLevel = file.GetFloat("Data", "HPPerLevel", HpPerLevel);
-            MpPerLevel = file.GetFloat("Data", "MPPerLevel", MpPerLevel);
             DamagePerLevel = file.GetFloat("Data", "DamagePerLevel", DamagePerLevel);
-            ArmorPerLevel = file.GetFloat("Data", "ArmorPerLevel", ArmorPerLevel);
-            SpellBlockPerLevel = file.GetFloat("Data", "SpellBlockPerLevel", SpellBlockPerLevel);
+            GameplayCollisionRadius = file.GetFloat("Data", "GameplayCollisionRadius", GameplayCollisionRadius);
+            GlobalExpGivenOnDeath = file.GetFloat("Data", "GlobalExpGivenOnDeath", GlobalExpGivenOnDeath);
+            GlobalGoldGivenOnDeath = file.GetFloat("Data", "GlobalGoldGivenOnDeath", GlobalGoldGivenOnDeath);
             HpRegenPerLevel = file.GetFloat("Data", "HPRegenPerLevel", HpRegenPerLevel);
-            MpRegenPerLevel = file.GetFloat("Data", "MPRegenPerLevel", MpRegenPerLevel);
-            AttackSpeedPerLevel = file.GetFloat("Data", "AttackSpeedPerLevel", AttackSpeedPerLevel);
+            HpPerLevel = file.GetFloat("Data", "HPPerLevel", HpPerLevel);
             IsMelee = file.GetString("Data", "IsMelee", IsMelee ? "true" : "false").Equals("true");
+            LocalGoldGivenOnDeath = file.GetFloat("Data", "LocalGoldGivenOnDeath", LocalGoldGivenOnDeath);
+            MoveSpeed = file.GetInt("Data", "MoveSpeed", MoveSpeed);
+            MpRegenPerLevel = file.GetFloat("Data", "MPRegenPerLevel", MpRegenPerLevel);
+            MpPerLevel = file.GetFloat("Data", "MPPerLevel", MpPerLevel);
             PathfindingCollisionRadius = file.GetFloat("Data", "PathfindingCollisionRadius", PathfindingCollisionRadius);
             PerceptionBubbleRadius = file.GetFloat("Data", "PerceptionBubbleRadius", PerceptionBubbleRadius);
-            GameplayCollisionRadius = file.GetFloat("Data", "GameplayCollisionRadius", GameplayCollisionRadius);
-            AcquisitionRange = file.GetFloat("Data", "AcquisitionRange", AcquisitionRange);
+            SpellBlock = file.GetFloat("Data", "SpellBlock", SpellBlock);
+            SpellBlockPerLevel = file.GetFloat("Data", "SpellBlockPerLevel", SpellBlockPerLevel);
+
             Enum.TryParse<PrimaryAbilityResourceType>(file.GetString("Data", "PARType", ParType.ToString()),
                 out var tempPar);
             ParType = tempPar;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
@@ -18,9 +18,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
     /// </summary>
     public class BaseTurret : ObjAiBase, IBaseTurret
     {
-        protected float _globalGold = 250.0f;
-        protected float _globalExp = 0.0f;
-
         /// <summary>
         /// Current lane this turret belongs to.
         /// </summary>
@@ -49,8 +46,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             IMapObject mapObject = null,
             int skinId = 0,
             string aiScript = ""
-        ) : base(game, model, new Stats.Stats(), 88, position, 1200, skinId, netId, team, aiScript)
+        ) : base(game, model, new Stats.Stats(), position: position, visionRadius: 800, skinId: skinId, netId: netId, team: team, aiScript: aiScript)
         {
+            CollisionRadius = CharData.GameplayCollisionRadius;
             ParentNetId = Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000;
             Name = name;
             Lane = lane;
@@ -68,25 +66,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// <param name="killer">Unit that killed this unit.</param>
         public override void Die(IDeathData data)
         {
-            foreach (var player in _game.ObjectManager.GetAllChampionsFromTeam(data.Killer.Team))
-            {
-                var goldEarn = _globalGold;
-
-                // Champions in Range within TURRET_RANGE * 1.5f will gain 150% more (obviously)
-                if (Vector2.DistanceSquared(player.Position, Position) <= (Stats.Range.Total * 1.5f) * (Stats.Range.Total * 1.5f) && !player.IsDead)
-                {
-                    goldEarn = _globalGold * 2.5f;
-                    if (_globalExp > 0)
-                    {
-                        player.Stats.Experience += _globalExp;
-                    }
-                }
-
-
-                player.Stats.Gold += goldEarn;
-                _game.PacketNotifier.NotifyUnitAddGold(player, this, goldEarn);
-            }
-
             var announce = new OnTurretDie
             {
                 AssistCount = 0,
@@ -128,15 +107,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public void SetLaneID(LaneID newId)
         {
             Lane = newId;
-        }
-
-        /// <summary>
-        /// Called by ObjectManager every tick.
-        /// </summary>
-        /// <param name="diff">Amount of milliseconds passed since this tick started.</param>
-        public override void Update(float diff)
-        {
-            base.Update(diff);
         }
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
@@ -52,7 +52,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             string aiScript = ""
         ) : base(game, model, new Stats.Stats(), position: position, visionRadius: 800, skinId: skinId, netId: netId, team: team, aiScript: aiScript)
         {
-            CollisionRadius = CharData.GameplayCollisionRadius;
             ParentNetId = Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000;
             Name = name;
             Lane = lane;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -78,6 +78,15 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
         }
 
+        public void AddGold(IAttackableUnit source, float gold, bool notify = true)
+        {
+            Stats.Gold += gold;
+            if (notify)
+            {
+                _game.PacketNotifier.NotifyUnitAddGold(this, source, gold);
+            }
+        }
+
         private string GetPlayerIndex()
         {
             return $"player{_playerId}";
@@ -256,13 +265,17 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
         public void AddExperience(float experience, bool notify = true)
         {
-            Stats.Experience += experience;
-            if (Stats.Experience > 0 && notify)
+            if (experience > 0)
             {
-                _game.PacketNotifier.NotifyUnitAddEXP(this, experience);
-            }
+                Stats.Experience += experience;
 
-            while (Stats.Experience >= _game.Config.MapData.ExpCurve[Stats.Level - 1] && LevelUp()) ;
+                if (notify)
+                {
+                    _game.PacketNotifier.NotifyUnitAddEXP(this, experience);
+                }
+
+                while (Stats.Experience >= _game.Config.MapData.ExpCurve[Stats.Level - 1] && LevelUp()) ;
+            }
         }
 
         public bool LevelUp(bool force = false)

--- a/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
@@ -53,15 +53,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             float globalGold = CharData.GlobalGoldGivenOnDeath;
             float globalEXP = CharData.GlobalExpGivenOnDeath;
 
-            List<IChampion> EnemyPlayers = new List<IChampion>();
-            foreach (var ch in _game.PlayerManager.GetPlayers())
-            {
-                if (ch.Item2.Team != Team)
-                {
-                    EnemyPlayers.Add(ch.Item2.Champion);
-                }
-            }
-
             //TODO: change this to assists
             var championsInRange = _game.ObjectManager.GetChampionsInRange(Position, Stats.Range.Total * 1.5f, true);
 
@@ -79,21 +70,31 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     champion.AddGold(this, globalGold);
                 }
 
-                foreach (var champion in EnemyPlayers)
+                foreach (var player in _game.PlayerManager.GetPlayers())
                 {
-                    if (!championsInRange.Contains(champion))
+                    var champion = player.Item2.Champion;
+                    if (player.Item2.Team != Team)
                     {
-                        champion.AddGold(champion, globalGold);
+                        if (!championsInRange.Contains(champion))
+                        {
+                            champion.AddGold(champion, globalGold);
+                        }
+                        champion.AddExperience(globalEXP);
                     }
-                    champion.AddExperience(globalEXP);
                 }
             }
             else
             {
-                foreach (var champion in EnemyPlayers)
+                foreach (var player in _game.PlayerManager.GetPlayers().FindAll(x => x.Item2.Team != Team))
                 {
-                    champion.AddGold(champion, globalGold);
-                    champion.AddExperience(globalEXP);
+                    var champion = player.Item2.Champion;
+                    if (player.Item2.Team != Team)
+                    {
+                        {
+                            champion.AddGold(champion, globalGold);
+                            champion.AddExperience(globalEXP);
+                        }
+                    }
                 }
             }
             base.Die(data);

--- a/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
@@ -9,7 +9,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
     public class LaneTurret : BaseTurret, ILaneTurret
     {
         public TurretType Type { get; }
-        private bool _turretHpUpdated;
 
         public LaneTurret(
             Game game,
@@ -45,230 +44,59 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 SetIsTargetableToTeam(TeamId.TEAM_BLUE, false);
                 SetIsTargetableToTeam(TeamId.TEAM_PURPLE, false);
             }
-
-            BuildTurret(type);
         }
 
-        public int GetEnemyChampionsCount()
+        //TODO: Decide wether we want MapScrits to handle this with Events or leave this here
+        public override void Die(IDeathData data)
         {
-            var blueTeam = new List<IChampion>();
-            var purpTeam = new List<IChampion>();
-            foreach (var player in _game.ObjectManager.GetAllChampionsFromTeam(TeamId.TEAM_BLUE))
+            float localGold = CharData.LocalGoldGivenOnDeath;
+            float globalGold = CharData.GlobalGoldGivenOnDeath;
+            float globalEXP = CharData.GlobalExpGivenOnDeath;
+
+            List<IChampion> EnemyPlayers = new List<IChampion>();
+            foreach (var ch in _game.PlayerManager.GetPlayers())
             {
-                blueTeam.Add(player);
+                if (ch.Item2.Team != Team)
+                {
+                    EnemyPlayers.Add(ch.Item2.Champion);
+                }
             }
 
-            foreach (var player in _game.ObjectManager.GetAllChampionsFromTeam(TeamId.TEAM_PURPLE))
+            //TODO: change this to assists
+            var championsInRange = _game.ObjectManager.GetChampionsInRange(Position, Stats.Range.Total * 1.5f, true);
+
+            if (localGold > 0 && championsInRange.Count > 0)
             {
-                purpTeam.Add(player);
-            }
+                foreach (var champion in championsInRange)
+                {
+                    if (champion.Team == Team)
+                    {
+                        continue;
+                    }
 
-            if (Team == TeamId.TEAM_BLUE)
+                    float gold = CharData.LocalGoldGivenOnDeath / championsInRange.Count;
+                    champion.AddGold(champion, gold);
+                    champion.AddGold(this, globalGold);
+                }
+
+                foreach (var champion in EnemyPlayers)
+                {
+                    if (!championsInRange.Contains(champion))
+                    {
+                        champion.AddGold(champion, globalGold);
+                    }
+                    champion.AddExperience(globalEXP);
+                }
+            }
+            else
             {
-                return purpTeam.Count;
+                foreach (var champion in EnemyPlayers)
+                {
+                    champion.AddGold(champion, globalGold);
+                    champion.AddExperience(globalEXP);
+                }
             }
-
-            return blueTeam.Count;
-        }
-
-        public void BuildTurret(TurretType type)
-        {
-            IsMelee = false;
-            switch (type)
-            {
-                case TurretType.INNER_TURRET:
-                    _globalGold = 100;
-
-                    Stats.CurrentHealth = 1300;
-                    Stats.HealthPoints.BaseValue = 1300;
-                    Stats.Range.BaseValue = 905.0f;
-                    Stats.AttackSpeedFlat = 0.83f;
-                    Stats.Armor.BaseValue = 60.0f;
-                    Stats.MagicResist.BaseValue = 100.0f;
-                    Stats.AttackDamage.BaseValue = 170.0f;
-                    break;
-                case TurretType.OUTER_TURRET:
-                    _globalGold = 125;
-
-                    Stats.CurrentHealth = 1300;
-                    Stats.HealthPoints.BaseValue = 1300;
-                    Stats.AttackDamage.BaseValue = 100;
-                    Stats.Range.BaseValue = 905.0f;
-                    Stats.AttackSpeedFlat = 0.83f;
-                    Stats.Armor.BaseValue = 60.0f;
-                    Stats.MagicResist.BaseValue = 100.0f;
-                    Stats.AttackDamage.BaseValue = 152.0f;
-                    break;
-                case TurretType.INHIBITOR_TURRET:
-                    _globalGold = 150;
-                    _globalExp = 500;
-
-                    Stats.CurrentHealth = 1300;
-                    Stats.HealthPoints.BaseValue = 1300;
-                    Stats.HealthRegeneration.BaseValue = 5;
-                    Stats.ArmorPenetration.PercentBonus = 0.825f;
-                    Stats.Range.BaseValue = 905.0f;
-                    Stats.AttackSpeedFlat = 0.83f;
-                    Stats.Armor.BaseValue = 67.0f;
-                    Stats.MagicResist.BaseValue = 100.0f;
-                    Stats.AttackDamage.BaseValue = 190.0f;
-                    break;
-                case TurretType.NEXUS_TURRET:
-                    _globalGold = 50;
-
-                    Stats.CurrentHealth = 1300;
-                    Stats.HealthPoints.BaseValue = 1300;
-                    Stats.HealthRegeneration.BaseValue = 5;
-                    Stats.ArmorPenetration.PercentBonus = 0.825f;
-                    Stats.Range.BaseValue = 905.0f;
-                    Stats.AttackSpeedFlat = 0.83f;
-                    Stats.Armor.BaseValue = 65.0f;
-                    Stats.MagicResist.BaseValue = 100.0f;
-                    Stats.AttackDamage.BaseValue = 180.0f;
-                    break;
-                case TurretType.FOUNTAIN_TURRET:
-                    IsMelee = true;
-                    Stats.AttackSpeedFlat = 1.6f;
-                    Stats.GrowthAttackSpeed = 2.125f;
-                    Stats.CurrentHealth = 9999;
-                    Stats.HealthPoints.BaseValue = 9999;
-                    _globalExp = 400.0f;
-                    Stats.AttackDamage.BaseValue = 999.0f;
-                    _globalGold = 100.0f;
-                    Stats.Range.BaseValue = 1250.0f;
-                    break;
-                default:
-
-                    Stats.CurrentHealth = 2000;
-                    Stats.HealthPoints.BaseValue = 2000;
-                    Stats.AttackDamage.BaseValue = 100;
-                    Stats.Range.BaseValue = 905.0f;
-                    Stats.AttackSpeedFlat = 0.83f;
-                    Stats.Armor.PercentBonus = 0.5f;
-                    Stats.MagicResist.PercentBonus = 0.5f;
-
-                    break;
-            }
-        }
-
-        public override void Update(float diff)
-        {
-            //Update Stats if it's time
-
-            //Maybe consider moving this to CharScripts?
-            switch (Type)
-            {
-                case TurretType.OUTER_TURRET:
-                    if (!_turretHpUpdated)
-                    {
-                        Stats.CurrentHealth = 1300 + GetEnemyChampionsCount() * 250;
-                        Stats.HealthPoints.BaseValue = 1300 + GetEnemyChampionsCount() * 250;
-                    }
-
-                    if (_game.GameTime > 40000 - GetEnemyChampionsCount() * 2000 &&
-                        _game.GameTime < 400000 - GetEnemyChampionsCount() * 2000)
-                    {
-                        Stats.MagicResist.BaseValue = 100.0f + (_game.GameTime - 30000) / 60000;
-                        Stats.AttackDamage.BaseValue = 152.0f + (_game.GameTime - 30000) / 60000 * 4;
-                    }
-                    else if (_game.GameTime < 30000)
-                    {
-                        Stats.MagicResist.BaseValue = 100.0f;
-                        Stats.AttackDamage.BaseValue = 152.0f;
-                    }
-                    else
-                    {
-                        Stats.MagicResist.BaseValue = 107.0f;
-                        Stats.AttackDamage.BaseValue = 180.0f;
-                    }
-                    break;
-                case TurretType.INNER_TURRET:
-                    if (!_turretHpUpdated)
-                    {
-                        Stats.CurrentHealth = 1300.0f + GetEnemyChampionsCount() * 250.0f;
-                        Stats.HealthPoints.BaseValue = 1300.0f + GetEnemyChampionsCount() * 250.0f;
-                    }
-                    if (_game.GameTime > 480000 && _game.GameTime < 1620000)
-                    {
-                        Stats.Armor.BaseValue = 60.0f + (_game.GameTime - 480000) / 60000;
-                        Stats.MagicResist.BaseValue = 100.0f + (_game.GameTime - 480000) / 60000;
-                        Stats.AttackDamage.BaseValue = 170.0f + (_game.GameTime - 480000) / 60000 * 4;
-                    }
-                    else if (_game.GameTime < 480000)
-                    {
-                        Stats.Armor.BaseValue = 60.0f;
-                        Stats.MagicResist.BaseValue = 100.0f;
-                        Stats.AttackDamage.BaseValue = 170.0f;
-                    }
-                    else
-                    {
-                        Stats.Armor.BaseValue = 80.0f;
-                        Stats.MagicResist.BaseValue = 120.0f;
-                        Stats.AttackDamage.BaseValue = 250.0f;
-                    }
-                    break;
-                case TurretType.INHIBITOR_TURRET:
-                    if (!_turretHpUpdated)
-                    {
-                        Stats.CurrentHealth = 1300 + GetEnemyChampionsCount() * 250;
-                        Stats.HealthPoints.BaseValue = 1300 + GetEnemyChampionsCount() * 250;
-                    }
-
-                    if (_game.GameTime > 480000 && _game.GameTime < 2220000)
-                    {
-                        Stats.Armor.BaseValue = 67.0f + (_game.GameTime - 480000) / 60000;
-                        Stats.MagicResist.BaseValue = 100.0f + (_game.GameTime - 480000) / 60000;
-                        Stats.AttackDamage.BaseValue = 190.0f + (_game.GameTime - 480000) / 60000 * 4;
-                    }
-                    else if (_game.GameTime < 480000)
-                    {
-                        Stats.Armor.BaseValue = 67.0f;
-                        Stats.MagicResist.BaseValue = 100.0f;
-                        Stats.AttackDamage.BaseValue = 190.0f;
-                    }
-                    else
-                    {
-                        Stats.Armor.BaseValue = 97.0f;
-                        Stats.MagicResist.BaseValue = 130.0f;
-                        Stats.AttackDamage.BaseValue = 250.0f;
-                    }
-                    break;
-                case TurretType.NEXUS_TURRET:
-                    if (!_turretHpUpdated)
-                    {
-                        Stats.CurrentHealth = 1300 + GetEnemyChampionsCount() * 125;
-                        Stats.HealthPoints.BaseValue = 1300 + GetEnemyChampionsCount() * 125;
-                    }
-
-                    if (_game.GameTime < 1)
-                    {
-                        Stats.Armor.BaseValue = 65.0f;
-                        Stats.MagicResist.BaseValue = 100.0f;
-                        Stats.AttackDamage.BaseValue = 180.0f;
-                    }
-                    else if (_game.GameTime > 480000 && _game.GameTime < 2220000)
-                    {
-                        Stats.Armor.BaseValue = 65.0f + (_game.GameTime - 480000) / 60000;
-                        Stats.MagicResist.BaseValue = 100.0f + (_game.GameTime - 480000) / 60000;
-                        Stats.AttackDamage.BaseValue = 180.0f + (_game.GameTime - 480000) / 60000 * 4;
-                    }
-                    else if (_game.GameTime < 480000)
-                    {
-                        Stats.Armor.BaseValue = 65.0f;
-                        Stats.MagicResist.BaseValue = 100.0f;
-                        Stats.AttackDamage.BaseValue = 180.0f;
-                    }
-                    else
-                    {
-                        Stats.Armor.BaseValue = 95.0f;
-                        Stats.MagicResist.BaseValue = 130.0f;
-                        Stats.AttackDamage.BaseValue = 300.0f;
-                    }
-                    break;
-            }
-
-            _turretHpUpdated = true;
-            base.Update(diff);
+            base.Die(data);
         }
 
         public override void AutoAttackHit(IAttackableUnit target)


### PR DESCRIPTION
* BaseTurret
    - Removed gold & EXP sections of  it's `Die` override.

* LaneTurret
    - Cleaned up that mess of hardcoded values.
    - Readded a reworked version of the Gold & EXP distribution on Death in `Die` override(Although i'm still indecisive if i should move it to MapScripts and let them handle tower deaths individually).

* CharData
    - Reorganized CharData variables in Alphabetical order.
    - Introduced `GlobalExpGivenOnDeath`, `GlobalGoldGivenOnDeath` and `LocalGoldGivenOnDeath`, variables used by turrets

* ApiFunctionManager
    - Introduced `GetAllPlayersFromTeam`

* Scripts
    - Updated all MapScripts (Besides Crystal Scar) to properly handle turret health addition at the start of the game.
     - MapScripts also now properly handle the tower's stat updates over the course of the game. (I got all the values from old videos on youtube, this took A LOT of work to research and make proper documentation)
     - Fixed swapped tower models on ARAM