### PR TITLE
Resolve #1355, Resolve #1356 -- Spell and Sector Cleanup (#1354)

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQManager.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQManager.cs
@@ -1,0 +1,59 @@
+﻿using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using System;
+
+namespace Buffs
+{
+    internal class BlindMonkQManager : IBuffGameScript
+    {
+        public IBuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffAddType = BuffAddType.REPLACE_EXISTING
+        };
+
+        public IStatsModifier StatsModifier { get; private set; }
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            var owner = unit as IObjAiBase;
+
+            if (owner != null)
+            {
+                var qTwoSpell = owner.SetSpell("BlindMonkQTwo", 0, true, true);
+                // TODO: Instead of doing this, simply make an API function for SetSpellSlotCooldown
+                qTwoSpell.SetCooldown(0, true);
+
+                var qOneBuff = buff.SourceUnit.GetBuffWithName("BlindMonkQOne");
+                var qOneChaosBuff = buff.SourceUnit.GetBuffWithName("BlindMonkQOneChaos");
+
+                if (qOneBuff == null && qOneChaosBuff == null)
+                {
+                    RemoveBuff(buff);
+                }
+            }
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            var owner = unit as IObjAiBase;
+
+            if (owner != null)
+            {
+                float[] cdByLevel = { 7f, 6f, 5f, 4f, 3f };
+                var newCooldown = (MathF.Max(buff.TimeElapsed - 3.0f, 0f) + cdByLevel[ownerSpell.CastInfo.SpellLevel - 1]) * owner.Stats.CooldownReduction.Total;
+
+                var qTwoSpell = owner.SetSpell("BlindMonkQOne", 0, true, true);
+                // TODO: Instead of doing this, simply make an API function for SetSpellSlotCooldown
+                qTwoSpell.SetCooldown(newCooldown, true);
+            }
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQOne.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQOne.cs
@@ -1,0 +1,63 @@
+﻿using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+
+namespace Buffs
+{
+    internal class BlindMonkQOne : IBuffGameScript
+    {
+        public IBuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffType = BuffType.COMBAT_DEHANCER,
+            BuffAddType = BuffAddType.REPLACE_EXISTING
+        };
+
+        public IStatsModifier StatsModifier { get; private set; }
+
+        ISpell originSpell;
+        IBuff thisBuff;
+        IRegion bubble1;
+        IRegion bubble2;
+        IParticle slow;
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            originSpell = ownerSpell;
+            thisBuff = buff;
+
+            bubble1 = AddUnitPerceptionBubble(unit, 400.0f, 20.0f, buff.SourceUnit.Team);
+            bubble2 = AddUnitPerceptionBubble(unit, 50.0f, 20.0f, buff.SourceUnit.Team, true);
+
+            // ApplyAssistMarker(buff.SourceUnit, unit, 10.0f);
+
+            AddParticleTarget(buff.SourceUnit, unit, "blindMonk_Q_resonatingStrike_tar", unit, buff.Duration, bone: "C_BuffBone_Glb_Center_Loc", flags: 0);
+            AddParticleTarget(buff.SourceUnit, unit, "blindMonk_Q_resonatingStrike_tar_blood", unit, buff.Duration, bone: "C_BuffBone_Glb_Center_Loc", flags: 0);
+            slow = AddParticleTarget(buff.SourceUnit, unit, "blindMonk_Q_tar_indicator", unit, buff.Duration, flags: 0);
+            if (buff.SourceUnit.SkinID == 5)
+            {
+                AddParticleTarget(buff.SourceUnit, unit, "leesin_skin05_q_tar_sound", unit, buff.Duration, bone: "C_BuffBone_Glb_Center_Loc", flags: 0);
+            }
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            bubble1.SetToRemove();
+            bubble2.SetToRemove();
+            slow.SetToRemove();
+
+            var manager = unit.GetBuffWithName("BlindMonkQManager");
+
+            if (manager != null && manager.SourceUnit == buff.SourceUnit)
+            {
+                RemoveBuff(manager);
+            }
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQOneChaos.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQOneChaos.cs
@@ -1,0 +1,63 @@
+﻿using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+
+namespace Buffs
+{
+    internal class BlindMonkQOneChaos : IBuffGameScript
+    {
+        public IBuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffType = BuffType.COMBAT_DEHANCER,
+            BuffAddType = BuffAddType.REPLACE_EXISTING
+        };
+
+        public IStatsModifier StatsModifier { get; private set; }
+
+        ISpell originSpell;
+        IBuff thisBuff;
+        IRegion bubble1;
+        IRegion bubble2;
+        IParticle slow;
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            originSpell = ownerSpell;
+            thisBuff = buff;
+
+            bubble1 = AddUnitPerceptionBubble(unit, 400.0f, 20.0f, buff.SourceUnit.Team);
+            bubble2 = AddUnitPerceptionBubble(unit, 50.0f, 20.0f, buff.SourceUnit.Team, true);
+
+            // ApplyAssistMarker(buff.SourceUnit, unit, 10.0f);
+
+            AddParticleTarget(buff.SourceUnit, unit, "blindMonk_Q_resonatingStrike_tar", unit, buff.Duration, bone: "C_BuffBone_Glb_Center_Loc", flags: 0);
+            AddParticleTarget(buff.SourceUnit, unit, "blindMonk_Q_resonatingStrike_tar_blood", unit, buff.Duration, bone: "C_BuffBone_Glb_Center_Loc", flags: 0);
+            slow = AddParticleTarget(buff.SourceUnit, unit, "blindMonk_Q_tar_indicator", unit, buff.Duration, flags: 0);
+            if (buff.SourceUnit.SkinID == 5)
+            {
+                AddParticleTarget(buff.SourceUnit, unit, "leesin_skin05_q_tar_sound", unit, buff.Duration, bone: "C_BuffBone_Glb_Center_Loc", flags: 0);
+            }
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            bubble1.SetToRemove();
+            bubble2.SetToRemove();
+            slow.SetToRemove();
+
+            var manager = unit.GetBuffWithName("BlindMonkQManager");
+
+            if (manager != null && manager.SourceUnit == buff.SourceUnit)
+            {
+                RemoveBuff(manager);
+            }
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQTwoDash.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQTwoDash.cs
@@ -1,0 +1,98 @@
+﻿using GameServerCore.Enums;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using System;
+using System.Numerics;
+
+namespace Buffs
+{
+    internal class BlindMonkQTwoDash : IBuffGameScript
+    {
+        public IBuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffAddType = BuffAddType.REPLACE_EXISTING
+        };
+
+        public IStatsModifier StatsModifier { get; private set; }
+
+        IObjAiBase owner;
+        ISpell originSpell;
+        IBuff thisBuff;
+        IAttackableUnit target;
+        bool toRemove;
+        IParticle selfParticle;
+
+        public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            owner = ownerSpell.CastInfo.Owner;
+            thisBuff = buff;
+            originSpell = ownerSpell;
+            target = buff.SourceUnit;
+            ApiEventManager.OnMoveEnd.AddListener(this, unit, OnMoveEnd, true);
+            ApiEventManager.OnMoveSuccess.AddListener(this, unit, OnMoveSuccess, true);
+
+            var dashSpeed = 1350f + owner.Stats.MoveSpeed.Total;
+
+            ForceMovement(owner, target, "", dashSpeed, 0f, Vector2.Distance(target.Position, owner.Position), 0f, -1f, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
+
+            selfParticle = AddParticleTarget(owner, owner, "blindMonk_Q_resonatingStrike_mis", owner, flags: 0);
+            // Flags: Blend false, Lock true, Loop true
+            PlayAnimation(owner, "Spell1b", 0f, flags: AnimationFlags.Lock);
+            toRemove = false;
+            SetStatus(owner, StatusFlags.Ghosted, true);
+        }
+
+        public void OnMoveEnd(IAttackableUnit unit)
+        {
+            toRemove = true;
+        }
+
+        public void OnMoveSuccess(IAttackableUnit unit)
+        {
+            var missingHealth = target.Stats.HealthPoints.Total - target.Stats.CurrentHealth;
+            var bonusDamage = missingHealth * 0.08f;
+
+            if (target.Team == TeamId.TEAM_NEUTRAL)
+            {
+                bonusDamage = MathF.Min(bonusDamage, 400.0f);
+            }
+
+            // BreakSpellShields(target);
+
+            var ad = owner.Stats.AttackDamage.Total * 1.0f;
+            var damage = 50 + (originSpell.CastInfo.SpellLevel * 30) + ad + bonusDamage;
+
+            AddBuff("BlindMonkQTwoDashParticle", 0.1f, 1, originSpell, target, owner);
+
+            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+
+            RemoveBuff(thisBuff);
+
+            if (owner.Team != target.Team && target is IChampion)
+            {
+                owner.SetTargetUnit(target, true);
+                owner.UpdateMoveOrder(OrderType.AttackTo, true);
+            }
+        }
+
+        public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
+        {
+            RemoveParticle(selfParticle);
+            // Flags: Blend true
+            // UnlockAnimation(true, unit);
+            SetStatus(owner, StatusFlags.Ghosted, false);
+        }
+
+        public void OnUpdate(float diff)
+        {
+            if (thisBuff != null && toRemove)
+            {
+                RemoveBuff(thisBuff);
+            }
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkSonicWave.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkSonicWave.cs
@@ -11,18 +11,14 @@ namespace Buffs
     {
         public IBuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
         {
+            BuffType = BuffType.COMBAT_DEHANCER,
             BuffAddType = BuffAddType.REPLACE_EXISTING
         };
 
         public IStatsModifier StatsModifier { get; private set; }
 
-        ISpell originSpell;
-        IBuff thisBuff;
-
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            originSpell = ownerSpell;
-            thisBuff = buff;
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
@@ -31,23 +27,6 @@ namespace Buffs
 
         public void OnUpdate(float diff)
         {
-            if (thisBuff == null || originSpell == null || thisBuff.Elapsed())
-            {
-                return;
-            }
-
-            var owner = originSpell.CastInfo.Owner;
-            var target = thisBuff.TargetUnit;
-            if (owner.MovementParameters != null && owner.IsCollidingWith(target))
-            {
-                owner.SetDashingState(false);
-                var ad = owner.Stats.AttackDamage.Total * 1.0f;
-                var damage = 50 + (originSpell.CastInfo.SpellLevel * 30) + ad + (0.08f * (target.Stats.HealthPoints.Total - target.Stats.CurrentHealth));
-                target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_REACTIVE, false);
-                AddParticleTarget(owner, owner, "GlobalHit_Yellow_tar", target);
-
-                thisBuff.DeactivateBuff();
-            }
         }
     }
 }

--- a/Content/LeagueSandbox-Scripts/Characters/Kalista/CharScriptKalista.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Kalista/CharScriptKalista.cs
@@ -124,7 +124,7 @@ namespace CharScripts
                 // TODO: Verify flags.
                 PlayAnimation(owner, "Attack1_Dash", 0.0f, 0.0f, 1.0f, flags: AnimationFlags.Unknown8 | AnimationFlags.UniqueOverride);
                 owner.CancelAutoAttack(false, true);
-                ForceMovement(owner, "", targetPos, speed, 0.0f, 0.0f, 0.0f, ForceMovementType.FIRST_WALL_HIT, ForceMovementOrdersType.POSTPONE_CURRENT_ORDER, ForceMovementOrdersFacing.FACE_MOVEMENT_DIRECTION);
+                ForceMovement(owner, "", targetPos, speed, 0.0f, 0.0f, 0.0f, true, ForceMovementType.FIRST_WALL_HIT, ForceMovementOrdersType.POSTPONE_CURRENT_ORDER, ForceMovementOrdersFacing.FACE_MOVEMENT_DIRECTION);
             }
         }
 

--- a/Content/LeagueSandbox-Scripts/Characters/LeeSin/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/LeeSin/Q.cs
@@ -6,6 +6,8 @@ using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using GameServerCore.Domain.GameObjects.Spell.Sector;
 
 namespace Spells
 {
@@ -13,12 +15,17 @@ namespace Spells
     {
         public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
-            TriggersSpellCasts = true
-            // TODO
+            TriggersSpellCasts = true,
+            NotSingleTargetSpell = true,
+            MissileParameters = new MissileParameters
+            {
+                Type = MissileType.Circle
+            }
         };
 
         public void OnActivate(IObjAiBase owner, ISpell spell)
         {
+            ApiEventManager.OnSpellHit.AddListener(this, spell, TargetExecute, false);
         }
 
         public void OnDeactivate(IObjAiBase owner, ISpell spell)
@@ -43,21 +50,87 @@ namespace Spells
             //spell.AddProjectile("BlindMonkQOne", new Vector2(spell.CastInfo.SpellCastLaunchPosition.X, spell.CastInfo.SpellCastLaunchPosition.Z), current, trueCoords, HitResult.HIT_Normal, true);
         }
 
-        public void ApplyEffects(IObjAiBase owner, IAttackableUnit target, ISpell spell, ISpellMissile missile)
+        public void TargetExecute(ISpell spell, IAttackableUnit target, ISpellMissile missile, ISpellSector sector)
         {
+            var owner = spell.CastInfo.Owner;
+
             var ad = owner.Stats.AttackDamage.Total * 0.9f;
             var damage = 50 + (spell.CastInfo.SpellLevel * 30) + ad;
-            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
-            AddParticleTarget(owner, target, "blindMonk_Q_resonatingStrike_tar", target, bone: "C_BuffBone_Glb_Center_Loc");
-            AddParticleTarget(owner, target, "blindMonk_Q_tar", target, bone: "C_BuffBone_Glb_Center_Loc");
-            if (target is IObjAiBase u)
+
+            if (!target.Status.HasFlag(StatusFlags.Stealthed))
             {
-                AddBuff("BlindMonkSonicWave", 3f, 1, spell, u, owner);
+                if (owner.Team == TeamId.TEAM_BLUE)
+                {
+                    AddBuff("BlindMonkQOne", 3f, 1, spell, target, owner);
+                }
+                else
+                {
+                    AddBuff("BlindMonkQOneChaos", 3f, 1, spell, target, owner);
+                }
+
+                //AddBuff("BlindMonkSonicWave", 3f, 1, spell, target, owner);
+
+                target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+
+                AddParticleTarget(owner, target, "blindMonk_Q_tar", target, bone: "C_BuffBone_Glb_Center_Loc", flags: 0);
+
+                missile.SetToRemove();
+
+                if (!target.IsDead && target is IObjAiBase ai)
+                {
+                    AddBuff("BlindMonkQManager", 3f, 1, spell, owner, ai);
+                }
             }
+            else
+            {
+                if (target is IChampion)
+                {
+                    if (owner.Team == TeamId.TEAM_BLUE)
+                    {
+                        AddBuff("BlindMonkQOne", 3f, 1, spell, target, owner);
+                    }
+                    else
+                    {
+                        AddBuff("BlindMonkQOneChaos", 3f, 1, spell, target, owner);
+                    }
 
-            missile.SetToRemove();
+                    //AddBuff("BlindMonkSonicWave", 3f, 1, spell, target, owner);
 
-            // TODO: SetSpell("BlindMonkQTwo")
+                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+
+                    AddParticleTarget(owner, target, "blindMonk_Q_tar", target, bone: "C_BuffBone_Glb_Center_Loc", flags: 0);
+
+                    missile.SetToRemove();
+
+                    if (!target.IsDead && target is IObjAiBase ai)
+                    {
+                        AddBuff("BlindMonkQManager", 3f, 1, spell, owner, ai);
+                    }
+                }
+                else
+                {
+                    // if (CanSeeTarget(owner, target))
+                    if (owner.Team == TeamId.TEAM_BLUE)
+                    {
+                        AddBuff("BlindMonkQOne", 3f, 1, spell, target, owner);
+                    }
+                    else
+                    {
+                        AddBuff("BlindMonkQOneChaos", 3f, 1, spell, target, owner);
+                    }
+
+                    target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+
+                    AddParticleTarget(owner, target, "blindMonk_Q_tar", target, bone: "C_BuffBone_Glb_Center_Loc", flags: 0);
+
+                    missile.SetToRemove();
+
+                    if (!target.IsDead && target is IObjAiBase ai)
+                    {
+                        AddBuff("BlindMonkQManager", 3f, 1, spell, owner, ai);
+                    }
+                }
+            }
         }
 
         public void OnSpellChannel(ISpell spell)
@@ -74,6 +147,131 @@ namespace Spells
 
         public void OnUpdate(float diff)
         {
+        }
+    }
+
+    public class BlindMonkQTwo : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            DoesntBreakShields = true,
+            TriggersSpellCasts = true,
+            NotSingleTargetSpell = false
+        };
+
+        IObjAiBase Owner;
+        ISpell thisSpell;
+        ISpellSector canCastSector;
+        bool seal = true;
+        string checkBuffName = "BlindMonkQOne";
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+            Owner = owner;
+            thisSpell = spell;
+            seal = true;
+
+            if (owner.Team != TeamId.TEAM_BLUE)
+            {
+                checkBuffName = "BlindMonkQOneChaos";
+            }
+
+            canCastSector = spell.CreateSpellSector(new SectorParameters
+            {
+                BindObject = Owner,
+                Length = 1250f,
+                SingleTick = false,
+                CanHitSameTarget = false,
+                CanHitSameTargetConsecutively = false,
+                MaximumHits = 0,
+                OverrideFlags = SpellDataFlags.AffectEnemies | SpellDataFlags.AffectNeutral | SpellDataFlags.AffectMinions | SpellDataFlags.AffectHeroes
+            });
+
+            SealSpellSlot(Owner, SpellSlotType.SpellSlots, 0, SpellbookType.SPELLBOOK_CHAMPION, seal);
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+            var owner = spell.CastInfo.Owner;
+
+            string buffName = "BlindMonkQOne";
+            if (owner.Team != TeamId.TEAM_BLUE)
+            {
+                buffName = "BlindMonkQOneChaos";
+            }
+
+            foreach (IAttackableUnit unit in GetUnitsInRange(owner.Position, 2000f, true))
+            {
+                if (spell.SpellData.IsValidTarget(owner, unit, SpellDataFlags.AffectEnemies | SpellDataFlags.AffectNeutral | SpellDataFlags.AffectMinions | SpellDataFlags.AffectHeroes))
+                {
+                    var buff = unit.GetBuffWithName(buffName);
+
+                    if (buff != null && buff.SourceUnit == owner)
+                    {
+                        RemoveBuff(buff);
+                        AddParticlePos(owner, "blindMonk_Q_resonatingStrike_02", owner.Position, owner.Position, bone: "C_BuffBone_Glb_Center_Loc", flags: 0);
+
+                        if (unit is IObjAiBase ai)
+                        {
+                            AddBuff("BlindMonkQTwoDash", 2.5f, 1, spell, owner, ai);
+                        }
+
+                        RemoveBuff(owner, "BlindMonkQManager");
+                    }
+                }
+            }
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        // TODO: Implement a CanCast function with a return value instead.
+        public void OnUpdate(float diff)
+        {
+            if (Owner != null && canCastSector != null)
+            {
+                canCastSector.ObjectsHit.Clear();
+                canCastSector.ExecuteTick();
+                foreach (IGameObject obj in canCastSector.ObjectsHit)
+                {
+                    if (obj is IObjAiBase ai)
+                    {
+                        var buff = ai.GetBuffWithName(checkBuffName);
+                        if (buff != null && buff.SourceUnit == Owner)
+                        {
+                            seal = false;
+                            break;
+                        }
+                        else
+                        {
+                            seal = true;
+                        }
+                    }
+                }
+
+                SealSpellSlot(Owner, SpellSlotType.SpellSlots, 0, SpellbookType.SPELLBOOK_CHAMPION, seal);
+            }
         }
     }
 }

