### PR TITLE
Resolve #1306, Progress #1326 -- Vision and spawn system rework

### DIFF
--- a/GameServerCore/Domain/GameObjects/IGameObject.cs
+++ b/GameServerCore/Domain/GameObjects/IGameObject.cs
@@ -116,18 +116,49 @@ namespace GameServerCore.Domain.GameObjects
         void FaceDirection(Vector3 newDirection, bool isInstant = true, float turnTime = 0.08333f);
 
         /// <summary>
-        /// Whether or not the object is networked to a specified team.
+        /// Whether or not the object is within the vision of the specified team.
         /// </summary>
         /// <param name="team">A team which could have vision of this object.</param>
         bool IsVisibleByTeam(TeamId team);
 
         /// <summary>
-        /// Sets the object to be networked or not to a specified team.
+        /// Sets the object as visible to a specified team.
+        /// Should be called in the ObjectManager. By itself, it only affects the return value of IsVisibleByTeam.
         /// </summary>
         /// <param name="team">A team which could have vision of this object.</param>
-        /// <param name="visible">true/false; networked or not</param>
-        void SetVisibleByTeam(TeamId team, bool visible);
+        /// <param name="visible">New value.</param>
+        void SetVisibleByTeam(TeamId team, bool visible = true);
+        
+        /// <summary>
+        /// Whether or not the object is visible for the specified player.
+        /// <summary>
+        /// <param name="userId">The player in relation to which the value is obtained</param>
+        bool IsVisibleForPlayer(int userId);
 
+        /// <summary>
+        /// Sets the object as visible and or not to a specified player.
+        /// Should be called in the ObjectManager. By itself, it only affects the return value of IsVisibleForPlayer.
+        /// <summary>
+        /// <param name="userId">The player for which the value is set.</param>
+        /// <param name="visible">New value.</param>
+        void SetVisibleForPlayer(int userId, bool visible = true);
+
+        /// <summary>
+        /// Whether or not the object is spawned on the player's client side.
+        /// <summary>
+        /// <param name="userId">The player in relation to which the value is obtained</param>
+        bool IsSpawnedForPlayer(int userId);
+
+        /// <summary>
+        /// Sets the object as spawned on the player's client side.
+        /// Should be called in the ObjectManager. By itself, it only affects the return value of IsSpawnedForPlayer.
+        /// <summary>
+        /// <param name="userId">The player for which the value is set.</param>
+        void SetSpawnedForPlayer(int userId);
+
+        /// <summary>
+        /// Allows to iterate all players who see the object 
+        /// </summary>
         IEnumerable<int> VisibleForPlayers { get; }
 
         /// <summary>

--- a/GameServerCore/Domain/GameObjects/IGameObject.cs
+++ b/GameServerCore/Domain/GameObjects/IGameObject.cs
@@ -128,6 +128,8 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="visible">true/false; networked or not</param>
         void SetVisibleByTeam(TeamId team, bool visible);
 
+        IEnumerable<int> VisibleForPlayers { get; }
+
         /// <summary>
         /// Sets the position of this GameObject to the specified position.
         /// </summary>

--- a/GameServerCore/IObjectManager.cs
+++ b/GameServerCore/IObjectManager.cs
@@ -23,6 +23,12 @@ namespace GameServerCore
         void AddObject(IGameObject o);
 
         /// <summary>
+        /// Normally, objects will spawn at the end of the frame, but calling this function will force the teams' and players' vision of that object to update and send out a spawn notification.
+        /// </summary>
+        /// <param name="obj">Object to spawn.</param>
+        void SpawnObject(IGameObject o);
+
+        /// <summary>
         /// Gets a new Dictionary of all NetID,GameObject pairs present in the dictionary of objects in ObjectManager.
         /// </summary>
         /// <returns>Dictionary of NetIDs and the GameObjects that they refer to.</returns>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -291,10 +291,8 @@ namespace GameServerCore.Packets.Interfaces
         /// <summary>
         /// Optionally sends a packet to all players who have vision of the specified Minion detailing that it has spawned.
         /// </summary>
-        /// <returns>A new and fully setup SpawnMinionS2C packet.</returns>
         /// <param name="minion">Minion that is spawning.</param>
-        /// <param name="send">Whether or not to send the created packet.</param>
-        SpawnMinionS2C NotifyMinionSpawned(IMinion minion, bool send = true);
+        void NotifyMinionSpawned(IMinion minion);
         /// <summary>
         /// Sends a packet to either all players with vision (given the projectile is networked to the client) of the projectile, or all players. The packet contains all details regarding the specified projectile's creation.
         /// </summary>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -138,7 +138,8 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="slotId">Slot of the spell.</param>
         /// <param name="currentCd">Amount of time the spell has already been on cooldown (if applicable).</param>
         /// <param name="totalCd">Amount of time that the spell should have be in cooldown before going off cooldown.</param>
-        void NotifyCHAR_SetCooldown(IObjAiBase c, byte slotId, float currentCd, float totalCd);
+        /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
+        void NotifyCHAR_SetCooldown(IObjAiBase c, byte slotId, float currentCd, float totalCd, int userId = 0);
         /// <summary>
         /// Sends a packet to the specified user that highlights the specified GameObject.
         /// </summary>
@@ -185,8 +186,8 @@ namespace GameServerCore.Packets.Interfaces
         /// Sends a packet to either all players with vision of the specified GameObject or a specified user. The packet contains details of the GameObject's health (given it is of the type AttackableUnit) and is meant for after the GameObject is first initialized into vision.
         /// </summary>
         /// <param name="o">GameObject coming into vision.</param>
-        /// <param name="userId">User to send the packet to.</param>
-        /// <param name="ignoreVision">Optionally ignore vision checks when sending this packet.</param>
+        /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
+        /// <param name="ignoreVision">Optionally ignore vision checks when sending this packet and broadcast it to all players instead.</param>
         void NotifyEnterLocalVisibilityClient(IGameObject o, int userId = 0, bool ignoreVision = false);
         /// <summary>
         /// Sends a packet to either all players with vision of the specified object or the specified user. The packet details the data surrounding the specified GameObject that is required by players when a GameObject enters vision such as items, shields, skin, and movements.
@@ -239,7 +240,8 @@ namespace GameServerCore.Packets.Interfaces
         /// <summary>
         /// Sends a packet to all players detailing that the game has started. Sent when all players have finished loading.
         /// </summary>
-        void NotifyGameStart();
+        /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players.</param>
+        void NotifyGameStart(int userId = 0);
         /// <summary>
         /// Sends a packet to all players which announces that the team which owns the specified inhibitor has an inhibitor which is respawning soon.
         /// </summary>
@@ -307,11 +309,12 @@ namespace GameServerCore.Packets.Interfaces
         /// Sends a packet to all players that updates the specified unit's model.
         /// </summary>
         /// <param name="obj">AttackableUnit to update.</param>
+        /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="skinID">Unit's skin ID after changing model.</param>
         /// <param name="modelOnly">Wether or not it's only the model that it's being changed(?). I don't really know what's this for</param>
         /// <param name="overrideSpells">Wether or not the user's spells should be overriden, i assume it would be used for things like Nidalee or Elise.</param>
         /// <param name="replaceCharacterPackage">Unknown.</param>
-        void NotifyS2C_ChangeCharacterData(IAttackableUnit obj, uint skinID = 0, bool modelOnly = true, bool overrideSpells = false, bool replaceCharacterPackage = false);
+        void NotifyS2C_ChangeCharacterData(IAttackableUnit obj, int userId = 0, uint skinID = 0, bool modelOnly = true, bool overrideSpells = false, bool replaceCharacterPackage = false);
         /// <summary>
         /// Sends a packet to the specified player detailing that the specified debug object's radius has changed.
         /// </summary>
@@ -438,7 +441,8 @@ namespace GameServerCore.Packets.Interfaces
         /// Sends a packet to all players detailing that the specified Champion has leveled up.
         /// </summary>
         /// <param name="c">Champion which leveled up.</param>
-        void NotifyNPC_LevelUp(IChampion c);
+        /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
+        void NotifyNPC_LevelUp(IChampion c, int userId = 0);
         /// <summary>
         /// Sends a packet to the specified user that the spell in the specified slot has been upgraded (skill point added).
         /// </summary>
@@ -791,9 +795,11 @@ namespace GameServerCore.Packets.Interfaces
         /// Calls for the appropriate spawn packet to be sent given the specified GameObject's type and calls for a vision packet to be sent for the specified GameObject.
         /// </summary>
         /// <param name="o">GameObject that has spawned.</param>
+        /// <param name="team">The team the user belongs to.</param>
         /// <param name="userId">UserId to send the packet to.</param>
