### PR TITLE
Progress #1366 -- Various TeleportID-related fixes

### DIFF
--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -195,11 +195,10 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="o">GameObject entering vision.</param>
         /// <param name="userId">User to send the packet to.</param>
         /// <param name="isChampion">Whether or not the GameObject entering vision is a Champion.</param>
-        /// <param name="useTeleportID">Whether or not to teleport the object to its current position.</param>
         /// <param name="ignoreVision">Optionally ignore vision checks when sending this packet.</param>
         /// <param name="packets">Takes in a list of packets to send alongside this vision packet.</param>
         /// TODO: Incomplete implementation.
-        void NotifyEnterVisibilityClient(IGameObject o, int userId = 0, bool isChampion = false, bool useTeleportID = false, bool ignoreVision = false, List<GamePacket> packets = null);
+        void NotifyEnterVisibilityClient(IGameObject o, int userId = 0, bool isChampion = false, bool ignoreVision = false, List<GamePacket> packets = null);
         /// <summary>
         /// Sends a packet to all players with vision of the specified unit detailing that the unit has begun facing the specified direction.
         /// </summary>
@@ -938,7 +937,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="u">AttackableUnit that is moving.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="useTeleportID">Whether or not to teleport the unit to its current position in its path.</param>
-        void NotifyWaypointGroup(IAttackableUnit u, int userId = 0, bool useTeleportID = true);
+        void NotifyWaypointGroup(IAttackableUnit u, int userId = 0, bool useTeleportID = false);
         /// <summary>
         /// Sends a packet to all players that have vision of the specified unit.
         /// The packet details a group of waypoints with speed parameters which determine what kind of movement will be done to reach the waypoints, or optionally a GameObject.

--- a/GameServerLib/Chatbox/Commands/SpawnCommand.cs
+++ b/GameServerLib/Chatbox/Commands/SpawnCommand.cs
@@ -178,7 +178,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             c.Stats.SetSummonerSpellEnabled(0, true);
             c.Stats.SetSummonerSpellEnabled(1, true);
 
-            Game.PacketNotifier.NotifyEnterVisibilityClient(c, 0, true, false, true);
+            Game.PacketNotifier.NotifyEnterVisibilityClient(c, 0, true, true);
 
             ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "Spawned Bot" + clientInfoTemp.Name + " as " + c.Model + " with NetID: " + c.NetId + ".");
         }

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -196,10 +196,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 else
                 {
                     Waypoints[0] = Position;
-                    if(CurrentWaypoint.Key == 0)
-                    {
-                        CurrentWaypoint = new KeyValuePair<int, Vector2>(0, Position);
-                    }
                 }
             }
             else
@@ -292,7 +288,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 // We should not teleport here because Pathfinding should handle it.
                 // TODO: Implement a PathfindingHandler, and remove currently implemented manual pathfinding.
                 Vector2 exit = Extensions.GetCircleEscapePoint(Position, PathfindingRadius + 1, collider.Position, collider.PathfindingRadius);
-                TeleportTo(exit.X, exit.Y, false);
+                if (!_game.Map.PathingHandler.IsWalkable(exit, PathfindingRadius))
+                {
+                    exit = _game.Map.NavigationGrid.GetClosestTerrainExit(exit, PathfindingRadius + 1.0f);
+                }
+                SetPosition(exit, false);
             }
         }
 
@@ -979,6 +979,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             if (!_game.Map.PathingHandler.IsWalkable(new Vector2(x, y), PathfindingRadius))
             {
                 position = _game.Map.NavigationGrid.GetClosestTerrainExit(new Vector2(x, y), PathfindingRadius + 1.0f);
+            }
+
+            if (!repath)
+            {
+                ResetWaypoints();
             }
 
             SetPosition(position, repath);

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -292,7 +292,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 // We should not teleport here because Pathfinding should handle it.
                 // TODO: Implement a PathfindingHandler, and remove currently implemented manual pathfinding.
                 Vector2 exit = Extensions.GetCircleEscapePoint(Position, PathfindingRadius + 1, collider.Position, collider.PathfindingRadius);