--- a/Content/LeagueSandbox-Scripts/Characters/Lucian/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Lucian/Q.cs
@@ -35,6 +35,8 @@ namespace Spells
         public void OnSpellCast(ISpell spell)
         {
             var owner = spell.CastInfo.Owner;
+            var castPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
+            FaceDirection(castPos, owner, true);
             var endPoint = GetPointFromUnit(owner, 1100f);
             //AddParticleTarget(owner, null, "Lucian_Q_cas.troy", owner, lifetime: 1.0f);
             AddParticle(owner, owner, "Lucian_Q_laser_red", endPoint, bone: "C_BUFFBONE_GLB_CENTER_LOC", lifetime: 1.0f);
@@ -43,7 +45,10 @@ namespace Spells
         public void OnSpellPostCast(ISpell spell)
         {
             var owner = spell.CastInfo.Owner;
+            var castPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
             var endPoint = GetPointFromUnit(owner, 1100f);
+
+            FaceDirection(castPos, owner, true);
 
             spell.CreateSpellSector(new SectorParameters
             {

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -265,16 +265,18 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="animation">Internal name of the dash animation.</param>
         /// <param name="leapGravity">Optionally how much gravity the unit will experience when above the ground while dashing.</param>
         /// <param name="keepFacingLastDirection">Whether or not the AI unit should face the direction they were facing before the dash.</param>
+        /// <param name="consideredCC">Whether or not to prevent movement, casting, or attacking during the duration of the movement.</param>
         /// TODO: Find a good way to grab these variables from spell data.
         /// TODO: Verify if we should count Dashing as a form of Crowd Control.
         /// TODO: Implement Dash class which houses these parameters, then have that as the only parameter to this function (and other Dash-based functions).
-        void DashToLocation(Vector2 endPos, float dashSpeed, string animation, float leapGravity = 0.0f, bool keepFacingLastDirection = true);
+        void DashToLocation(Vector2 endPos, float dashSpeed, string animation = "", float leapGravity = 0.0f, bool keepFacingLastDirection = true, bool consideredCC = true);
         /// <summary>
         /// Sets this unit's current dash state to the given state.
         /// </summary>
         /// <param name="state">State to set. True = dashing, false = not dashing.</param>
+        /// <param name="setStatus">Whether or not to modify movement, casting, and attacking states.</param>
         /// TODO: Implement ForcedMovement methods and enumerators to handle different kinds of dashes.
-        void SetDashingState(bool state, MoveStopReason reason = MoveStopReason.Finished);
+        void SetDashingState(bool state, bool setStatus = true, MoveStopReason reason = MoveStopReason.Finished);
         /// <summary>
         /// Sets this unit's animation states to the given set of states.
         /// Given state pairs are expected to follow a specific structure:

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -67,7 +67,7 @@ namespace GameServerCore.Domain.GameObjects
         Dictionary<short, ISpell> Spells { get; }
         ICharScript CharScript { get; }
         /// <summary>
-        /// Unit this AI will auto attack when it is in auto attack range.
+        /// Unit this AI will auto attack or use a spell on when in range.
         /// </summary>
         IAttackableUnit TargetUnit { get; set; }
         
@@ -94,9 +94,21 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="keepFacingLastDirection">Whether or not the unit should maintain the direction they were facing before dashing.</param>
         /// <param name="followTargetMaxDistance">Maximum distance the unit will follow the Target before stopping the dash or reaching to the Target.</param>
         /// <param name="backDistance">Unknown parameter.</param>
-        /// <param name="travelTime">Total time the dash will follow the GameObject before stopping or reaching the Target.</param>
+        /// <param name="travelTime">Total time (in seconds) the dash will follow the GameObject before stopping or reaching the Target.</param>
+        /// <param name="consideredCC">Whether or not to prevent movement, casting, or attacking during the duration of the movement.</param>
         /// TODO: Implement Dash class which houses these parameters, then have that as the only parameter to this function (and other Dash-based functions).
-        void DashToTarget(IAttackableUnit target, float dashSpeed, string animation, float leapGravity, bool keepFacingLastDirection, float followTargetMaxDistance, float backDistance, float travelTime);
+        void DashToTarget
+        (
+            IAttackableUnit target,
+            float dashSpeed,
+            string animation,
+            float leapGravity,
+            bool keepFacingLastDirection,
+            float followTargetMaxDistance,
+            float backDistance,
+            float travelTime,
+            bool consideredCC = true
+        );
         /// <summary>
         /// Gets a random auto attack spell from the list of auto attacks available for this AI.
         /// Will only select crit auto attacks if the next auto attack is going to be a crit, otherwise normal auto attacks will be selected.

--- a/GameServerCore/Domain/GameObjects/Spell/Sector/ISectorParameters.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/Sector/ISectorParameters.cs
@@ -64,7 +64,7 @@ namespace GameServerCore.Domain.GameObjects.Spell.Sector
         bool CanHitSameTargetConsecutively { get; set; }
 
         /// <summary>
-        /// Maximum number of times the spell sector can hit something before being removed.
+        /// Maximum number of times the spell sector can hit something before being removed. A value of 0 or less means this variable will be unused.
         /// </summary>
         int MaximumHits { get; set; }
 

--- a/GameServerCore/ICollisionHandler.cs
+++ b/GameServerCore/ICollisionHandler.cs
@@ -25,5 +25,10 @@ namespace GameServerCore
         /// Function called every tick of the game by Map.cs.
         /// </summary>
         void Update();
+        /// <summary>
+        /// Updates collision for the specified object.
+        /// </summary>
+        /// <param name="obj">GameObject to check if colliding with other objects.</param>
+        void UpdateCollision(IGameObject obj);
     }
 }

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -695,6 +695,7 @@ namespace LeagueSandbox.GameServer.API
         /// <param name="idealDistance">How far the forced movement should travel from the unit's position.</param>
         /// <param name="gravity">How high the force movement should reach at the mid point of the force movement.</param>
         /// <param name="moveBackBy">How far behind the end point the force movement should go before finishing.</param>
+        /// <param name="consideredAsCC">Whether or not to prevent movement, casting, or attacking during the duration of the movement.</param>
         /// <param name="movementType">Type of force movement to perform. Refer to ForceMovementType enum.</param>
         /// <param name="movementOrdersType">How should the force movement affect the orders of the unit?</param>
         /// <param name="movementOrdersFacing">How should the force movement affect the facing direction of the unit?</param>
@@ -708,6 +709,7 @@ namespace LeagueSandbox.GameServer.API
             float idealDistance,
             float gravity,
             float moveBackBy,
+            bool consideredAsCC = true,
             ForceMovementType movementType = ForceMovementType.FURTHEST_WITHIN_RANGE,
             ForceMovementOrdersType movementOrdersType = ForceMovementOrdersType.POSTPONE_CURRENT_ORDER,
             ForceMovementOrdersFacing movementOrdersFacing = ForceMovementOrdersFacing.FACE_MOVEMENT_DIRECTION)
@@ -717,7 +719,7 @@ namespace LeagueSandbox.GameServer.API
             {
                 keepFacingLastDirection = true;
             }
-            unit.DashToLocation(target, speed, animation, gravity, keepFacingLastDirection);
+            unit.DashToLocation(target, speed, animation, gravity, keepFacingLastDirection, consideredAsCC);
         }
 
         /// <summary>