+        /// <param name="gameTime">Time elapsed since the start of the game</param>
         /// <param name="doVision">Whether or not to package the packets into a vision packet.</param>
-        void NotifySpawn(IGameObject o, int userId = 0, bool doVision = true, float gameTime = 0);
+        void NotifySpawn(IGameObject obj, TeamId team, int userId, float gameTime, bool doVision = true);
         /// <summary>
         /// Sends a packet to the specified player detailing that the spawning (of champions & buildings) that occurs at the start of the game has ended.
         /// </summary>
@@ -911,9 +917,10 @@ namespace GameServerCore.Packets.Interfaces
         /// Sends a packet to all players with vision of the specified unit detailing that the specified unit's stats have been updated.
         /// </summary>
         /// <param name="u">Unit who's stats have been updated.</param>
+        /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="partial">Whether or not the packet should be counted as a partial update (whether the stats have actually changed or not). *NOTE*: Use case for this parameter is unknown.</param>
         /// TODO: Replace with LeaguePackets and preferably move all uses of this function to a central EventHandler class (if one is fully implemented).
-        void NotifyUpdatedStats(IAttackableUnit u, bool partial = true);
+        void NotifyUpdatedStats(IAttackableUnit u, int userId = 0, bool partial = true);
         /// <summary>
         /// Sends a packet to the player attempting to use an item that the item was used successfully.
         /// </summary>
@@ -928,13 +935,15 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="obj">GameObject which had their visibility changed.</param>
         /// <param name="team">Team which is affected by this visibility change.</param>
         /// <param name="becameVisible">Whether or not the change was an entry into vision.</param>
-        void NotifyVisibilityChange(IGameObject obj, TeamId team, bool becameVisible);
+        /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to the team.</param>
+        void NotifyVisibilityChange(IGameObject obj, TeamId team, bool becameVisible, int userId = 0);
         /// <summary>
         /// Sends a packet to all players that have vision of the specified unit that it has made a movement.
         /// </summary>
         /// <param name="u">AttackableUnit that is moving.</param>
+        /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="useTeleportID">Whether or not to teleport the unit to its current position in its path.</param>
-        void NotifyWaypointGroup(IAttackableUnit u, bool useTeleportID = true);
+        void NotifyWaypointGroup(IAttackableUnit u, int userId = 0, bool useTeleportID = true);
         /// <summary>
         /// Sends a packet to all players that have vision of the specified unit.
         /// The packet details a group of waypoints with speed parameters which determine what kind of movement will be done to reach the waypoints, or optionally a GameObject.

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -62,6 +62,11 @@ namespace GameServerCore.Packets.Interfaces
         /// TODO: Implement a Region class so we can easily grab these parameters instead of listing them all in the function.
         void NotifyAddRegion(uint unitNetId, uint bubbleNetId, TeamId team, Vector2 position, float time, float radius = 0, int regionType = 0, ClientInfo clientInfo = null, IGameObject obj = null, float collisionRadius = 0, float grassRadius = 0, float sizemult = 1.0f, float addsize = 0, bool grantVis = true, bool stealthVis = false);
         /// <summary>
+        /// Sends a packet to the specified team that a part of the map has changed. Known to be used in League for initializing turret vision and collision.
+        /// </summary>
+        /// <param name="region">Region to add.</param>
+        void NotifyAddRegion(IRegion region);
+        /// <summary>
         /// Sends a packet to all players with vision of the specified attacker detailing that they have targeted the specified target.
         /// </summary>
         /// <param name="attacker">AI that is targeting an AttackableUnit.</param>

--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -554,8 +554,7 @@ namespace LeagueSandbox.GameServer.API
 
         public static void NotifySpawn(IGameObject obj)
         {
-            // currently unavailable
-            //_game.PacketNotifier.NotifySpawn(obj, obj.Team);
+            _game.ObjectManager.SpawnObject(obj);
         }
     }
 }

--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -554,7 +554,8 @@ namespace LeagueSandbox.GameServer.API
 
         public static void NotifySpawn(IGameObject obj)
         {
-            _game.PacketNotifier.NotifySpawn(obj);
+            // currently unavailable
+            //_game.PacketNotifier.NotifySpawn(obj, obj.Team);
         }
     }
 }

--- a/GameServerLib/API/ApiEventManager.cs
+++ b/GameServerLib/API/ApiEventManager.cs
@@ -121,6 +121,9 @@ namespace LeagueSandbox.GameServer.API
         public static EventOnKill OnKill = new EventOnKill();
         public static EventOnKillUnit OnKillUnit = new EventOnKillUnit();
         public static EventOnLaunchAttack OnLaunchAttack = new EventOnLaunchAttack();
+        /// <summary>
+        /// Called immediately after the rocket is added to the scene. *NOTE*: At the time of the call, the rocket has not yet been spawned for players.
+        /// <summary>
         public static EventOnLaunchMissile OnLaunchMissile = new EventOnLaunchMissile();
         public static EventOnLevelUp OnLevelUp = new EventOnLevelUp();
         public static EventOnLevelUpSpell OnLevelUpSpell = new EventOnLevelUpSpell();

--- a/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
+++ b/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
@@ -221,7 +221,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
             var circleparticle = new Particle(_game, null, null, _userChampion.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, false, 0.1f);
             _circleParticles.Add(_userChampion.NetId, circleparticle);
-            _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
+            //_game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
             if (_userChampion.Waypoints.Count > 0)
             {
@@ -261,7 +261,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                     var arrowparticle = new Particle(_game, null, null, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, false, 0.1f);
                     _arrowParticlesList[_userChampion.NetId].Add(arrowparticle);
 
-                    _game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
+                    //_game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
 
                     if (waypoint >= _userChampion.Waypoints.Count)
                     {
@@ -318,7 +318,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
                 var circleparticle = new Particle(_game, null, null, champion.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, false, 0.1f);
                 _circleParticles.Add(champion.NetId, circleparticle);
-                _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
+                //_game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
                 if (champion.Waypoints.Count > 0)
                 {
@@ -358,7 +358,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                         var arrowparticle = new Particle(_game, null, null, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, false, 0.1f);
                         _arrowParticlesList[champion.NetId].Add(arrowparticle);
 
-                        _game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
+                        //_game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
 
                         if (waypoint >= champion.Waypoints.Count)
                         {
@@ -414,7 +414,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
                 var circleparticle = new Particle(_game, null, null, minion.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, false, 0.1f);
                 _circleParticles.Add(minion.NetId, circleparticle);
-                _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
+                //_game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
                     if (minion.Waypoints.Count > 0)
                     {
@@ -454,7 +454,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                         var arrowparticle = new Particle(_game, null, null, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, false, 0.1f);
                         _arrowParticlesList[minion.NetId].Add(arrowparticle);
 
-                            _game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
+                            //_game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
 
                             if (waypoint >= minion.Waypoints.Count)
                             {
@@ -512,7 +512,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
                     var circleparticle = new Particle(_game, null, null, missile.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, false, 0.1f);
                     _circleParticles.Add(missile.NetId, circleparticle);
-                    _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
+                    //_game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
                     if (missile.CastInfo.Targets[0] != null || (missile.CastInfo.TargetPosition != Vector3.Zero && missile.CastInfo.TargetPositionEnd != Vector3.Zero))
                     {
@@ -547,7 +547,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                             var arrowparticle = new Particle(_game, null, null, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, direction, false, 0.1f);
                             _arrowParticlesList[missile.NetId].Add(arrowparticle);
 
-                            _game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
+                            //_game.PacketNotifier.NotifyFXCreateGroup(arrowparticle, userId);
                         }
                         else if (missile is ISpellCircleMissile skillshot)
                         {
@@ -566,27 +566,27 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
                             var arrowParticleStart = new Particle(_game, null, null, current, "DebugArrow_green.troy", 0.5f, "", "", 0, missile.Direction, false, 0.1f);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleStart);
-                            _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart, userId);
+                            //_game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart, userId);
 
                             var arrowParticleEnd = new Particle(_game, null, null, wpTarget, "DebugArrow_green.troy", 0.5f, "", "", 0, missile.Direction, false, 0.1f);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleEnd);
-                            _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd, userId);
+                            //_game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd, userId);
 
                             var arrowParticleEnd2Temp = new Particle(_game, null, null, new Vector2(wpTarget.X + dirTangent.X, wpTarget.Y + dirTangent.Y), "Global_Indicator_Line_Beam.troy", 0.0f, "", "", 0, missile.Direction, false, 0.1f);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleEnd2Temp);
-                            _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd2Temp, userId);
+                            //_game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd2Temp, userId);
 
                             var arrowParticleStart2 = new Particle(_game, null, arrowParticleEnd2Temp, new Vector2(current.X + dirTangent.X, current.Y + dirTangent.Y), "Global_Indicator_Line_Beam.troy", 1.0f, "", "", 0, missile.Direction, false, 0.1f);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleStart2);