-                SetPosition(exit, false);
+                TeleportTo(exit.X, exit.Y, false);
             }
         }
 

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -236,7 +236,7 @@ namespace LeagueSandbox.GameServer.GameObjects
                 // Escape functionality should be moved to GameObject.OnCollision.
                 // only time we would collide with terrain is if we are inside of it, so we should teleport out of it.
                 Vector2 exit = _game.Map.NavigationGrid.GetClosestTerrainExit(Position, PathfindingRadius + 1.0f);
-                TeleportTo(exit.X, exit.Y);
+                SetPosition(exit);
             }
         }
 

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -236,7 +236,7 @@ namespace LeagueSandbox.GameServer.GameObjects
                 // Escape functionality should be moved to GameObject.OnCollision.
                 // only time we would collide with terrain is if we are inside of it, so we should teleport out of it.
                 Vector2 exit = _game.Map.NavigationGrid.GetClosestTerrainExit(Position, PathfindingRadius + 1.0f);
-                SetPosition(exit);
+                TeleportTo(exit.X, exit.Y);
             }
         }
 

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -320,11 +320,12 @@ namespace LeagueSandbox.GameServer.GameObjects
         public virtual void TeleportTo(float x, float y)
         {
             var position = _game.Map.NavigationGrid.GetClosestTerrainExit(new Vector2(x, y), PathfindingRadius + 1.0f);
-
+            
             SetPosition(position);
 
             // TODO: Find a suitable function for this. Maybe modify NotifyWaypointGroup to accept simple objects. 
             _game.PacketNotifier.NotifyEnterVisibilityClient(this);
+            _movementUpdated = false;
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -236,7 +236,7 @@ namespace LeagueSandbox.GameServer.GameObjects
                 // Escape functionality should be moved to GameObject.OnCollision.
                 // only time we would collide with terrain is if we are inside of it, so we should teleport out of it.
                 Vector2 exit = _game.Map.NavigationGrid.GetClosestTerrainExit(Position, PathfindingRadius + 1.0f);
-                TeleportTo(exit.X, exit.Y);
+                SetPosition(exit);
             }
         }
 
@@ -322,10 +322,6 @@ namespace LeagueSandbox.GameServer.GameObjects
             var position = _game.Map.NavigationGrid.GetClosestTerrainExit(new Vector2(x, y), PathfindingRadius + 1.0f);
 
             SetPosition(position);
-
-            // TODO: Verify which one we want to use. WaypointList does not require conversions, however WaypointGroup does (and it has TeleportID functionality).
-            //_game.PacketNotifier.NotifyWaypointList(this, new List<Vector2> { Position });
-            _game.PacketNotifier.NotifyEnterVisibilityClient(this, useTeleportID: true);
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -322,6 +322,9 @@ namespace LeagueSandbox.GameServer.GameObjects
             var position = _game.Map.NavigationGrid.GetClosestTerrainExit(new Vector2(x, y), PathfindingRadius + 1.0f);
 
             SetPosition(position);
+
+            // TODO: Find a suitable function for this. Maybe modify NotifyWaypointGroup to accept simple objects. 
+            _game.PacketNotifier.NotifyEnterVisibilityClient(this);
         }
 
         /// <summary>

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -236,7 +236,7 @@ namespace LeagueSandbox.GameServer
                     // TODO: Verify which one we want to use. WaypointList does not require conversions, however WaypointGroup does (and it has TeleportID functionality).
                     //_game.PacketNotifier.NotifyWaypointList(u);
                     // TODO: Verify if we want to use TeleportID.
-                    _game.PacketNotifier.NotifyWaypointGroup(u, userId, true);
+                    _game.PacketNotifier.NotifyWaypointGroup(u, userId, false);
                 }
             }
         }

