### PR TITLE
Resolve #1350 -- Late connect fix

### DIFF
--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -47,9 +47,6 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// Comparison variable for small distance movements.
         /// </summary>
         public static readonly uint MOVEMENT_EPSILON = 5; //TODO: Verify if this should be changed
-        /// <summary>
-        /// Whether or not this object counts as a single point target. *NOTE*: Will be depricated once Target class is removed.
-        /// </summary>
 
         /// <summary>
         ///  Identifier unique to this game object.

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -356,18 +356,11 @@ namespace LeagueSandbox.GameServer
         /// <returns>true/false; networked or not.</returns>
         public bool TeamHasVisionOn(TeamId team, IGameObject o)
         {
-            if (o == null)
+            if (o != null)
             {
-                return false;
-            }
-
-            foreach (var kv in _visionProviders[team])
-            {
-                if (
-                    UnitHasVisionOn(kv, o)
-                )
+                foreach (var p in _visionProviders[team])
                 {
-                    if (!(kv is IAttackableUnit unit && unit.IsDead))
+                    if (UnitHasVisionOn(p, o))
                     {
                         return true;
                     }
@@ -411,7 +404,8 @@ namespace LeagueSandbox.GameServer
             }
 
             if(
-                Vector2.DistanceSquared(observer.Position, tested.Position) < observer.VisionRadius * observer.VisionRadius
+                !(observer is IAttackableUnit u && u.IsDead)
+                && Vector2.DistanceSquared(observer.Position, tested.Position) < observer.VisionRadius * observer.VisionRadius
                 && !_game.Map.NavigationGrid.IsAnythingBetween(observer, tested, true)
             ){
                 return true;

--- a/GameServerLib/Players/PlayerManager.cs
+++ b/GameServerLib/Players/PlayerManager.cs
@@ -56,6 +56,9 @@ namespace LeagueSandbox.GameServer.Players
                 summonerSkills,
                 p.Value.PlayerID // same as StartClient.bat
             );
+            
+            player.ClientId = (uint)_players.Count;
+
             var c = new Champion(_game, p.Value.Champion, (uint)player.PlayerId, _userIdsPerTeam[teamId]++, p.Value.Runes, player, 0, teamId);
 
             var pos = c.GetSpawnPosition((int)_userIdsPerTeam[teamId]);


### PR DESCRIPTION
- Now the `ClientId` is issued when the server starts, and when connecting, the client is informed of the correspondence of all `PlayerId`s registered in the game by their `ClientId`.
- Also, the death check has been moved from `TeamHasVisionOn` to `UnitHasVisionOn` because it looks better and prevents a theoretical bug where a vision-limited champion can still see the surroundings after death.
- Also, an obsolete comment was removed, which was displayed by VSCode as a comment to the `NetId` field.