-                            _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart2, userId);
+                            //_game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart2, userId);
 
                             var arrowParticleEnd3Temp = new Particle(_game, null, null, new Vector2(wpTarget.X + dirTangent2.X, wpTarget.Y + dirTangent2.Y), "Global_Indicator_Line_Beam.troy", 0.0f, "", "", 0, missile.Direction, false, 0.1f);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleEnd3Temp);
-                            _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd3Temp, userId);
+                            //_game.PacketNotifier.NotifyFXCreateGroup(arrowParticleEnd3Temp, userId);
 
                             var arrowParticleStart3 = new Particle(_game, null, arrowParticleEnd3Temp, new Vector2(current.X + dirTangent2.X, current.Y + dirTangent2.Y), "Global_Indicator_Line_Beam.troy", 1.0f, "", "", 0, missile.Direction, false, 0.1f);
                             _arrowParticlesList[missile.NetId].Add(arrowParticleStart3);
-                            _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart3, userId);
+                            //_game.PacketNotifier.NotifyFXCreateGroup(arrowParticleStart3, userId);
                         }
                     }
                 }
@@ -670,14 +670,14 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
                             var circleparticle = new Particle(_game, null, null, polygon.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, false, 0.1f);
                             _circleParticles.Add(polygon.NetId, circleparticle);
-                            _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
+                            //_game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
                             foreach (Vector2 vert in polygon.GetPolygonVertices())
                             {
                                 var truePos = bindObj.Position + Extensions.Rotate(vert, -Extensions.UnitVectorToAngle(new Vector2(bindObj.Direction.X, bindObj.Direction.Z)) + 90f);
                                 var arrowParticleVert = new Particle(_game, null, null, truePos, "DebugArrow_green.troy", 0.5f, "", "", 0, bindObj.Direction, false, 0.1f);
                                 _arrowParticlesList[polygon.NetId].Add(arrowParticleVert);
-                                _game.PacketNotifier.NotifyFXCreateGroup(arrowParticleVert, userId);
+                                //_game.PacketNotifier.NotifyFXCreateGroup(arrowParticleVert, userId);
                             }
                         }
                     }
@@ -729,7 +729,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
                 var circleparticle = new Particle(_game, null, null, obj.Position, "DebugCircle_green.troy", circlesize, "", "", 0, default, false, 0.1f);
                 _circleParticles.Add(obj.NetId, circleparticle);
-                _game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
+                //_game.PacketNotifier.NotifyFXCreateGroup(circleparticle, userId);
 
                 // TODO: Add check for AttackableUnit and draw waypoints.
             }

--- a/GameServerLib/Chatbox/Commands/SpawnCommand.cs
+++ b/GameServerLib/Chatbox/Commands/SpawnCommand.cs
@@ -172,7 +172,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             Game.PacketNotifier.NotifyAvatarInfo(clientInfoTemp);
             Game.ObjectManager.AddObject(c);
             Game.PacketNotifier.NotifyEnterLocalVisibilityClient(c, ignoreVision: true);
-            Game.PacketNotifier.NotifyUpdatedStats(c, false);
+            Game.PacketNotifier.NotifyUpdatedStats(c, partial: false);
 
             c.Stats.SetSpellEnabled(13, true);
             c.Stats.SetSummonerSpellEnabled(0, true);

--- a/GameServerLib/Content/Navigation/NavigationGrid.cs
+++ b/GameServerLib/Content/Navigation/NavigationGrid.cs
@@ -656,7 +656,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
 
             NavigationGridCell cell = GetCell((short)vector.X, (short)vector.Y);
 
-            return cell.HasFlag(flag);
+            return cell != null && cell.HasFlag(flag);
         }
 
         /// <summary>

--- a/GameServerLib/Content/Navigation/NavigationGrid.cs
+++ b/GameServerLib/Content/Navigation/NavigationGrid.cs
@@ -656,6 +656,12 @@ namespace LeagueSandbox.GameServer.Content.Navigation
 
             NavigationGridCell cell = GetCell((short)vector.X, (short)vector.Y);
 
+            if(cell == null)
+            {
+                Console.WriteLine($"GetCell({vector})");
+                return false;
+            }
+
             return cell.HasFlag(flag);
         }
 

--- a/GameServerLib/Content/Navigation/NavigationGrid.cs
+++ b/GameServerLib/Content/Navigation/NavigationGrid.cs
@@ -656,12 +656,6 @@ namespace LeagueSandbox.GameServer.Content.Navigation
 
             NavigationGridCell cell = GetCell((short)vector.X, (short)vector.Y);
 
-            if(cell == null)
-            {
-                Console.WriteLine($"GetCell({vector})");
-                return false;
-            }
-
             return cell.HasFlag(flag);
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/AzirTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/AzirTurret.cs
@@ -24,11 +24,5 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             SetTeam(team);
             Stats.Range.BaseValue = 905.0f;
         }
-
-        public override void OnAdded()
-        {
-            base.OnAdded();
-            _game.PacketNotifier.NotifySpawn(this);
-        }
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -226,7 +226,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             // League sends a single packet detailing every champion's tool tip changes.
             if (_tipsChanged.Count > 0)
             {
-                //_game.PacketNotifier.NotifyS2C_ToolTipVars(_tipsChanged);
+                _game.PacketNotifier.NotifyS2C_ToolTipVars(_tipsChanged);
                 ClearToolTipsChanged();
             }
         }
@@ -299,7 +299,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 }
                 ApiEventManager.OnLevelUp.Publish(this);
                 _game.PacketNotifier.NotifyNPC_LevelUp(this);
-                //_game.PacketNotifier.NotifyUpdatedStats(this, false);
+                _game.PacketNotifier.NotifyUpdatedStats(this, partial: false);
 
                 return true;
             }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -98,16 +98,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             base.OnAdded();
             _game.ObjectManager.AddChampion(this);
-            _game.PacketNotifier.NotifySpawn(this);
-
-            if (Spells.ContainsKey((int)SpellSlotType.PassiveSpellSlot))
-            {
-                CharScript.OnActivate(this, (Spells[(int)SpellSlotType.PassiveSpellSlot]));
-            }
-            else
-            {
-                CharScript.OnActivate(this);
-            }
         }
 
         public override void OnRemoved()
@@ -236,7 +226,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             // League sends a single packet detailing every champion's tool tip changes.
             if (_tipsChanged.Count > 0)
             {
-                _game.PacketNotifier.NotifyS2C_ToolTipVars(_tipsChanged);
+                //_game.PacketNotifier.NotifyS2C_ToolTipVars(_tipsChanged);
                 ClearToolTipsChanged();
             }
         }
@@ -309,7 +299,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 }
                 ApiEventManager.OnLevelUp.Publish(this);
                 _game.PacketNotifier.NotifyNPC_LevelUp(this);
-                _game.PacketNotifier.NotifyUpdatedStats(this, false);
+                //_game.PacketNotifier.NotifyUpdatedStats(this, false);
 
                 return true;
             }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -231,6 +231,20 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             AIScript.OnActivate(this);
         }
 
+        public override void OnAdded()
+        {
+            base.OnAdded();
+
+            if (Spells.ContainsKey((int)SpellSlotType.PassiveSpellSlot))
+            {
+                CharScript.OnActivate(this, Spells[(int)SpellSlotType.PassiveSpellSlot]);
+            }
+            else
+            {
+                CharScript.OnActivate(this);
+            }
+        }
+
         /// <summary>
         /// Loads the Passive Script
         /// </summary>

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -25,6 +25,9 @@ namespace LeagueSandbox.GameServer.GameObjects
         private Dictionary<TeamId, bool> _visibleByTeam;
         private HashSet<int> _spawnedForPlayers = new HashSet<int>();
         private Dictionary<int, bool> _visibleForPlayers = new Dictionary<int, bool>();
+        /// <summary>
+        /// Allows to iterate all players who see the object 
+        /// </summary>
         public IEnumerable<int> VisibleForPlayers
         {
             get
@@ -255,7 +258,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         }
 
         /// <summary>
-        /// Whether or not the object is networked to a specified team.
+        /// Whether or not the object is within the vision of the specified team.
         /// </summary>
         /// <param name="team">A team which could have vision of this object.</param>
         public bool IsVisibleByTeam(TeamId team)
@@ -264,31 +267,50 @@ namespace LeagueSandbox.GameServer.GameObjects
         }
 
         /// <summary>
-        /// Sets the object to be networked or not to a specified team.
+        /// Sets the object as visible to a specified team.
+        /// Should be called in the ObjectManager. By itself, it only affects the return value of IsVisibleByTeam.
         /// </summary>
         /// <param name="team">A team which could have vision of this object.</param>