@@ -731,6 +733,7 @@ namespace LeagueSandbox.GameServer.API
         /// <param name="gravity">How high the force movement should reach at the mid point of the force movement.</param>
         /// <param name="moveBackBy">How far behind the end point the force movement should go before finishing.</param>
         /// <param name="maxTravelTime">Maximum amount of time the forced movement is allowed to last.</param>
+        /// <param name="consideredAsCC">Whether or not to prevent movement, casting, or attacking during the duration of the movement.</param>
         /// <param name="movementType">Type of force movement to perform. Refer to ForceMovementType enum.</param>
         /// <param name="movementOrdersType">How should the force movement affect the orders of the unit?</param>
         /// <param name="movementOrdersFacing">How should the force movement affect the facing direction of the unit?</param>
@@ -745,6 +748,7 @@ namespace LeagueSandbox.GameServer.API
             float gravity,
             float moveBackBy,
             float maxTravelTime,
+            bool consideredAsCC = true,
             ForceMovementType movementType = ForceMovementType.FURTHEST_WITHIN_RANGE,
             ForceMovementOrdersType movementOrdersType = ForceMovementOrdersType.POSTPONE_CURRENT_ORDER,
             ForceMovementOrdersFacing movementOrdersFacing = ForceMovementOrdersFacing.FACE_MOVEMENT_DIRECTION)
