### PR TITLE
Attack, Cast, and Dash QOL

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Caitlyn/CaitlynEntrapment.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Caitlyn/CaitlynEntrapment.cs
@@ -1,0 +1,36 @@
+﻿using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using System.Collections.Generic;
+
+namespace Buffs
+{
+    internal class CaitlynEntrapment : IBuffGameScript
+    {
+        public IBuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffAddType = BuffAddType.REPLACE_EXISTING,
+            IsHidden = true
+        };
+
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
+
+        public void OnUpdate(float diff)
+        {
+        }
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            OverrideAnimation(unit, "Spell3b", "Run");
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            ClearOverrideAnimation(unit, "Run");
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/Caitlyn/CaitlynEntrapmentMissile.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Caitlyn/CaitlynEntrapmentMissile.cs
@@ -1,0 +1,40 @@
+﻿using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeagueSandbox.GameServer.GameObjects.Stats;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using System.Collections.Generic;
+
+namespace Buffs
+{
+    internal class CaitlynEntrapmentMissile : IBuffGameScript
+    {
+        public IBuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffType = BuffType.SLOW,
+            BuffAddType = BuffAddType.STACKS_AND_OVERLAPS,
+            MaxStacks = 100,
+            IsHidden = true
+        };
+
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
+
+        IParticle slowParticle;
+
+        public void OnUpdate(float diff)
+        {
+        }
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            slowParticle = AddParticleTarget(unit, unit, "caitlyn_entrapment_slow", unit, buff.Duration);
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            RemoveParticle(slowParticle);
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Recall.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Recall.cs
@@ -48,7 +48,7 @@ namespace Buffs
         {
             if (willRemove)
             {
-                owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.LostTarget);
+                StopChanneling(owner, ChannelingStopCondition.Cancel, ChannelingStopSource.LostTarget);
 
                 RemoveBuff(sourceBuff);
             }

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Slow.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Slow.cs
@@ -4,6 +4,7 @@ using GameServerCore.Domain.GameObjects.Spell;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using LeagueSandbox.GameServer.GameObjects.Stats;
 
 namespace Buffs
 {
@@ -16,7 +17,7 @@ namespace Buffs
             MaxStacks = 100
         };
 
-        public IStatsModifier StatsModifier { get; private set; }
+        public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
         IParticle slow;
         IAttackableUnit owner;

--- a/Content/LeagueSandbox-Scripts/Characters/Caitlyn/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Caitlyn/E.cs
@@ -6,6 +6,9 @@ using GameServerCore.Domain.GameObjects.Spell.Missile;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using GameServerCore.Scripting.CSharp;
+using GameServerCore.Domain.GameObjects.Spell.Sector;
+using LeagueSandbox.GameServer.API;
+using Buffs;
 
 namespace Spells
 {
@@ -13,8 +16,10 @@ namespace Spells
     {
         public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
-            TriggersSpellCasts = true
-            // TODO
+            DoesntBreakShields = true,
+            TriggersSpellCasts = true,
+            NotSingleTargetSpell = false,
+            SpellDamageRatio = 1.0f
         };
 
         public void OnActivate(IObjAiBase owner, ISpell spell)
@@ -36,31 +41,138 @@ namespace Spells
         public void OnSpellPostCast(ISpell spell)
         {
             var owner = spell.CastInfo.Owner;
-            // Calculate net coords
-            var current = new Vector2(owner.Position.X, owner.Position.Y);
             var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
-            var to = Vector2.Normalize(spellPos - current);
-            var range = to * 750;
-            var trueCoords = current + range;
 
-            // Calculate dash coords/vector
-            var dash = Vector2.Negate(to) * 500;
-            var dashCoords = current + dash;
-            ForceMovement(owner, "Spell3", dashCoords, 1000, 0, 0, 0, movementOrdersFacing: ForceMovementOrdersFacing.KEEP_CURRENT_FACING);
-            //spell.AddProjectile("CaitlynEntrapmentMissile", current, current, trueCoords);
+            FaceDirection(spellPos, owner, true);
+
+            var misPos = GetPointFromUnit(owner, spell.SpellData.CastRangeDisplayOverride);
+            SpellCast(owner, 1, SpellSlotType.ExtraSlots, misPos, misPos, true, Vector2.Zero);
+
+            if (owner.CanMove())
+            {
+                AddBuff("CaitlynEntrapment", 0.25f, 1, spell, owner, owner);
+
+                // Distance is 500 - 10 = 490 (a point 10 units in front is used for MoveAway, decreasing the effective range by 10)
+                ForceMovement(owner, "", GetPointFromUnit(owner, 490f, 180f), 1000f, 0.0f, 3.0f, 0.0f, movementOrdersFacing: ForceMovementOrdersFacing.KEEP_CURRENT_FACING);
+            }
         }
 
-        public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, ISpellMissile missile)
+        public void OnSpellChannel(ISpell spell)
         {
-            var ap = owner.Stats.AbilityPower.Total * 0.8f;
-            var damage = 80 + (spell.CastInfo.SpellLevel - 1) * 50 + ap;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
-            var slowDuration = new[] { 0, 1, 1.25f, 1.5f, 1.75f, 2 }[spell.CastInfo.SpellLevel];
-            AddBuff("Slow", slowDuration, 1, spell, target, owner);
-            AddParticleTarget(owner, target, "caitlyn_entrapment_tar", target);
-            AddParticleTarget(owner, target, "caitlyn_entrapment_slow", target);
+        }
 
-            missile.SetToRemove();
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+
+    public class CaitlynEntrapmentMissile : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            DoesntBreakShields = true,
+            TriggersSpellCasts = true,
+            NotSingleTargetSpell = false,
+            SpellDamageRatio = 1.0f,
+            MissileParameters = new MissileParameters
+            {
+                Type = MissileType.Circle
+            }
+        };
+
+        //Vector2 direction;
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+            ApiEventManager.OnSpellHit.AddListener(this, spell, TargetExecute, false);
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+
+        public void TargetExecute(ISpell spell, IAttackableUnit target, ISpellMissile missile, ISpellSector sector)
+        {
+            var owner = spell.CastInfo.Owner;
+
+            if (!target.Status.HasFlag(StatusFlags.Stealthed))
+            {
+                // BreakSpellShields(target);
+
+                var slowDuration = new[] { 0, 1, 1.25f, 1.5f, 1.75f, 2 }[spell.CastInfo.SpellLevel];
+                var slowBuffScript = AddBuff("Slow", slowDuration, 1, spell, target, owner).BuffScript as Slow;
+                slowBuffScript.SetSlowMod(0.5f);
+
+                AddBuff("CaitlynEntrapmentMissile", slowDuration, 1, spell, target, owner);
+
+                var ap = owner.Stats.AbilityPower.Total * 0.8f;
+                var damage = 80 + (spell.CastInfo.SpellLevel - 1) * 50 + ap;
+                target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+
+                AddParticleTarget(owner, target, "caitlyn_entrapment_tar", target);
+
+                missile.SetToRemove();
+            }
+            else
+            {
+                if (target is IChampion)
+                {
+                    // BreakSpellShields(target);
+
+                    var slowDuration = new[] { 0, 1, 1.25f, 1.5f, 1.75f, 2 }[spell.CastInfo.SpellLevel];
+                    var slowBuffScript = AddBuff("Slow", slowDuration, 1, spell, target, owner).BuffScript as Slow;
+                    slowBuffScript.SetSlowMod(0.5f);
+
+                    AddBuff("CaitlynEntrapmentMissile", slowDuration, 1, spell, target, owner);
+
+                    var ap = owner.Stats.AbilityPower.Total * 0.8f;
+                    var damage = 80 + (spell.CastInfo.SpellLevel - 1) * 50 + ap;
+                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+
+                    AddParticleTarget(owner, target, "caitlyn_entrapment_tar", target);
+
+                    missile.SetToRemove();
+                }
+                // TODO: Implement a CanSee function for specific unit->unit vision checking (things such as blinds need this)
+                else if (TeamHasVision(owner.Team, target))
+                {
+                    // BreakSpellShields(target);
+
+                    var slowDuration = new[] { 0, 1, 1.25f, 1.5f, 1.75f, 2 }[spell.CastInfo.SpellLevel];
+                    var slowBuffScript = AddBuff("Slow", slowDuration, 1, spell, target, owner).BuffScript as Slow;
+                    slowBuffScript.SetSlowMod(0.5f);
+
+                    AddBuff("CaitlynEntrapmentMissile", slowDuration, 1, spell, target, owner);
+
+                    var ap = owner.Stats.AbilityPower.Total * 0.8f;
+                    var damage = 80 + (spell.CastInfo.SpellLevel - 1) * 50 + ap;
+                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+
+                    AddParticleTarget(owner, target, "caitlyn_entrapment_tar", target);
+
+                    missile.SetToRemove();
+                }
+            }
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
         }
 
         public void OnSpellChannel(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Characters/Global/SummonerFlash.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Global/SummonerFlash.cs
@@ -13,6 +13,8 @@ namespace Spells
     {
         public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
+            CastingBreaksStealth = false,
+            TriggersSpellCasts = false,
             NotSingleTargetSpell = true
             // TODO
         };
@@ -28,27 +30,21 @@ namespace Spells
         public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
         {
             var current = new Vector2(owner.Position.X, owner.Position.Y);
-            var to = start - current;
-            Vector2 trueCoords;
+            var dist = Vector2.Distance(current, start);
 
-            if (to.Length() > 425)
+            FaceDirection(start, owner, true);
+
+            if (dist > spell.SpellData.CastRangeDisplayOverride)
             {
-                to = Vector2.Normalize(to);
-                var range = to * 425;
-                trueCoords = current + range;
-            }
-            else
-            {
-                trueCoords = start;
+                start = GetPointFromUnit(owner, spell.SpellData.CastRangeDisplayOverride);
             }
 
-            owner.FaceDirection(new Vector3(to.X, 0.0f, to.Y));
-            owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.Move);
+            StopChanneling(owner, ChannelingStopCondition.Cancel, ChannelingStopSource.Move);
 
             AddParticle(owner, null, "global_ss_flash", owner.Position);
             AddParticleTarget(owner, owner, "global_ss_flash_02", owner);
 
-            TeleportTo(owner, trueCoords.X, trueCoords.Y);
+            TeleportTo(owner, start.X, start.Y);
         }
 
         public void OnSpellCast(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Characters/Graves/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Graves/E.cs
@@ -18,7 +18,6 @@ namespace Spells
             TriggersSpellCasts = true,
             IsDamagingSpell = false,
             NotSingleTargetSpell = true
-            // TODO
         };
 
         public void OnActivate(IObjAiBase owner, ISpell spell)
@@ -42,9 +41,15 @@ namespace Spells
             var owner = spell.CastInfo.Owner;
             var current = new Vector2(owner.Position.X, owner.Position.Y);
             var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
-            var to = Vector2.Normalize(spellPos - current);
-            var range = to * 425;
-            var trueCoords = current + range;
+            var dist = Vector2.Distance(current, spellPos);
+
+            if (dist > 425.0f)
+            {
+                dist = 425.0f;
+            }
+
+            FaceDirection(spellPos, owner, true);
+            var trueCoords = GetPointFromUnit(owner, dist);
 
             ForceMovement(owner, "Spell3", trueCoords, 1200, 0, 0, 0);
             AddBuff("Quickdraw", 4.0f, 1, spell, owner, owner);

--- a/Content/LeagueSandbox-Scripts/Characters/Lucian/E.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Lucian/E.cs
@@ -34,14 +34,13 @@ namespace Spells
 
         public void OnSpellPostCast(ISpell spell)
         {
-            var current = new Vector2(spell.CastInfo.Owner.Position.X, spell.CastInfo.Owner.Position.Y);
+            var owner = spell.CastInfo.Owner;
             var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
-            var to = Vector2.Normalize(spellPos - current);
-            var range = to * spell.SpellData.CastRangeDisplayOverride;
-            var trueCoords = current + range;
 
-            FaceDirection(trueCoords, spell.CastInfo.Owner, true);
-            ForceMovement(spell.CastInfo.Owner, "Spell3", trueCoords, 1350, 0, 0, 0, movementOrdersFacing: GameServerCore.Enums.ForceMovementOrdersFacing.KEEP_CURRENT_FACING);
+            FaceDirection(spellPos, owner, true);
+            var trueCoords = GetPointFromUnit(owner, spell.SpellData.CastRangeDisplayOverride);
+
+            ForceMovement(owner, "Spell3", trueCoords, 1350, 0, 0, 0, movementOrdersFacing: ForceMovementOrdersFacing.KEEP_CURRENT_FACING);
         }
 
         public void OnSpellChannel(ISpell spell)

--- a/Content/LeagueSandbox-Scripts/Characters/Lucian/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Lucian/Q.cs
@@ -48,7 +48,7 @@ namespace Spells
             spell.CreateSpellSector(new SectorParameters
             {
                 BindObject = owner,
-                Length = 550f,
+                Length = 1100f,
                 Width = spell.SpellData.LineWidth,
                 PolygonVertices = new Vector2[]
                 {

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -578,9 +578,9 @@ namespace LeagueSandbox.GameServer.API
         /// <returns>List of AttackableUnits.</returns>
         public static IEnumerable<IAttackableUnit> EnumerateUnitsInRange(Vector2 targetPos, float range, bool isAlive)
         {
-            foreach(var obj in _game.Map.CollisionHandler.QuadDynamic.GetNodesInside(targetPos, range))
+            foreach (var obj in _game.Map.CollisionHandler.QuadDynamic.GetNodesInside(targetPos, range))
             {
-                if(obj is IAttackableUnit u && (!isAlive || !u.IsDead))
+                if (obj is IAttackableUnit u && (!isAlive || !u.IsDead))
                 {
                     yield return u;
                 }
@@ -814,15 +814,25 @@ namespace LeagueSandbox.GameServer.API
         }
 
         /// <summary>
-        /// Sets the specified unit's animation states to the given set of states.
-        /// Given state pairs are expected to follow a specific structure:
+        /// Overrides the given animation with the other given animation.
         /// First string is the animation to override, second string is the animation to play in place of the first.
         /// </summary>
         /// <param name="unit">Unit to set animation states on.</param>
-        /// <param name="animPairs">Dictionary of animations to set.</param>
-        public static void SetAnimStates(IAttackableUnit unit, Dictionary<string, string> animPairs)
+        /// <param name="overrideAnim">Animation to use instead.</param>
+        /// <param name="toOverrideAnim">Animation to override.</param>
+        public static void OverrideAnimation(IAttackableUnit unit, string overrideAnim, string toOverrideAnim)
         {
-            unit.SetAnimStates(animPairs);
+            unit.SetAnimStates(new Dictionary<string, string> { { toOverrideAnim, overrideAnim } });
+        }
+
+        /// <summary>
+        /// Clears the given overridden animation, making it play its original animation.
+        /// </summary>
+        /// <param name="unit">Unit to set animation states on.</param>
+        /// <param name="overriddenAnim">Animation which has been overridden.</param>
+        public static void ClearOverrideAnimation(IAttackableUnit unit, string overriddenAnim)
+        {
+            unit.SetAnimStates(new Dictionary<string, string> { { overriddenAnim, "" } });
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -81,7 +81,7 @@ namespace LeagueSandbox.GameServer.GameObjects
                 NetId = _networkIdManager.GetNewNetId(); // base class assigns a netId
             }
             Position = position;
-            Direction = new Vector3();
+            Direction = Vector3.Zero;
             SyncId = Environment.TickCount; // TODO: use movement manager to generate this
             CollisionRadius = collisionRadius;
             PathfindingRadius = pathingRadius;


### PR DESCRIPTION
* Scripting:
  * Caitlyn E, Flash, Graves E, Lucian E, and Lucian Q have been made more accurate.
  * The API supports OverrideAnimation function for overridding individial animations.
* ObjAIBase:
  * Added CanChangeWaypoints used for blocking changes in waypoints in order to maintain the current path (forced movements as an example).
  * CanMove and CanCast now correctly account for casts, channels, and attacks.
  * Fixed an issue where spell cast queue would prevent attack move queue.
  * Fixed an issue where attacking state would not be reset when the attack has finished.
  * Attack move will now wait until an attack can be made before stopping movement.
* AttackableUnit:
  * Dashes now properly maintain their facing direction
* Spell:
  * Forced movements disable casting.
  * OnSpellChannel is published at the end of the Channel function.
  * OnSpellPostCast is published at the end of the FinishCasting function.
  * Fixed an issue where spell queues would be removed by another spell.
* Packets:
  * HandleMove separates movements from targetting, allowing for one to occur without the other (in the case of a forced movement).
  * HandleMove overrides spell queues in favor of a normal movement or attack queue.