-        /// <param name="visible">true/false; networked or not</param>
-        public void SetVisibleByTeam(TeamId team, bool visible)
+        /// <param name="visible">New value.</param>
+        public void SetVisibleByTeam(TeamId team, bool visible = true)
         {
             _visibleByTeam[team] = visible;
         }
 
+        /// <summary>
+        /// Whether or not the object is visible for the specified player.
+        /// <summary>
+        /// <param name="userId">The player in relation to which the value is obtained</param>
         public bool IsVisibleForPlayer(int userId)
         {
             return _visibleForPlayers.GetValueOrDefault(userId, false);
         }
 
-        public bool SetVisibleForPlayer(int userId, bool visible = true)
+        /// <summary>
+        /// Sets the object as visible and or not to a specified player.
+        /// Should be called in the ObjectManager. By itself, it only affects the return value of IsVisibleForPlayer.
+        /// <summary>
+        /// <param name="userId">The player for which the value is set.</param>
+        /// <param name="visible">New value.</param>
+        public void SetVisibleForPlayer(int userId, bool visible = true)
         {
-            return _visibleForPlayers[userId] = visible;
+            _visibleForPlayers[userId] = visible;
         }
 
-
+        /// <summary>
+        /// Whether or not the object is spawned on the player's client side.
+        /// <summary>
+        /// <param name="userId">The player in relation to which the value is obtained</param>
         public bool IsSpawnedForPlayer(int userId)
         {
             return _spawnedForPlayers.Contains(userId);
         }
 