@@ -754,7 +758,7 @@ namespace LeagueSandbox.GameServer.API
             {
                 keepFacingLastDirection = true;
             }
-            unit.DashToTarget(target, speed, animation, gravity, keepFacingLastDirection, idealDistance, moveBackBy, maxTravelTime);
+            unit.DashToTarget(target, speed, animation, gravity, keepFacingLastDirection, idealDistance, moveBackBy, maxTravelTime, consideredAsCC);
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -1599,10 +1599,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// <param name="animation">Internal name of the dash animation.</param>
         /// <param name="leapGravity">Optionally how much gravity the unit will experience when above the ground while dashing.</param>
         /// <param name="keepFacingLastDirection">Whether or not the AI unit should face the direction they were facing before the dash.</param>
+        /// <param name="consideredCC">Whether or not to prevent movement, casting, or attacking during the duration of the movement.</param>
         /// TODO: Find a good way to grab these variables from spell data.
         /// TODO: Verify if we should count Dashing as a form of Crowd Control.
         /// TODO: Implement Dash class which houses these parameters, then have that as the only parameter to this function (and other Dash-based functions).
-        public void DashToLocation(Vector2 endPos, float dashSpeed, string animation = "", float leapGravity = 0.0f, bool keepFacingLastDirection = true)
+        public void DashToLocation(Vector2 endPos, float dashSpeed, string animation = "", float leapGravity = 0.0f, bool keepFacingLastDirection = true, bool consideredCC = true)
         {
             var newCoords = _game.Map.NavigationGrid.GetClosestTerrainExit(endPos, PathfindingRadius + 1.0f);
 
@@ -1623,7 +1624,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 FollowTravelTime = 0
             };
 