--- a/PacketDefinitions420/PacketExtensions.cs
+++ b/PacketDefinitions420/PacketExtensions.cs
@@ -132,20 +132,15 @@ namespace PacketDefinitions420
                     return md;
                 }
 
-                List<Vector2> currentWaypoints = unit.Waypoints;
-                if (useTeleportID)
-                {
-                    currentWaypoints = new List<Vector2>();
-                    currentWaypoints.AddRange(unit.Waypoints);
-                    currentWaypoints.RemoveAt(0);
-                    currentWaypoints.Insert(0, unit.Position);
+                var currentWaypoints = new List<Vector2>(unit.Waypoints);
+                currentWaypoints[0] = unit.Position;
 
-                    var count = 2 + ((currentWaypoints.Count - 1) - unit.CurrentWaypoint.Key);
-                    if (count >= 2)
-                    {
-                        currentWaypoints.RemoveRange(1, currentWaypoints.Count - count);
-                    }
+                int count = 2 + ((currentWaypoints.Count - 1) - unit.CurrentWaypoint.Key);
+                if (count >= 2)
+                {
+                    currentWaypoints.RemoveRange(1, currentWaypoints.Count - count);
                 }
+                
                 var waypoints = currentWaypoints.ConvertAll(v => Vector2ToWaypoint(TranslateToCenteredCoordinates(v, grid)));
 
                 switch (type)

--- a/PacketDefinitions420/PacketExtensions.cs
+++ b/PacketDefinitions420/PacketExtensions.cs
@@ -100,17 +100,6 @@ namespace PacketDefinitions420
         /// <returns>Default MovementDataStop, otherwise: If GameObject, None or Stop. If AttackableUnit, all of the above.</returns>
         public static MovementData CreateMovementData(IGameObject o, INavigationGrid grid, MovementDataType type, SpeedParams speeds = null, bool useTeleportID = false)
         {
-            /*
-            if(useTeleportID)
-            {
-                var st = Environment.StackTrace;
-                if(!st.Contains("ConstructEnterVisibilityClientPacket"))
-                {
-                    Console.WriteLine($"JUMP {st}");
-                }
-            }
-            */
-
             MovementData md = new MovementDataStop
             {
                 SyncID = (int)o.SyncId,
@@ -143,7 +132,6 @@ namespace PacketDefinitions420
                     return md;
                 }
 
-                //TODO: Modify MOVE and just throw out the visited points from the list of waypoints
                 List<Vector2> currentWaypoints = unit.Waypoints;
                 if (useTeleportID)
                 {
@@ -164,15 +152,12 @@ namespace PacketDefinitions420
                 {
                     case MovementDataType.WithSpeed:
                     {
-                        //TODO: assert?
                         if (speeds != null)
                         {
                             md = new MovementDataWithSpeed
                             {
                                 SyncID = unit.SyncId,
                                 TeleportNetID = unit.NetId,
-                                // TODO: Implement teleportID (likely to be the index (starting at 1) of a waypoint we want to TP to).
-                                // Crucial in syncing client positions with server positions, especially when entering vision
                                 HasTeleportID = useTeleportID,
                                 TeleportID = useTeleportID ? unit.TeleportID : (byte)0,
                                 Waypoints = waypoints,
@@ -188,8 +173,6 @@ namespace PacketDefinitions420
                         {
                             SyncID = unit.SyncId,
                             TeleportNetID = unit.NetId,
-                            // TODO: Implement teleportID (likely to be the index (starting at 1) of a waypoint we want to TP to).
-                            // Crucial in syncing client positions with server positions, especially when entering vision
                             HasTeleportID = useTeleportID,
                             TeleportID = useTeleportID ? unit.TeleportID : (byte)0,
                             Waypoints = waypoints

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -724,7 +724,7 @@ namespace PacketDefinitions420
             }
         }
 
-        OnEnterVisibilityClient ConstructEnterVisibilityClientPacket(IGameObject o, bool isChampion = false, bool useTeleportID = false, List<GamePacket> packets = null)
+        OnEnterVisibilityClient ConstructEnterVisibilityClientPacket(IGameObject o, bool isChampion = false, List<GamePacket> packets = null)
         {
             var itemData = new List<ItemData>(); //TODO: Fix item system so this can be finished
             var shields = new ShieldValues(); //TODO: Implement shields so this can be finished
@@ -793,7 +793,7 @@ namespace PacketDefinitions420
                 }
             }
 
-            var md = PacketExtensions.CreateMovementData(o, _navGrid, type, speeds, useTeleportID: useTeleportID);
+            var md = PacketExtensions.CreateMovementData(o, _navGrid, type, speeds, useTeleportID: true);
 
             var enterVis = new OnEnterVisibilityClient // TYPO >:(
             {
@@ -822,14 +822,13 @@ namespace PacketDefinitions420
         /// <param name="o">GameObject entering vision.</param>
         /// <param name="userId">User to send the packet to.</param>
         /// <param name="isChampion">Whether or not the GameObject entering vision is a Champion.</param>
-        /// <param name="useTeleportID">Whether or not to teleport the object to its current position.</param>
         /// <param name="ignoreVision">Optionally ignore vision checks when sending this packet.</param>
         /// <param name="packets">Takes in a list of packets to send alongside this vision packet.</param>
         /// TODO: Incomplete implementation.
-        public void NotifyEnterVisibilityClient(IGameObject o, int userId = 0, bool isChampion = false, bool useTeleportID = false, bool ignoreVision = false, List<GamePacket> packets = null)
+        public void NotifyEnterVisibilityClient(IGameObject o, int userId = 0, bool isChampion = false, bool ignoreVision = false, List<GamePacket> packets = null)
         {
             
-            var enterVis = ConstructEnterVisibilityClientPacket(o, isChampion, useTeleportID, packets);
+            var enterVis = ConstructEnterVisibilityClientPacket(o, isChampion, packets);
         
             if (userId != 0)
             {
@@ -3312,7 +3311,7 @@ namespace PacketDefinitions420
                     return ConstructFXCreateGroupPacket(particle);
             }
             // Generic object
-            return ConstructEnterVisibilityClientPacket(o, useTeleportID: true);
+            return ConstructEnterVisibilityClientPacket(o);
         }      
 
         /// <summary>
@@ -3802,12 +3801,7 @@ namespace PacketDefinitions420
                     {
                         packets = new List<GamePacket>(1){ spawnPacket };
                     }
-                    visibilityPacket = ConstructEnterVisibilityClientPacket(
-                        obj,
-                        isChampion: obj is IChampion,
-                        useTeleportID: true,
-                        packets: packets
-                    );
+                    visibilityPacket = ConstructEnterVisibilityClientPacket(obj, obj is IChampion, packets);
                 }
                 var healthbarPacket = ConstructEnterLocalVisibilityClientPacket(obj);
                 //TODO: try to include it to packets too?
@@ -3873,7 +3867,7 @@ namespace PacketDefinitions420
         /// <param name="u">AttackableUnit that is moving.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="useTeleportID">Whether or not to teleport the unit to its current position in its path.</param>
-        public void NotifyWaypointGroup(IAttackableUnit u, int userId = 0, bool useTeleportID = true)
+        public void NotifyWaypointGroup(IAttackableUnit u, int userId = 0, bool useTeleportID = false)
         {
             // TODO: Verify if casts correctly
             var move = (MovementDataNormal)PacketExtensions.CreateMovementData(u, _navGrid, MovementDataType.Normal, useTeleportID: useTeleportID);


### PR DESCRIPTION
I wrote "progress" because I still have to use teleportation for collisions. Otherwise, collision avoidance comes into play and the minions go in different directions. They are already trying to do this, but in the *indev* branch they are teleported away every tick of the server. This also looks ugly, but I decided to keep this behavior.
At least now, instead of recalculating the entire path, a collision only changes the zero point of the path. And this is usually enough, because the collision only throws the unit back a little.