+        /// <summary>
+        /// Sets the object as spawned on the player's client side.
+        /// Should be called in the ObjectManager. By itself, it only affects the return value of IsSpawnedForPlayer.
+        /// <summary>
+        /// <param name="userId">The player for which the value is set.</param>
         public void SetSpawnedForPlayer(int userId)
         {
             _spawnedForPlayers.Add(userId);

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -26,7 +26,8 @@ namespace LeagueSandbox.GameServer.GameObjects
         private HashSet<int> _spawnedForPlayers = new HashSet<int>();
         private Dictionary<int, bool> _visibleForPlayers = new Dictionary<int, bool>();
         /// <summary>
-        /// Allows to iterate all players who see the object 
+        /// A set of players with vision of this GameObject.
+        /// Can be iterated through.
         /// </summary>
         public IEnumerable<int> VisibleForPlayers
         {
@@ -248,9 +249,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
         public virtual void SetTeam(TeamId team)
         {
-            //_visibleByTeam[Team] = false;
             Team = team;
-            //_visibleByTeam[Team] = true;
             if (_game.IsRunning)
             {
                 _game.PacketNotifier.NotifySetTeam(this as IAttackableUnit);
@@ -258,12 +257,12 @@ namespace LeagueSandbox.GameServer.GameObjects
         }
 
         /// <summary>
-        /// Whether or not the object is within the vision of the specified team.
+        /// Whether or not the object is within vision of the specified team.
         /// </summary>
         /// <param name="team">A team which could have vision of this object.</param>
         public bool IsVisibleByTeam(TeamId team)
         {
-            return /*team == Team ||*/ _visibleByTeam[team];
+            return _visibleByTeam[team];
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -23,7 +23,21 @@ namespace LeagueSandbox.GameServer.GameObjects
         protected bool _toRemove;
         protected bool _movementUpdated;
         private Dictionary<TeamId, bool> _visibleByTeam;
-        private Dictionary<TeamId, bool> _spawnedForTeam;
+        private HashSet<int> _spawnedForPlayers = new HashSet<int>();
+        private Dictionary<int, bool> _visibleForPlayers = new Dictionary<int, bool>();
+        public IEnumerable<int> VisibleForPlayers
+        {
+            get
+            {
+                foreach(var kv in _visibleForPlayers)
+                {
+                    if(kv.Value)
+                    {
+                        yield return kv.Key;
+                    }
+                }
+            }
+        }
 
         /// <summary>
         /// Comparison variable for small distance movements.
@@ -89,12 +103,10 @@ namespace LeagueSandbox.GameServer.GameObjects
             VisionRadius = visionRadius;
 
             _visibleByTeam = new Dictionary<TeamId, bool>();
-            _spawnedForTeam = new Dictionary<TeamId, bool>();
             var teams = Enum.GetValues(typeof(TeamId)).Cast<TeamId>();
             foreach (var t in teams)
             {
                 _visibleByTeam.Add(t, false);
-                _spawnedForTeam.Add(t, false);
             }
 
             Team = team;
@@ -261,34 +273,25 @@ namespace LeagueSandbox.GameServer.GameObjects
             _visibleByTeam[team] = visible;
         }
 
-        public bool IsSpawnedForTeam(TeamId team)
+        public bool IsVisibleForPlayer(int userId)
         {
-            return _spawnedForTeam[team];
+            return _visibleForPlayers.GetValueOrDefault(userId, false);
         }
 
-        public bool IsSpawned()
+        public bool SetVisibleForPlayer(int userId, bool visible = true)
         {
-            foreach(bool spawned in _spawnedForTeam.Values)
-            {
-                if(!spawned)
-                {
-                    return false;
-                }
-            }
-            return true;
+            return _visibleForPlayers[userId] = visible;
         }
 
-        public void SetSpawnedForTeam(TeamId team, bool spawned = true)
+
+        public bool IsSpawnedForPlayer(int userId)
         {
-            _spawnedForTeam[team] = spawned;
+            return _spawnedForPlayers.Contains(userId);
         }
 
-        public void SetSpawned(bool spawned = true)
+        public void SetSpawnedForPlayer(int userId)
         {
-            foreach(TeamId team in _spawnedForTeam.Keys)
-            {
-                _spawnedForTeam[team] = spawned;
-            };
+            _spawnedForPlayers.Add(userId);
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -333,8 +333,8 @@ namespace LeagueSandbox.GameServer.GameObjects
             SetPosition(position);
 
             // TODO: Verify which one we want to use. WaypointList does not require conversions, however WaypointGroup does (and it has TeleportID functionality).
-            _game.PacketNotifier.NotifyWaypointList(this, new List<Vector2> { Position });
-            //_game.PacketNotifier.NotifyEnterVisibilityClient(this, useTeleportID: true);
+            //_game.PacketNotifier.NotifyWaypointList(this, new List<Vector2> { Position });
+            _game.PacketNotifier.NotifyEnterVisibilityClient(this, useTeleportID: true);
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -23,6 +23,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         protected bool _toRemove;
         protected bool _movementUpdated;
         private Dictionary<TeamId, bool> _visibleByTeam;
+        private Dictionary<TeamId, bool> _spawnedForTeam;
 
         /// <summary>
         /// Comparison variable for small distance movements.
@@ -88,10 +89,12 @@ namespace LeagueSandbox.GameServer.GameObjects
             VisionRadius = visionRadius;
 
             _visibleByTeam = new Dictionary<TeamId, bool>();
+            _spawnedForTeam = new Dictionary<TeamId, bool>();
             var teams = Enum.GetValues(typeof(TeamId)).Cast<TeamId>();
             foreach (var t in teams)
             {
                 _visibleByTeam.Add(t, false);
+                _spawnedForTeam.Add(t, false);
             }
 
             Team = team;
@@ -230,9 +233,9 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="team">TeamId.BLUE/PURPLE/NEUTRAL</param>
         public virtual void SetTeam(TeamId team)
         {
-            _visibleByTeam[Team] = false;
+            //_visibleByTeam[Team] = false;
             Team = team;
-            _visibleByTeam[Team] = true;
+            //_visibleByTeam[Team] = true;
             if (_game.IsRunning)
             {
                 _game.PacketNotifier.NotifySetTeam(this as IAttackableUnit);
@@ -245,7 +248,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="team">A team which could have vision of this object.</param>
         public bool IsVisibleByTeam(TeamId team)
         {
-            return team == Team || _visibleByTeam[team];
+            return /*team == Team ||*/ _visibleByTeam[team];
         }
 
         /// <summary>
@@ -256,6 +259,36 @@ namespace LeagueSandbox.GameServer.GameObjects
         public void SetVisibleByTeam(TeamId team, bool visible)
         {
             _visibleByTeam[team] = visible;
+        }
+
+        public bool IsSpawnedForTeam(TeamId team)
+        {
+            return _spawnedForTeam[team];
+        }
+
+        public bool IsSpawned()
+        {
+            foreach(bool spawned in _spawnedForTeam.Values)
+            {
+                if(!spawned)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public void SetSpawnedForTeam(TeamId team, bool spawned = true)
+        {
+            _spawnedForTeam[team] = spawned;
+        }
+
+        public void SetSpawned(bool spawned = true)
+        {
+            foreach(TeamId team in _spawnedForTeam.Keys)
+            {
+                _spawnedForTeam[team] = spawned;
+            };
         }
 
         /// <summary>
@@ -275,8 +308,8 @@ namespace LeagueSandbox.GameServer.GameObjects
             SetPosition(position);
 
             // TODO: Verify which one we want to use. WaypointList does not require conversions, however WaypointGroup does (and it has TeleportID functionality).
-            //_game.PacketNotifier.NotifyWaypointList(this, new List<Vector2> { Position });
-            _game.PacketNotifier.NotifyEnterVisibilityClient(this, useTeleportID: true);
+            _game.PacketNotifier.NotifyWaypointList(this, new List<Vector2> { Position });
+            //_game.PacketNotifier.NotifyEnterVisibilityClient(this, useTeleportID: true);
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -1057,7 +1057,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
 
             ApiEventManager.OnLaunchMissile.Publish(new KeyValuePair<IObjAiBase, ISpell>(CastInfo.Owner, this), p);
 
-            _game.PacketNotifier.NotifyMissileReplication(p);
+            //_game.PacketNotifier.NotifyMissileReplication(p);
 
             // TODO: Verify when NotifyForceCreateMissile should be used instead.
 

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -128,7 +128,7 @@ namespace LeagueSandbox.GameServer
 
                 foreach (var kv in players)
                 {
-                    UpdateVisibilityAndSpawnIfNeeded(obj, kv.Item2);
+                    UpdateVisionAndSpawn(obj, kv.Item2);
                 }
 
                 if (obj is IAttackableUnit u)
@@ -142,7 +142,7 @@ namespace LeagueSandbox.GameServer
             _currentlyInUpdate = false;
         }
 
-        public void UpdateVisibilityAndSpawnIfNeeded(IGameObject obj, ClientInfo clientInfo, bool forceSpawn = false)
+        public void UpdateVisionAndSpawn(IGameObject obj, ClientInfo clientInfo, bool forceSpawn = false)
         {
             int pid = (int)clientInfo.PlayerId;
             TeamId team = clientInfo.Team;

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -87,7 +87,8 @@ namespace LeagueSandbox.GameServer
                 obj.Update(diff);
             }
 
-            //BEGIN HACK
+            // It is now safe to call RemoveObject at any time,
+            // but compatibility with the older remove method remains.
             foreach (var obj in _objects.Values)
             {
                 if (obj.IsToRemove())
@@ -95,7 +96,6 @@ namespace LeagueSandbox.GameServer
                     RemoveObject(obj);
                 }
             }
-            //END HACK
             
             foreach (var obj in _objectsToRemove)
             {
@@ -118,6 +118,7 @@ namespace LeagueSandbox.GameServer
             
             foreach (IGameObject obj in _objects.Values)
             {
+                // Update the vision of the teams
                 if (IsAffectedByVision(obj))
                 {
                     foreach (var team in Teams)
@@ -128,7 +129,7 @@ namespace LeagueSandbox.GameServer
 
                 foreach (var kv in players)
                 {
-                    UpdateVisionAndSpawn(obj, kv.Item2);
+                    UpdateVisionSpawnAndSync(obj, kv.Item2);
                 }
 
                 if (obj is IAttackableUnit u)
@@ -142,7 +143,11 @@ namespace LeagueSandbox.GameServer
             _currentlyInUpdate = false;
         }
 
-        public void UpdateVisionAndSpawn(IGameObject obj, ClientInfo clientInfo, bool forceSpawn = false)
+
+        /// <summary>
+        /// Updates the player's vision, which may not be tied to the team's vision, sends a spawn notification or updates if the object is already spawned.
+        /// </summary>
+        public void UpdateVisionSpawnAndSync(IGameObject obj, ClientInfo clientInfo, bool forceSpawn = false)
         {
             int pid = (int)clientInfo.PlayerId;
             TeamId team = clientInfo.Team;

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -128,7 +128,13 @@ namespace LeagueSandbox.GameServer
                             }
                         }
                     }
-                    
+
+                    if(obj is IAttackableUnit u)
+                    {
+                        // Stats are not updated when object is created
+                        //TODO: Send along with NotifyEnterVisibilityClient packets?
+                        _game.PacketNotifier.NotifyUpdatedStats(u, false);
+                    }
                     _queuedObjects.Remove(obj.NetId);
                 }
                 else // post-Update and sync
@@ -234,7 +240,10 @@ namespace LeagueSandbox.GameServer
                             if(publish)
                             {
                                 _game.PacketNotifier.NotifyVisibilityChange(obj, team, teamHasVision);
-                                _game.PacketNotifier.NotifyUpdatedStats(u, false);
+                                if(u != null && teamHasVision)
+                                {
+                                    _game.PacketNotifier.NotifyUpdatedStats(u, false);
+                                }
                             }
                         }
                     }

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -118,14 +118,7 @@ namespace LeagueSandbox.GameServer
             
             foreach (IGameObject obj in _objects.Values)
             {
-                // Update the vision of the teams
-                if (IsAffectedByVision(obj))
-                {
-                    foreach (var team in Teams)
-                    {
-                        obj.SetVisibleByTeam(team, TeamHasVisionOn(team, obj));
-                    }
-                }
+                UpdateTeamsVision(obj);
 
                 foreach (var kv in players)
                 {
@@ -143,6 +136,34 @@ namespace LeagueSandbox.GameServer
             _currentlyInUpdate = false;
         }
 
+        /// <summary>
+        /// Normally, objects will spawn at the end of the frame, but calling this function will force the teams' and players' vision of that object to update and send out a spawn notification.
+        /// </summary>
+        /// <param name="obj">Object to spawn.</param>
+        public void SpawnObject(IGameObject obj)
+        {
+            UpdateTeamsVision(obj);
+
+            var players = _game.PlayerManager.GetPlayers(includeBots: false);
+            foreach (var kv in players)
+            {
+                UpdateVisionSpawnAndSync(obj, kv.Item2, forceSpawn: true);
+            }
+        }
+
+        /// <summary>
+        /// Updates the vision of the teams on the object.
+        /// </summary>
+        void UpdateTeamsVision(IGameObject obj)
+        {
+            if (IsAffectedByVision(obj))
+            {
+                foreach (var team in Teams)
+                {
+                    obj.SetVisibleByTeam(team, TeamHasVisionOn(team, obj));
+                }
+            }
+        }
 
         /// <summary>
         /// Updates the player's vision, which may not be tied to the team's vision, sends a spawn notification or updates if the object is already spawned.

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -167,8 +167,10 @@ namespace LeagueSandbox.GameServer
                             }
                         }
 
-                        //TODO: sync partially and only when u.Replication.Changed
-                        _game.PacketNotifier.NotifyUpdatedStats(u, false);
+                        if(u.Replication.Changed)
+                        {
+                            _game.PacketNotifier.NotifyUpdatedStats(u, true);
+                        }
                         
                         if (u.IsModelUpdated)
                         {
@@ -232,6 +234,7 @@ namespace LeagueSandbox.GameServer
                             if(publish)
                             {
                                 _game.PacketNotifier.NotifyVisibilityChange(obj, team, teamHasVision);
+                                _game.PacketNotifier.NotifyUpdatedStats(u, false);
                             }
                         }
                     }

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -87,6 +87,10 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 {
                     _game.PacketNotifier.NotifySpawnLevelPropS2C(levelProp, userId);
                 }
+                else if (kv.Value is IRegion region)
+                {
+                    _game.PacketNotifier.NotifyAddRegion(region);
+                }
                 else
                 {
                     _logger.Warn("Object of type: " + kv.Value.GetType() + " not handled in HandleSpawn.");

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -29,80 +29,91 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             _networkIdManager = game.NetworkIdManager;
         }
 
+        private bool _firstSpawn = true;
         public override bool HandlePacket(int userId, SpawnRequest req)
         {
+            var packetNotifier = _game.PacketNotifier as PacketDefinitions420.PacketNotifier;
+
+            var players = _playerManager.GetPlayers(true);
+
+            if(_firstSpawn)
+            {
+                _firstSpawn = false;
+
+                var bluePill = _itemManager.GetItemType(_game.Map.MapScript.MapScriptMetadata.RecallSpellItemId);
+
+                foreach (var kv in players)
+                {
+                    var peerInfo = kv.Item2;
+
+                    var itemInstance = peerInfo.Champion.Inventory.SetExtraItem(7, bluePill);
+
+                    // Runes
+                    byte runeItemSlot = 14;
+                    foreach (var rune in peerInfo.Champion.RuneList.Runes)
+                    {
+                        var runeItem = _itemManager.GetItemType(rune.Value);
+                        var newRune = peerInfo.Champion.Inventory.SetExtraItem(runeItemSlot, runeItem);
+                        peerInfo.Champion.Stats.AddModifier(runeItem);
+                        runeItemSlot++;
+                    }
+
+                    peerInfo.Champion.Stats.SetSummonerSpellEnabled(0, true);
+                    peerInfo.Champion.Stats.SetSummonerSpellEnabled(1, true);
+
+                    _game.ObjectManager.AddObject(peerInfo.Champion);
+                }
+            }
+
             _logger.Debug("Spawning map");
             _game.PacketNotifier.NotifyS2C_StartSpawn(userId);
 
-            var peerInfo = _playerManager.GetPeerInfo(userId);
-            var bluePill = _itemManager.GetItemType(_game.Map.MapScript.MapScriptMetadata.RecallSpellItemId);
-            var itemInstance = peerInfo.Champion.Inventory.SetExtraItem(7, bluePill);
+            var userInfo = _playerManager.GetPeerInfo(userId);
 
-            // self-inform
-            _game.PacketNotifier.NotifyS2C_CreateHero(peerInfo, userId);
-            _game.PacketNotifier.NotifyAvatarInfo(peerInfo, userId);
-
-            _game.PacketNotifier.NotifyBuyItem(userId, peerInfo.Champion, itemInstance);
-
-            // Runes
-            byte runeItemSlot = 14;
-            foreach (var rune in peerInfo.Champion.RuneList.Runes)
+            foreach (var kv in players)
             {
-                var runeItem = _itemManager.GetItemType(rune.Value);
-                var newRune = peerInfo.Champion.Inventory.SetExtraItem(runeItemSlot, runeItem);
-                _playerManager.GetPeerInfo(userId).Champion.Stats.AddModifier(runeItem);
-                runeItemSlot++;
+                var peerInfo = kv.Item2;
+                var champ = peerInfo.Champion as GameObject;
+
+                _game.PacketNotifier.NotifyS2C_CreateHero(peerInfo, userId);
+                _game.PacketNotifier.NotifyAvatarInfo(peerInfo, userId);
+
+                // Buy blue pill
+                var itemInstance = peerInfo.Champion.Inventory.GetItem(7);
+                _game.PacketNotifier.NotifyBuyItem(userId, peerInfo.Champion, itemInstance);
+                
+                champ.SetSpawnedForPlayer(userId);
+
+                if(_game.IsRunning && champ.IsVisibleForPlayer(userId))
+                {
+                    packetNotifier.NotifyVisibilityChange(champ, userInfo.Team, userId, true);
+                }
             }
-
-            // Does not seem to work without Recall being skilled and enabled.
-            // TODO: Verify if ^ is still true! Commenting it out does not seem to cause any damage.
-            _game.PacketNotifier.NotifyNPC_UpgradeSpellAns(userId, peerInfo.Champion.NetId, 13, 1, peerInfo.Champion.SkillPoints);
-
-            peerInfo.Champion.Stats.SetSummonerSpellEnabled(0, true);
-            peerInfo.Champion.Stats.SetSummonerSpellEnabled(1, true);
 
             var objects = _game.ObjectManager.GetObjects();
-            foreach (var kv in objects)
+            foreach (var _obj in objects.Values)
             {
-                if (kv.Value is IChampion champion)
+                var obj = _obj as GameObject;
+                if(!(obj is IChampion))
                 {
-                    if (champion.IsVisibleByTeam(peerInfo.Champion.Team))
+                    if(_game.IsRunning)
                     {
-                        _game.PacketNotifier.NotifyEnterVisibilityClient(champion, userId, false, false, true);
+                        if(obj.IsSpawnedForPlayer(userId))
+                        {
+                            packetNotifier.NotifySpawn(obj, userId, obj.IsVisibleForPlayer(userId), _game.GameTime);
+                        }
                     }
-                }
-                else if (kv.Value is ILaneTurret turret)
-                {
-                    _game.PacketNotifier.NotifyS2C_CreateTurret(turret, userId);
-                }
-                else if (kv.Value is INexus nexus)
-                {
-                    _game.PacketNotifier.NotifyEnterVisibilityClient(nexus, userId, ignoreVision: true);
-                }
-                else if (kv.Value is IInhibitor inhib)
-                {
-                    _game.PacketNotifier.NotifyEnterVisibilityClient(inhib, userId, ignoreVision: true);
-                }
-                else if (kv.Value is ILevelProp levelProp)
-                {
-                    _game.PacketNotifier.NotifySpawnLevelPropS2C(levelProp, userId);
-                }
-                else if (kv.Value is IRegion region)
-                {
-                    _game.PacketNotifier.NotifyAddRegion(region);
-                }
-                else
-                {
-                    _logger.Warn("Object of type: " + kv.Value.GetType() + " not handled in HandleSpawn.");
+                    else
+                    {
+                        (_game.ObjectManager as ObjectManager)
+                        .UpdateVisibilityAndSpawnIfNeeded(obj, userInfo, forceSpawn: true);
+                    }
                 }
             }
 
-            // TODO shop map specific?
+            //TODO: shop map specific?
             // Level props are just models, we need button-object minions to allow the client to interact with it
-            if (peerInfo != null)
-            {
-                _game.PacketNotifier.NotifySpawn(_game.Map.ShopList[peerInfo.Team], userId, false);
-            }
+            _game.PacketNotifier.NotifySpawn(_game.Map.ShopList[userInfo.Team], userId, false);
 
             _game.PacketNotifier.NotifySpawnEnd(userId);
             return true;

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -31,8 +31,8 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 
         public override bool HandlePacket(int userId, SpawnRequest req)
         {
-            _game.PacketNotifier.NotifyS2C_StartSpawn(userId);
             _logger.Debug("Spawning map");
+            _game.PacketNotifier.NotifyS2C_StartSpawn(userId);
 
             var peerInfo = _playerManager.GetPeerInfo(userId);
             var bluePill = _itemManager.GetItemType(_game.Map.MapScript.MapScriptMetadata.RecallSpellItemId);
@@ -97,7 +97,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             // Level props are just models, we need button-object minions to allow the client to interact with it
             if (peerInfo != null)
             {
-                _game.PacketNotifier.NotifySpawn(_game.Map.ShopList[peerInfo.Team]);
+                _game.PacketNotifier.NotifySpawn(_game.Map.ShopList[peerInfo.Team], userId, false);
             }
 
             _game.PacketNotifier.NotifySpawnEnd(userId);

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -131,7 +131,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                     else
                     {
                         (_game.ObjectManager as ObjectManager)
-                        .UpdateVisionAndSpawn(obj, userInfo, forceSpawn: true);
+                        .UpdateVisionSpawnAndSync(obj, userInfo, forceSpawn: true);
                     }
                 }
             }

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -131,7 +131,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                     else
                     {
                         (_game.ObjectManager as ObjectManager)
-                        .UpdateVisibilityAndSpawnIfNeeded(obj, userInfo, forceSpawn: true);
+                        .UpdateVisionAndSpawn(obj, userInfo, forceSpawn: true);
                     }
                 }
             }

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -19,17 +19,15 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 
         public override bool HandlePacket(int userId, StartGameRequest req)
         {
-            var packetNotifier = _game.PacketNotifier as PacketDefinitions420.PacketNotifier;
-
             var peerInfo = _playerManager.GetPeerInfo(userId);
 
             if(_game.IsRunning)
             {
                 if (_game.IsPaused)
                 {
-                    packetNotifier.NotifyPausePacket(peerInfo, (int)_game.PauseTimeLeft, true);
+                    _game.PacketNotifier.NotifyPausePacket(peerInfo, (int)_game.PauseTimeLeft, true);
                 }
-                packetNotifier.NotifyGameStart(userId);
+                _game.PacketNotifier.NotifyGameStart(userId);
 
                 if(peerInfo.IsDisconnected)
                 {
@@ -40,7 +38,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 }
                 
                 SyncTime(userId);
-                
+
                 return true;
             }
             else

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -25,6 +25,12 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 
             if(_game.IsRunning)
             {
+                if (_game.IsPaused)
+                {
+                    packetNotifier.NotifyPausePacket(peerInfo, (int)_game.PauseTimeLeft, true);
+                }
+                packetNotifier.NotifyGameStart(userId);
+
                 if(peerInfo.IsDisconnected)
                 {
                     peerInfo.IsDisconnected = false;
@@ -32,9 +38,9 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                     var announcement = new OnReconnect { OtherNetID = peerInfo.Champion.NetId };
                     _game.PacketNotifier.NotifyS2C_OnEventWorld(announcement, peerInfo.Champion.NetId);
                 }
-
-                packetNotifier.NotifyGameStart(userId);
+                
                 SyncTime(userId);
+                
                 return true;
             }
             else

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -19,108 +19,75 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 
         public override bool HandlePacket(int userId, StartGameRequest req)
         {
+            var packetNotifier = _game.PacketNotifier as PacketDefinitions420.PacketNotifier;
+
             var peerInfo = _playerManager.GetPeerInfo(userId);
 
-            if (!peerInfo.IsDisconnected)
+            if(_game.IsRunning)
             {
-                _game.IncrementReadyPlayers();
-            }
-
-            /* if (_game.IsRunning)
-                return true; */
-            
-            // Only one packet enter here
-            if (_game.PlayersReady == _playerManager.GetPlayers().Count)
-            {
-                _game.PacketNotifier.NotifyGameStart();
-
-                foreach (var player in _playerManager.GetPlayers())
+                if(peerInfo.IsDisconnected)
                 {
-                    // Get notified about the spawn of other connected players - IMPORTANT: should only occur one-time
-                    foreach (var p in _playerManager.GetPlayers(true))
-                    {
-                        if (!p.Item2.IsStartedClient) continue; //user still didn't connect, not get informed about it
-                        if (player.Item2.PlayerId == p.Item2.PlayerId) continue; //Don't self-inform twice
-                        _game.PacketNotifier.NotifyS2C_CreateHero(p.Item2, (int)player.Item2.PlayerId);
-                        _game.PacketNotifier.NotifyAvatarInfo(p.Item2, (int)player.Item2.PlayerId);
-                    }
-
-                    if (player.Item2.PlayerId == userId && !player.Item2.IsMatchingVersion)
-                    {
-                        var msg = "Your client version does not match the server. " +
-                                  "Check the server log for more information.";
-                         _game.PacketNotifier.NotifyS2C_SystemMessage(userId, msg);
-                    }
-
-                    _game.PacketNotifier.NotifySpawn(player.Item2.Champion, userId, false);
-                    
-                    while(player.Item2.Champion.Stats.Level < _game.Map.MapScript.MapScriptMetadata.InitialLevel)
-                    {
-                        player.Item2.Champion.LevelUp(true);
-                    }
-
-                    // TODO: send this in one place only
-                    _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int) player.Item2.PlayerId, "Welcome to League Sandbox!",
-                        "This is a WIP project.", "", 0, player.Item2.Champion.NetId,
-                        _game.NetworkIdManager.GetNewNetId());
-                    _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int) player.Item2.PlayerId, "Server Build Date",
-                        ServerContext.BuildDateString, "", 0, player.Item2.Champion.NetId,
-                        _game.NetworkIdManager.GetNewNetId());
-                    _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int)player.Item2.PlayerId, "Your Champion:",
-                        player.Item2.Champion.Model, "", 0, player.Item2.Champion.NetId,
-                        _game.NetworkIdManager.GetNewNetId());
-                }
-                _game.Start();
-            }
-
-            if (_game.IsRunning)
-            {
-                if (peerInfo.IsDisconnected)
-                {
-                    foreach (var player in _playerManager.GetPlayers(true))
-                    {
-                        if (player.Item2.Team == peerInfo.Team)
-                        {
-                            _game.PacketNotifier.NotifySpawn(player.Item2.Champion, userId, false);
-
-                            /* This is probably not the best way
-                             * of updating a champion's level, but it works */
-                            _game.PacketNotifier.NotifyNPC_LevelUp(player.Item2.Champion);
-                            if (_game.IsPaused)
-                            {
-                                 _game.PacketNotifier.NotifyPausePacket(peerInfo, (int)_game.PauseTimeLeft, true);
-                            }
-                        }
-                    }
                     peerInfo.IsDisconnected = false;
+                    
                     var announcement = new OnReconnect { OtherNetID = peerInfo.Champion.NetId };
                     _game.PacketNotifier.NotifyS2C_OnEventWorld(announcement, peerInfo.Champion.NetId);
-
-                    // Send the initial game time sync packets, then let the map send another
-                    var gameTime = _game.GameTime;
-                     _game.PacketNotifier.NotifySynchSimTimeS2C(userId, gameTime);
-                     _game.PacketNotifier.NotifySyncMissionStartTimeS2C(userId, gameTime);
-
-                    return true;
                 }
 
-                foreach (var p in _playerManager.GetPlayers(true))
+                packetNotifier.NotifyGameStart(userId);
+                SyncTime(userId);
+                return true;
+            }
+            else
+            {
+                if (!peerInfo.IsDisconnected)
                 {
-                    _game.ObjectManager.AddObject(p.Item2.Champion);
+                    _game.IncrementReadyPlayers();
+                }
+                
+                // Only one packet enter here
+                if (_game.PlayersReady == _playerManager.GetPlayers().Count)
+                {
+                    _game.PacketNotifier.NotifyGameStart();
 
-                    if (p.Item2.Champion.IsBot)
+                    foreach (var player in _playerManager.GetPlayers())
                     {
-                        continue;
-                    }
+                        if (player.Item2.PlayerId == userId && !player.Item2.IsMatchingVersion)
+                        {
+                            var msg = "Your client version does not match the server. " +
+                                    "Check the server log for more information.";
+                            _game.PacketNotifier.NotifyS2C_SystemMessage(userId, msg);
+                        }
 
-                    // Send the initial game time sync packets, then let the map send another
-                    var gameTime = _game.GameTime;
-                     _game.PacketNotifier.NotifySynchSimTimeS2C((int) p.Item2.PlayerId, gameTime);
-                     _game.PacketNotifier.NotifySyncMissionStartTimeS2C((int) p.Item2.PlayerId, gameTime);
+                        while(player.Item2.Champion.Stats.Level < _game.Map.MapScript.MapScriptMetadata.InitialLevel)
+                        {
+                            player.Item2.Champion.LevelUp(true);
+                        }
+
+                        // TODO: send this in one place only
+                        _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int) player.Item2.PlayerId, "Welcome to League Sandbox!",
+                            "This is a WIP project.", "", 0, player.Item2.Champion.NetId,
+                            _game.NetworkIdManager.GetNewNetId());
+                        _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int) player.Item2.PlayerId, "Server Build Date",
+                            ServerContext.BuildDateString, "", 0, player.Item2.Champion.NetId,
+                            _game.NetworkIdManager.GetNewNetId());
+                        _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int)player.Item2.PlayerId, "Your Champion:",
+                            player.Item2.Champion.Model, "", 0, player.Item2.Champion.NetId,
+                            _game.NetworkIdManager.GetNewNetId());
+
+                        SyncTime(player.Item2.PlayerId);
+                    }
+                    _game.Start();
                 }
             }