-            SetDashingState(true);
+            SetDashingState(true, consideredCC);
 
             if (animation != null && animation != "")
             {
@@ -1642,8 +1643,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// Sets this unit's current dash state to the given state.
         /// </summary>
         /// <param name="state">State to set. True = dashing, false = not dashing.</param>
+        /// <param name="setStatus">Whether or not to modify movement, casting, and attacking states.</param>
         /// TODO: Implement ForcedMovement methods and enumerators to handle different kinds of dashes.
-        public virtual void SetDashingState(bool state, MoveStopReason reason = MoveStopReason.Finished)
+        public virtual void SetDashingState(bool state, bool setStatus = true, MoveStopReason reason = MoveStopReason.Finished)
         {
             if (MovementParameters != null && state == false)
             {
@@ -1664,11 +1666,14 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 }
             }
 
-            // TODO: Implement this as a parameter.
-            SetStatus(StatusFlags.CanAttack, !state);
-            // TODO: Verify if changing cast status is correct.
-            SetStatus(StatusFlags.CanCast, !state);
-            SetStatus(StatusFlags.CanMove, !state);
+            if (setStatus)
+            {
+                // TODO: Implement this as a parameter.
+                SetStatus(StatusFlags.CanAttack, !state);
+                // TODO: Verify if changing cast status is correct.
+                SetStatus(StatusFlags.CanCast, !state);
+                SetStatus(StatusFlags.CanMove, !state);
+            }
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/Other/CollisionHandler.cs
+++ b/GameServerLib/GameObjects/Other/CollisionHandler.cs
@@ -73,11 +73,11 @@ namespace LeagueSandbox.GameServer.GameObjects.Other
         {
             bool collides = IsCollisionObject(obj);
             bool detects = IsCollisionAffected(obj);
-            if(collides || detects)
+            if (collides || detects)
             {
                 _objects.Add(obj);
             }
-            if(collides)
+            if (collides)
             {
                 QuadDynamic.Insert(obj, GetBounds(obj));
             }
@@ -123,6 +123,31 @@ namespace LeagueSandbox.GameServer.GameObjects.Other
             }
 
             UpdateQuadTree();
+        }
+
+        /// <summary>
+        /// Updates collision for the specified object.
+        /// </summary>
+        /// <param name="obj">GameObject to check if colliding with other objects.</param>
+        public void UpdateCollision(IGameObject obj)
+        {
+            if (IsCollisionAffected(obj))
+            {
+                if (!_map.NavigationGrid.IsWalkable(obj.Position.X, obj.Position.Y))
+                {
+                    obj.OnCollision(null, true);
+                }
+
+                var nearest = QuadDynamic.GetNodesInside(GetBounds(obj));
+                foreach (var obj2 in nearest)
+                {
+                    // TODO: Implement interpolation (or hull tracing) to account for fast moving gameobjects that may go past other gameobjects within one tick, which bypasses collision.
+                    if (obj != obj2 && !obj2.IsToRemove() && obj.IsCollidingWith(obj2))
+                    {
+                        obj.OnCollision(obj2);
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/Spell/Sector/SpellSector.cs
+++ b/GameServerLib/GameObjects/Spell/Sector/SpellSector.cs
@@ -67,6 +67,16 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
             Team = CastInfo.Owner.Team;
         }
 
+        public override void OnAdded()
+        {
+            base.OnAdded();
+
+            // Update same tick of creation.
+            // This prevents cases where single tick sectors change position before executing.
+            _game.Map.CollisionHandler.UpdateCollision(this);
+            Update(0f);
+        }
+
         public override void Update(float diff)
         {
             if (IsToRemove())
@@ -76,7 +86,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
 
             _lastTickTime += diff;
 
-            if ((Parameters.Lifetime >= 0 && (Parameters.Lifetime * 1000.0f) <= _timeSinceCreation))
+            if (Parameters.Lifetime >= 0 && (Parameters.Lifetime * 1000.0f) <= _timeSinceCreation)
             {
                 SetToRemove();
                 return;
@@ -87,7 +97,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
                 Move(diff);
             }
 
-            if (_lastTickTime >= (1000.0f / Parameters.Tickrate))
+            if (_lastTickTime >= (1000.0f / Parameters.Tickrate) || (Parameters.SingleTick && Parameters.Tickrate <= 0))
             {
                 _lastTickTime = 0;
 
@@ -184,7 +194,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Sector
 
             ObjectsHit.Add(unit);
 
-            if (ObjectsHit.Count >= Parameters.MaximumHits)
+            if (Parameters.MaximumHits > 0 && ObjectsHit.Count >= Parameters.MaximumHits)
             {
                 SetToRemove();
             }

--- a/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
@@ -151,7 +151,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         /// <summary>
         /// How many times a second the spell sector should check for hitbox collisions.
         /// </summary>
-        public int Tickrate { get; set; } = 60;
+        public int Tickrate { get; set; } = 0;
         /// <summary>
         /// Whether or not the spell sector should be able to hit something multiple times.
         /// Will only hit again if the unit hit re-enters the hitbox (constant per-collision hitbox).
@@ -165,7 +165,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         /// </summary>
         public bool CanHitSameTargetConsecutively { get; set; } = false;
         /// <summary>
-        /// Maximum number of times the spell sector can hit something before being removed.
+        /// Maximum number of times the spell sector can hit something before being removed. A value of 0 or less means this variable will be unused.
         /// </summary>
         public int MaximumHits { get; set; } = int.MaxValue;
         /// <summary>


### PR DESCRIPTION
* Scripting:
  * Lee Sin Q has been fully implemented (CanCast feature being done instead in a roundabout way).
  * Lucian Q now properly faces the direction of the target after finishing casting.
  * ForceMovement now supports an option to not set status effects.
  * SpellScriptMetadata:
    * SectorParameters has had its Tickrate set to 0 as the default.
* AttackableUnit:
  * DashToLocation will no longer set animation states by default.
  * SetDashingState optionally sets status.
* ObjAiBase:
  * CanCast now takes into account whether or not the current channel spell is cancelable (and thus that we can cast during it).
  * SetSpell deactivates the spell which is being overridden.
  * DashToTarget will no longer set animation states by default
* CollisionHandler:
  * Added UpdateCollision function for manually updating collision status for a specific GameObject.
* Spell:
  * Deactivate function now resets spell state, toggles the spell off, and resets the owner's cast spell and channel spell.
  * Update function resets owner cast spell when state is ready and sets when first casting.
  * Removed _futureProjNeteId in favor of just CastInfo.MissileNetID.
* SpellSector:
  * Added OnAdded override which will update collisions. This is for single tick sectors.
  * Supports indefinite sectors via MaximumHits being 0 or less.
* Packets:
  * HandleCastSpell handles more of the specific cases where casting is allowed rather than simply using the CanCast function.