-
             return true;
+        }
+
+        void SyncTime(long userId)
+        {
+            // Send the initial game time sync packets, then let the map send another
+            var gameTime = _game.GameTime;
+            _game.PacketNotifier.NotifySynchSimTimeS2C((int) userId, gameTime);
+            _game.PacketNotifier.NotifySyncMissionStartTimeS2C((int) userId, gameTime);
         }
     }
 }

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -90,7 +90,6 @@ namespace PacketDefinitions420
 
             if (_game.IsPaused && !packetsHandledWhilePaused.Contains(packetId))
             {
-                Console.WriteLine($"1 PACKET {packetId} REJECTED");
                 return null;
             }
 
@@ -117,9 +116,12 @@ namespace PacketDefinitions420
                 GamePacketID.SendSelectedObjID,
                 GamePacketID.C2S_CharSelected,
 
+                // The next two are required to reconnect 
                 GamePacketID.SynchVersionC2S,
                 GamePacketID.C2S_Ping_Load_Info,
 
+                // The next 5 are not really needed when reconnecting,
+                // but they don't do much harm either
                 GamePacketID.C2S_UpdateGameOptions,
                 GamePacketID.OnReplication_Acc,
                 GamePacketID.C2S_StatsUpdateReq,
@@ -128,7 +130,6 @@ namespace PacketDefinitions420
             };
             if (_game.IsPaused && !packetsHandledWhilePaused.Contains(packetId))
             {
-                Console.WriteLine($"2 PACKET {packetId} REJECTED");
                 return null;
             }
             var key = new Tuple<GamePacketID, Channel>(packetId, channelId);
@@ -171,8 +172,6 @@ namespace PacketDefinitions420
 
         public bool SendPacket(int playerId, byte[] source, Channel channelNo, PacketFlags flag = PacketFlags.Reliable)
         {
-            //Console.WriteLine($"SendPacket({playerId}) {new System.Diagnostics.StackTrace().ToString()}");
-
             // Sometimes we try to send packets to a user that doesn't exist (like in broadcast when not all players are connected).
             // TODO: fix casting
             if (_peers.ContainsKey(playerId))
@@ -197,8 +196,6 @@ namespace PacketDefinitions420
 
         public bool BroadcastPacket(byte[] data, Channel channelNo, PacketFlags flag = PacketFlags.Reliable)
         {
-            //Console.WriteLine($"BroadcastPacket() {new System.Diagnostics.StackTrace().ToString()}");
-
             if (data.Length >= 8)
             {
                 // send packet to all peers and save failed ones

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -160,6 +160,8 @@ namespace PacketDefinitions420
 
         public bool SendPacket(int playerId, byte[] source, Channel channelNo, PacketFlags flag = PacketFlags.Reliable)
         {
+            //Console.WriteLine($"SendPacket({playerId}) {new System.Diagnostics.StackTrace().ToString()}");
+
             // Sometimes we try to send packets to a user that doesn't exist (like in broadcast when not all players are connected).
             // TODO: fix casting
             if (_peers.ContainsKey(playerId))
@@ -184,6 +186,8 @@ namespace PacketDefinitions420
 
         public bool BroadcastPacket(byte[] data, Channel channelNo, PacketFlags flag = PacketFlags.Reliable)
         {
+            //Console.WriteLine($"BroadcastPacket() {new System.Diagnostics.StackTrace().ToString()}");
+
             if (data.Length >= 8)
             {
                 // send packet to all peers and save failed ones

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -90,6 +90,7 @@ namespace PacketDefinitions420
 
             if (_game.IsPaused && !packetsHandledWhilePaused.Contains(packetId))
             {
+                Console.WriteLine($"1 PACKET {packetId} REJECTED");
                 return null;
             }
 
@@ -114,10 +115,20 @@ namespace PacketDefinitions420
                 GamePacketID.C2S_Exit,
                 GamePacketID.World_SendGameNumber,
                 GamePacketID.SendSelectedObjID,
-                GamePacketID.C2S_CharSelected
+                GamePacketID.C2S_CharSelected,
+
+                GamePacketID.SynchVersionC2S,
+                GamePacketID.C2S_Ping_Load_Info,
+
+                GamePacketID.C2S_UpdateGameOptions,
+                GamePacketID.OnReplication_Acc,
+                GamePacketID.C2S_StatsUpdateReq,
+                GamePacketID.World_SendCamera_Server,
+                GamePacketID.C2S_OnTipEvent
             };
             if (_game.IsPaused && !packetsHandledWhilePaused.Contains(packetId))
             {
+                Console.WriteLine($"2 PACKET {packetId} REJECTED");
                 return null;
             }
             var key = new Tuple<GamePacketID, Channel>(packetId, channelId);

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -242,19 +242,10 @@ namespace PacketDefinitions420
         public bool BroadcastPacketVision(IGameObject o, byte[] data, Channel channelNo,
             PacketFlags flag = PacketFlags.Reliable)
         {
-            foreach (var team in _teamsEnumerator)
+            foreach (int pid in o.VisibleForPlayers)
             {
-                if (team == TeamId.TEAM_NEUTRAL)
-                {
-                    continue;
-                }
-
-                if (o.IsVisibleByTeam(team))
-                {
-                    BroadcastPacketTeam(team, data, channelNo, flag);
-                }
+                SendPacket(pid, data, channelNo, flag);
             }
-
             return true;
         }
 

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3804,7 +3804,7 @@ namespace PacketDefinitions420
         /// <summary>
         /// Sends a notification that the object has entered the team's scope and fully synchronizes its state.
         /// </summary>
-        public void NotifyEnterTeamVision(IGameObject obj, TeamId team, int userId = 0, GamePacket spawnPacket = null)
+        void NotifyEnterTeamVision(IGameObject obj, TeamId team, int userId = 0, GamePacket spawnPacket = null)
         {
             if(obj is IAttackableUnit u)
             {
@@ -3843,16 +3843,17 @@ namespace PacketDefinitions420
             else //if(obj is IRegion || obj is ISpellMissile || obj is ILevelProp || obj is IParticle)
             {
                 var packet = spawnPacket;
-
-                if (spawnPacket == null && obj is IParticle p)
+                if (packet == null)
                 {
-                    packet = ConstructFXEnterTeamVisibilityPacket(p, team);
-                }
-                else
-                {
-                    packet = ConstructOnEnterTeamVisibilityPacket(obj, team);
-                }
-
+                    if(obj is IParticle p)
+                    {
+                        packet = ConstructFXEnterTeamVisibilityPacket(p, team);
+                    }
+                    else
+                    {
+                        packet = ConstructOnEnterTeamVisibilityPacket(obj, team); // Generic visibility packet
+                    }
+                };
                 if(userId == 0)
                 {
                     _packetHandlerManager.BroadcastPacketTeam(team, packet.GetBytes(), Channel.CHL_S2C);
@@ -3864,8 +3865,7 @@ namespace PacketDefinitions420
             }
         }
 
-        //TODO: rework too?
-        public void NotifyLeaveTeamVision(IGameObject obj, TeamId team, int userId = 0)
+        void NotifyLeaveTeamVision(IGameObject obj, TeamId team, int userId = 0)
         {
             if(obj is IParticle p)
             {

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -1038,12 +1038,19 @@ namespace PacketDefinitions420
 
         S2C_FX_OnEnterTeamVisibility ConstructFXEnterTeamVisibilityPacket(IParticle particle, TeamId team)
         {
-            return new S2C_FX_OnEnterTeamVisibility
+            var fxVisPacket = new S2C_FX_OnEnterTeamVisibility
             {
                 SenderNetID = particle.NetId,
-                NetID = particle.NetId,
-                VisibilityTeam = (byte)team
+                NetID = particle.NetId
             };
+
+            fxVisPacket.VisibilityTeam = 0;
+            if (team == TeamId.TEAM_PURPLE || team == TeamId.TEAM_NEUTRAL)
+            {
+                fxVisPacket.VisibilityTeam = 1;
+            }
+
+            return fxVisPacket;
         }
 
         /// <summary>
@@ -1054,13 +1061,6 @@ namespace PacketDefinitions420
         public void NotifyFXEnterTeamVisibility(IParticle particle, TeamId team)
         {
             var fxVisPacket = ConstructFXEnterTeamVisibilityPacket(particle, team);
-
-            fxVisPacket.VisibilityTeam = 0;
-            if (team == TeamId.TEAM_PURPLE || team == TeamId.TEAM_NEUTRAL)
-            {
-                fxVisPacket.VisibilityTeam = 1;
-            }
-
             _packetHandlerManager.BroadcastPacketTeam(team, fxVisPacket.GetBytes(), Channel.CHL_S2C);
         }
 
@@ -2672,11 +2672,18 @@ namespace PacketDefinitions420
 
         S2C_OnEnterTeamVisibility ConstructOnEnterTeamVisibilityPacket(IGameObject o, TeamId team)
         {
-            return new S2C_OnEnterTeamVisibility()
+            var enterTeamVis = new S2C_OnEnterTeamVisibility()
             {
-                SenderNetID = o.NetId,
-                VisibilityTeam = (byte)team
+                SenderNetID = o.NetId
             };
+
+            enterTeamVis.VisibilityTeam = 0;
+            if (team == TeamId.TEAM_PURPLE || team == TeamId.TEAM_NEUTRAL)
+            {
+                enterTeamVis.VisibilityTeam = 1;
+            }
+
+            return enterTeamVis;
         }
 
         /// <summary>
@@ -2688,12 +2695,6 @@ namespace PacketDefinitions420
         public void NotifyS2C_OnEnterTeamVisibility(IGameObject o, TeamId team, int userId = 0)
         {
             var enterTeamVis = ConstructOnEnterTeamVisibilityPacket(o, team);
-
-            enterTeamVis.VisibilityTeam = 0;
-            if (team == TeamId.TEAM_PURPLE || team == TeamId.TEAM_NEUTRAL)
-            {
-                enterTeamVis.VisibilityTeam = 1;
-            }
 
             if (userId == 0)
             {


### PR DESCRIPTION
Previously, the vision system tried to be team-based. The proposed one still calculates team vision, but sends out packets based on players' individual vision, which is linked to their champions' vision. This will make it possible to implement such effects as nearsight in the future.
- It is now possible to describe all the conditions under which one unit sees another in one place, in the `UnitHasVisionOn` function of the `ObjectManager`.
- Some objects now only spawn when entering player line of sight to prevent cheating:
`spawnShouldBeHidden = obj is IParticle || obj is ISpellMissile || (obj is IMinion && !(obj is ILaneMinion))`
- Part of the functionality has been moved from `HandleStartGame` to `HandleSpawn`. Now it is possible to reconnect and use skills and reconnect during a pause (still have bugs with minimap, inventory and time)