### PR TITLE
Inhibitor Respawn rework/MonsterDataTable introduction

### DIFF
--- a/Content/LeagueSandbox-Scripts/Maps/Map1/LevelScript.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/LevelScript.cs
@@ -7,7 +7,6 @@ using GameServerCore.Enums;
 using LeagueSandbox.GameServer.Content;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.Scripting.CSharp;
-using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.GameObjects.Stats;
 using static LeagueSandbox.GameServer.API.ApiMapFunctionManager;
 

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/LevelScript.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/LevelScript.cs
@@ -289,9 +289,8 @@ namespace MapScripts.Map1
                 LaneID lane = barrack.Value.GetSpawnBarrackLaneID();
                 IInhibitor inhibitor = LevelScriptObjects.InhibitorList[opposed_team][lane];
                 Vector2 position = new Vector2(barrack.Value.CentralPoint.X, barrack.Value.CentralPoint.Z);
-                bool isInhibitorDead = inhibitor.InhibitorState == InhibitorState.DEAD && !inhibitor.RespawnAnnounced;
-                bool areAllInhibitorsDead = AllInhibitorsDestroyedFromTeam(LevelScriptObjects.InhibitorList, opposed_team) && !inhibitor.RespawnAnnounced;
-                Tuple<int, List<MinionSpawnType>> spawnWave = MinionWaveToSpawn(GameTime(), _cannonMinionCount, isInhibitorDead, areAllInhibitorsDead);
+                bool isInhibitorDead = inhibitor.InhibitorState == InhibitorState.DEAD;
+                Tuple<int, List<MinionSpawnType>> spawnWave = MinionWaveToSpawn(GameTime(), _cannonMinionCount, isInhibitorDead, LevelScriptObjects.AllInhibitorsAreDead[opposed_team]);
                 cannonMinionCap = spawnWave.Item1;
 
                 List<Vector2> waypoint = new List<Vector2>(MinionPaths[lane]);

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/LevelScriptObjects.cs
@@ -16,6 +16,8 @@ namespace MapScripts.Map1
 
         public static Dictionary<TeamId, IFountain> FountainList = new Dictionary<TeamId, IFountain>();
         public static Dictionary<string, MapObject> SpawnBarracks = new Dictionary<string, MapObject>();
+        public static Dictionary<TeamId, bool> AllInhibitorsAreDead = new Dictionary<TeamId, bool> { { TeamId.TEAM_BLUE, false }, { TeamId.TEAM_PURPLE, false } };
+        static Dictionary<TeamId, Dictionary<IInhibitor, float>> DeadInhibitors = new Dictionary<TeamId, Dictionary<IInhibitor, float>> { { TeamId.TEAM_BLUE, new Dictionary<IInhibitor, float>() }, { TeamId.TEAM_PURPLE, new Dictionary<IInhibitor, float>() } };
         static List<INexus> NexusList = new List<INexus>();
         public static string LaneTurretAI = "TurretAI";
 
@@ -100,26 +102,21 @@ namespace MapScripts.Map1
             _mapObjects = mapObjects;
 
             CreateBuildings();
-            ChangeTowerOnMapList(TurretList, "Turret_T1_C_06_A", TeamId.TEAM_BLUE, LaneID.MIDDLE, LaneID.TOP);
-            ChangeTowerOnMapList(TurretList, "Turret_T1_C_07_A", TeamId.TEAM_BLUE, LaneID.MIDDLE, LaneID.BOTTOM);
             LoadProtection();
 
             LoadSpawnBarracks();
             LoadFountains();
         }
-
-        static Dictionary<TeamId, List<IChampion>> Players = new Dictionary<TeamId, List<IChampion>>();
+ 
         public static void OnMatchStart()
         {
             LoadShops();
 
-            foreach (var nexus in NexusList)
+            Dictionary<TeamId, List<IChampion>> Players = new Dictionary<TeamId, List<IChampion>>
             {
-                ApiEventManager.OnDeath.AddListener(nexus, nexus, OnNexusDeath, true);
-            }
-
-            Players.Add(TeamId.TEAM_BLUE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_BLUE));
-            Players.Add(TeamId.TEAM_PURPLE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_PURPLE));
+                {TeamId.TEAM_BLUE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_BLUE) },
+                {TeamId.TEAM_PURPLE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_PURPLE) }
+            };
 
             IStatsModifier TurretHealthModifier = new StatsModifier();
             foreach (var team in TurretList.Keys)
@@ -182,12 +179,42 @@ namespace MapScripts.Map1
             {
                 fountain.Update(diff);
             }
+
+            foreach (var team in DeadInhibitors.Keys)
+            {
+                foreach (var inhibitor in DeadInhibitors[team].Keys.ToList())
+                {
+                    DeadInhibitors[team][inhibitor] -= diff;
+                    if (DeadInhibitors[team][inhibitor] <= 0)
+                    {
+                        inhibitor.Stats.CurrentHealth = inhibitor.Stats.HealthPoints.Total;
+                        inhibitor.NotifyState();
+                        DeadInhibitors[inhibitor.Team].Remove(inhibitor);
+                    }
+                    else if (DeadInhibitors[team][inhibitor] <= 15.0f * 1000)
+                    {
+                        inhibitor.SetState(InhibitorState.ALIVE);
+                    }
+                }
+            }
         }
 
         public static void OnNexusDeath(IDeathData deathaData)
         {
             var nexus = deathaData.Unit;
             EndGame(nexus.Team, new Vector3(nexus.Position.X, nexus.GetHeight(), nexus.Position.Y), deathData: deathaData);
+        }
+
+        public static void OnInhibitorDeath(IDeathData deathData)
+        {
+            var inhibitor = deathData.Unit as IInhibitor;
+
+            DeadInhibitors[inhibitor.Team].Add(inhibitor, inhibitor.RespawnTime * 1000);
+
+            if (DeadInhibitors[inhibitor.Team].Count == InhibitorList[inhibitor.Team].Count)
+            {
+                AllInhibitorsAreDead[inhibitor.Team] = true;
+            }
         }
 
         static float timeCheck = 480.0f * 1000;
@@ -268,6 +295,7 @@ namespace MapScripts.Map1
                 var position = new Vector2(nexusObj.CentralPoint.X, nexusObj.CentralPoint.Z);
 
                 var nexus = CreateNexus(nexusObj.Name, NexusModels[teamId], position, teamId, 353, 1700);
+                ApiEventManager.OnDeath.AddListener(nexus, nexus, OnNexusDeath, true);
                 NexusList.Add(nexus);
                 AddObject(nexus);
             }
@@ -279,10 +307,13 @@ namespace MapScripts.Map1
                 var position = new Vector2(inhibitorObj.CentralPoint.X, inhibitorObj.CentralPoint.Z);
 
                 var inhibitor = CreateInhibitor(inhibitorObj.Name, InhibitorModels[teamId], position, teamId, lane, 214, 0);
+                ApiEventManager.OnDeath.AddListener(inhibitor, inhibitor, OnInhibitorDeath, false);
+                inhibitor.RespawnTime = 240.0f;
+                inhibitor.Stats.CurrentHealth = 4000.0f;
+                inhibitor.Stats.HealthPoints.BaseValue = 4000.0f;
                 InhibitorList[teamId][lane] = inhibitor;
                 AddObject(inhibitor);
             }
-
             foreach (var turretObj in _mapObjects[GameObjectTypes.ObjAIBase_Turret])
             {
                 var teamId = turretObj.GetTeamID();
@@ -302,6 +333,16 @@ namespace MapScripts.Map1
                 if (turretType == TurretType.FOUNTAIN_TURRET)
                 {
                     continue;
+                }
+
+                switch (turretObj.Name)
+                {
+                    case "Turret_T1_C_06":
+                        lane = LaneID.TOP;
+                        break;
+                    case "Turret_T1_C_07":
+                        lane = LaneID.BOTTOM;
+                        break;
                 }
 
                 var turret = CreateLaneTurret(turretObj.Name + "_A", TowerModels[teamId][turretType], position, teamId, turretType, lane, LaneTurretAI, turretObj);

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/MonsterDataTable.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/MonsterDataTable.cs
@@ -1,0 +1,97 @@
+﻿using GameServerCore.Domain.GameObjects;
+using System.Collections.Generic;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+namespace MapScripts.Map1
+{
+    public static class MonsterDataTable
+    {
+        readonly static List<float> AttackDamage = new List<float>
+        {
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0199999809265137f,
+            1.1f,
+            1.2000000000000002f,
+            1.3f,
+            1.4000000000000001f,
+            1.5f,
+            1.6f,
+            1.7000000000000002f,
+            1.8f,
+            2.0f,
+            2.2f,
+            2.4000000000000004f,
+            2.6f,
+            2.8000000000000003f,
+            3.0f,
+            3.2f,
+            3.4000000000000004f,
+        };
+
+        readonly static List<float> Gold = new List<float>
+        {
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0099999904632568f,
+            1.0199999809265137f,
+            1.0299999713897705f,
+            1.0399999618530273f,
+            1.0499999523162842f,
+            1.059999942779541f,
+            1.0700000524520874f,
+            1.0800000429153442f,
+            1.090000033378601f,
+            1.1f,
+            1.1200000047683716f,
+            1.1399999856948853f,
+            1.159999966621399f,
+            1.1799999475479126f,
+            1.2000000000000002f,
+            1.2200000286102295f,
+            1.2400000095367432f,
+        };
+
+        readonly static List<float> Health = new List<float>
+        {
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0199999809265137f,
+            1.1f,
+            1.2000000000000002f,
+            1.3f,
+            1.4000000000000001f,
+            1.5f,
+            1.6f,
+            1.7000000000000002f,
+            1.8f,
+            1.9000000000000001f,
+            2.0f,
+            2.1f,
+            2.2f,
+            2.3000000000000003f,
+            2.4000000000000004f,
+            2.5f,
+            2.6f,
+        };
+
+        public static void UpdateStats(IMonster monster)
+        {
+            var level = monster.Stats.Level;
+            //Taking into account URF's max level cap at 30
+            if(level > 19)
+            {
+                level = 19;
+            }
+
+            //The Attack damage doesn't get updated on the Monster's HUD, i already double checked and the value is right though.
+            monster.Stats.AttackDamage.BaseValue *= AttackDamage[level];
+            monster.Stats.GoldGivenOnDeath.BaseValue *= Gold[level];
+            monster.Stats.HealthPoints.BaseValue *= Health[level];
+            monster.Stats.CurrentHealth = monster.Stats.HealthPoints.Total;
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/MonsterDataTable.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/MonsterDataTable.cs
@@ -1,6 +1,5 @@
 ﻿using GameServerCore.Domain.GameObjects;
 using System.Collections.Generic;
-using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
 namespace MapScripts.Map1
 {

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/NeutralMinionSpawn.cs
@@ -1,10 +1,8 @@
 ﻿using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
-using System;
 using System.Collections.Generic;
 using System.Numerics;
-using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using static LeagueSandbox.GameServer.API.ApiMapFunctionManager;
 
 namespace MapScripts.Map1

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/NeutralMinionSpawn.cs
@@ -155,7 +155,7 @@ namespace MapScripts.Map1
 
         public static void SpawnCamp(IMonsterCamp monsterCamp)
         {
-            var averageLevel = GetAverageLevel();
+            var averageLevel = GetPlayerAverageLevel();
 
             foreach (var monster in MonsterCamps[monsterCamp])
             {

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/NeutralMinionSpawn.cs
@@ -1,8 +1,10 @@
 ﻿using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using static LeagueSandbox.GameServer.API.ApiMapFunctionManager;
 
 namespace MapScripts.Map1
@@ -155,9 +157,14 @@ namespace MapScripts.Map1
 
         public static void SpawnCamp(IMonsterCamp monsterCamp)
         {
+            var averageLevel = GetAverageLevel();
+
             foreach (var monster in MonsterCamps[monsterCamp])
             {
-                monsterCamp.AddMonster(monster);
+                monster.UpdateInitialLevel(averageLevel);
+                monster.Stats.Level = (byte)averageLevel;
+                IMonster campMonster = monsterCamp.AddMonster(monster);
+                MonsterDataTable.UpdateStats(campMonster);
             }
         }
 

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/URFMutator.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/URFMutator.cs
@@ -19,7 +19,7 @@ namespace MapScripts.Map1
         public override void Init(Dictionary<GameObjectTypes, List<MapObject>> mapObjects)
         {
             base.Init(mapObjects);
-            SetGameFeatures(GameServerCore.Enums.FeatureFlags.EnableManaCosts, false);
+            SetGameFeatures(FeatureFlags.EnableManaCosts, false);
         }
 
         public override void OnMatchStart()

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/LevelScript.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/LevelScript.cs
@@ -17,7 +17,8 @@ namespace MapScripts.Map10
     {
         public IMapScriptMetadata MapScriptMetadata { get; set; } = new MapScriptMetadata
         {
-            StartingGold = 825.0f
+            StartingGold = 825.0f,
+            ExpRange = 1250.0f
         };
 
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
@@ -230,9 +231,8 @@ namespace MapScripts.Map10
                     MapObject opposedBarrack = LevelScriptObjects.SpawnBarracks[opposed_team][lane];
                     IInhibitor inhibitor = LevelScriptObjects.InhibitorList[opposed_team][lane];
                     Vector2 position = new Vector2(barrack.CentralPoint.X, barrack.CentralPoint.Z);
-                    bool isInhibitorDead = inhibitor.InhibitorState == InhibitorState.DEAD && !inhibitor.RespawnAnnounced;
-                    bool areAllInhibitorsDead = AllInhibitorsDestroyedFromTeam(LevelScriptObjects.InhibitorList, opposed_team) && !inhibitor.RespawnAnnounced;
-                    Tuple<int, List<MinionSpawnType>> spawnWave = MinionWaveToSpawn(GameTime(), _cannonMinionCount, isInhibitorDead, areAllInhibitorsDead);
+                    bool isInhibitorDead = inhibitor.InhibitorState == InhibitorState.DEAD;
+                    Tuple<int, List<MinionSpawnType>> spawnWave = MinionWaveToSpawn(GameTime(), _cannonMinionCount, isInhibitorDead, LevelScriptObjects.AllInhibitorsAreDead[opposed_team]);
                     cannonMinionCap = spawnWave.Item1;
 
                     List<Vector2> waypoint = new List<Vector2>(LevelScriptObjects.MinionPaths[lane]);

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/LevelScript.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/LevelScript.cs
@@ -5,9 +5,7 @@ using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
-using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.Content;
-using LeagueSandbox.GameServer.GameObjects.Stats;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using static LeagueSandbox.GameServer.API.ApiMapFunctionManager;
 

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/MonsterDataTable.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/MonsterDataTable.cs
@@ -1,6 +1,5 @@
 ﻿using GameServerCore.Domain.GameObjects;
 using System.Collections.Generic;
-using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
 namespace MapScripts.Map10
 {

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/MonsterDataTable.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/MonsterDataTable.cs
@@ -1,0 +1,121 @@
+﻿using GameServerCore.Domain.GameObjects;
+using System.Collections.Generic;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+namespace MapScripts.Map10
+{
+    public static class MonsterDataTable
+    {
+        readonly static List<float> AttackDamage = new List<float>
+        {
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0199999809265137f,
+            1.1f,
+            1.2000000000000002f,
+            1.3f,
+            1.4000000000000001f,
+            1.5f,
+            1.6f,
+            1.7000000000000002f,
+            1.8f,
+            2.0f,
+            2.2f,
+            2.4000000000000004f,
+            2.6f,
+            2.8000000000000003f,
+            3.0f,
+            3.2f,
+            3.4000000000000004f
+        };
+
+        readonly static List<float> Experience = new List<float>
+        {
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0099999904632568f,
+            1.0199999809265137f,
+            1.0299999713897705f,
+            1.0399999618530273f,
+            1.0499999523162842f,
+            1.059999942779541f,
+            1.0700000524520874f,
+            1.0800000429153442f,
+            1.090000033378601f,
+            1.1f,
+            1.1200000047683716f,
+            1.1399999856948853f,
+            1.159999966621399f,
+            1.1799999475479126f,
+            1.2000000000000002f,
+            1.2200000286102295f,
+            1.2400000095367432f
+        };
+
+        readonly static List<float> Gold = new List<float>
+        {
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0099999904632568f,
+            1.0199999809265137f,
+            1.0299999713897705f,
+            1.0399999618530273f,
+            1.0499999523162842f,
+            1.059999942779541f,
+            1.0700000524520874f,
+            1.0800000429153442f,
+            1.090000033378601f,
+            1.1f,
+            1.1200000047683716f,
+            1.1399999856948853f,
+            1.159999966621399f,
+            1.1799999475479126f,
+            1.2000000000000002f,
+            1.2200000286102295f,
+            1.2400000095367432f
+        };
+
+        readonly static List<float> Health = new List<float>
+        {
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0199999809265137f,
+            1.1f,
+            1.2000000000000002f,
+            1.3f,
+            1.4000000000000001f,
+            1.5f,
+            1.6f,
+            1.7000000000000002f,
+            1.8f,
+            1.9000000000000001f,
+            2.0f,
+            2.1f,
+            2.2f,
+            2.3000000000000003f,
+            2.4000000000000004f,
+            2.5f,
+            2.6f
+        };
+
+        public static void UpdateStats(IMonster monster)
+        {
+            var level = monster.Stats.Level;
+            if(level > 19)
+            {
+                level = 19;
+            }
+
+            //The Attack damage doesn't get updated on the Monster's HUD, i already double checked and the value is right though.
+            monster.Stats.AttackDamage.BaseValue *= AttackDamage[level];
+            monster.Stats.ExpGivenOnDeath.BaseValue *= Experience[level];
+            monster.Stats.GoldGivenOnDeath.BaseValue *= Gold[level];
+            monster.Stats.HealthPoints.BaseValue *= Health[level];
+            monster.Stats.CurrentHealth = monster.Stats.HealthPoints.Total;
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/NeutralMinionSpawn.cs
@@ -1,8 +1,10 @@
 ﻿using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using static LeagueSandbox.GameServer.API.ApiMapFunctionManager;
 
 namespace MapScripts.Map10
@@ -106,9 +108,14 @@ namespace MapScripts.Map10
 
         public static void SpawnCamp(IMonsterCamp monsterCamp)
         {
+            var averageLevel = GetAverageLevel();
+
             foreach (var monster in MonsterCamps[monsterCamp])
             {
-                monsterCamp.AddMonster(monster);
+                monster.UpdateInitialLevel(averageLevel);
+                monster.Stats.Level = (byte)averageLevel;
+                IMonster campMonster = monsterCamp.AddMonster(monster);
+                MonsterDataTable.UpdateStats(campMonster);
             }
         }
 

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/NeutralMinionSpawn.cs
@@ -106,7 +106,7 @@ namespace MapScripts.Map10
 
         public static void SpawnCamp(IMonsterCamp monsterCamp)
         {
-            var averageLevel = GetAverageLevel();
+            var averageLevel = GetPlayerAverageLevel();
 
             foreach (var monster in MonsterCamps[monsterCamp])
             {

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/NeutralMinionSpawn.cs
@@ -1,10 +1,8 @@
 ﻿using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
-using System;
 using System.Collections.Generic;
 using System.Numerics;
-using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using static LeagueSandbox.GameServer.API.ApiMapFunctionManager;
 
 namespace MapScripts.Map10

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScript.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScript.cs
@@ -7,10 +7,7 @@ using GameServerCore.Enums;
 using LeagueSandbox.GameServer.Content;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.Scripting.CSharp;
-using LeagueSandbox.GameServer.API;
-using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using static LeagueSandbox.GameServer.API.ApiMapFunctionManager;
-using LeagueSandbox.GameServer.GameObjects.Stats;
 
 namespace MapScripts.Map11
 {

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScript.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScript.cs
@@ -274,9 +274,8 @@ namespace MapScripts.Map11
                 LaneID lane = barrack.Value.GetSpawnBarrackLaneID();
                 IInhibitor inhibitor = LevelScriptObjects.InhibitorList[opposed_team][lane];
                 Vector2 position = new Vector2(barrack.Value.CentralPoint.X, barrack.Value.CentralPoint.Z);
-                bool isInhibitorDead = inhibitor.InhibitorState == InhibitorState.DEAD && !inhibitor.RespawnAnnounced;
-                bool areAllInhibitorsDead = AllInhibitorsDestroyedFromTeam(LevelScriptObjects.InhibitorList, opposed_team) && !inhibitor.RespawnAnnounced;
-                Tuple<int, List<MinionSpawnType>> spawnWave = MinionWaveToSpawn(GameTime(), _cannonMinionCount, isInhibitorDead, areAllInhibitorsDead);
+                bool isInhibitorDead = inhibitor.InhibitorState == InhibitorState.DEAD;
+                Tuple<int, List<MinionSpawnType>> spawnWave = MinionWaveToSpawn(GameTime(), _cannonMinionCount, isInhibitorDead, LevelScriptObjects.AllInhibitorsAreDead[opposed_team]);
                 cannonMinionCap = spawnWave.Item1;
 
                 List<Vector2> waypoint = new List<Vector2>(MinionPaths[lane]);

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/MonsterDataTable.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/MonsterDataTable.cs
@@ -1,0 +1,97 @@
+﻿using GameServerCore.Domain.GameObjects;
+using System.Collections.Generic;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+namespace MapScripts.Map11
+{
+    public static class MonsterDataTable
+    {
+        static List<float> AttackDamage = new List<float>
+        {
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0f,
+            1.1f,
+            1.2000000000000002f,
+            1.3f,
+            1.4000000000000001f,
+            1.5f,
+            1.6f,
+            1.7000000000000002f,
+            1.9000000000000001f,
+            2.1f,
+            2.3000000000000003f,
+            2.5f,
+            2.7f,
+            2.9000000000000004f,
+            3.1f,
+            3.3000000000000003f,
+            3.5f
+        };
+
+        static List<float> Gold = new List<float>
+        {
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0099999904632568f,
+            1.0199999809265137f,
+            1.0299999713897705f,
+            1.0399999618530273f,
+            1.0499999523162842f,
+            1.059999942779541f,
+            1.0700000524520874f,
+            1.0800000429153442f,
+            1.090000033378601f,
+            1.1f,
+            1.1200000047683716f,
+            1.1399999856948853f,
+            1.159999966621399f,
+            1.1799999475479126f,
+            1.2000000000000002f,
+            1.2200000286102295f
+        };
+
+        static List<float> Health = new List<float>
+        {
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0f,
+            1.0499999523162842f,
+            1.1f,
+            1.149999976158142f,
+            1.25f,
+            1.350000023841858f,
+            1.4500000476837158f,
+            1.5499999523162842f,
+            1.649999976158142f,
+            1.75f,
+            2.0f,
+            2.0f,
+            2.0f,
+            2.0f,
+            2.0f,
+            2.0f,
+            2.0f
+        };
+
+        public static void UpdateStats(IMonster monster)
+        {
+            var level = monster.Stats.Level;
+            //Taking into account URF's max level cap at 30
+            if(level > 19)
+            {
+                level = 19;
+            }
+
+            //The Attack damage doesn't get updated on the Monster's HUD, i already double checked and the value is right though.
+            monster.Stats.AttackDamage.BaseValue *= AttackDamage[level];
+            monster.Stats.GoldGivenOnDeath.BaseValue *= Gold[level];
+            monster.Stats.HealthPoints.BaseValue *= Health[level];
+            monster.Stats.CurrentHealth = monster.Stats.HealthPoints.Total;
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/MonsterDataTable.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/MonsterDataTable.cs
@@ -1,6 +1,5 @@
 ﻿using GameServerCore.Domain.GameObjects;
 using System.Collections.Generic;
-using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
 namespace MapScripts.Map11
 {

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/NeutralMinionSpawn.cs
@@ -180,19 +180,9 @@ namespace MapScripts.Map11
             {
                 monster.UpdateInitialLevel(averageLevel);
                 monster.Stats.Level = (byte)averageLevel;
-                monsterCamp.AddMonster(monster);
+                IMonster campMonster = monsterCamp.AddMonster(monster);
+                MonsterDataTable.UpdateStats(campMonster);
             }
-        }
-
-        public static int GetAverageLevel()
-        {
-            float average = 0;
-            var players = GetAllPlayers();
-            foreach (var player in players)
-            {
-                average += player.Stats.Level / players.Count;
-            }
-            return Math.Min((int)average, 18);
         }
 
         public static void ForceCampSpawn()

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/NeutralMinionSpawn.cs
@@ -1,10 +1,8 @@
 ﻿using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
-using System;
 using System.Collections.Generic;
 using System.Numerics;
-using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 using static LeagueSandbox.GameServer.API.ApiMapFunctionManager;
 
 namespace MapScripts.Map11

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/NeutralMinionSpawn.cs
@@ -172,7 +172,7 @@ namespace MapScripts.Map11
 
         public static void SpawnCamp(IMonsterCamp monsterCamp)
         {
-            var averageLevel = GetAverageLevel();
+            var averageLevel = GetPlayerAverageLevel();
 
             foreach (var monster in MonsterCamps[monsterCamp])
             {

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/LevelScript.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/LevelScript.cs
@@ -6,7 +6,6 @@ using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.Content;
-using LeagueSandbox.GameServer.GameObjects.Stats;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using static LeagueSandbox.GameServer.API.ApiMapFunctionManager;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/LevelScript.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/LevelScript.cs
@@ -20,7 +20,9 @@ namespace MapScripts.Map12
             StartingGold = 1375.0f,
             GoldPerSecond = 5.0f,
             RecallSpellItemId = 2007,
-            InitialLevel = 3
+            InitialLevel = 3,
+            ExpRange = 1250.0f,
+            GoldRange = 0.0f
         };
 
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
@@ -240,7 +242,7 @@ namespace MapScripts.Map12
                     MapObject opposedBarrack = LevelScriptObjects.SpawnBarracks[opposed_team][lane];
                     IInhibitor inhibitor = LevelScriptObjects.InhibitorList[opposed_team];
                     Vector2 position = new Vector2(barrack.CentralPoint.X, barrack.CentralPoint.Z);
-                    bool isInhibitorDead = inhibitor.InhibitorState == InhibitorState.DEAD && !inhibitor.RespawnAnnounced;
+                    bool isInhibitorDead = inhibitor.InhibitorState == InhibitorState.DEAD;
                     Tuple<int, List<MinionSpawnType>> spawnWave = MinionWaveToSpawn(GameTime(), _cannonMinionCount, isInhibitorDead);
                     cannonMinionCap = spawnWave.Item1;
 

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/LevelScriptObjects.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using GameServerCore.Domain;
 using System.Numerics;
 using System.Linq;
-using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
 namespace MapScripts.Map12
 {
@@ -18,6 +17,7 @@ namespace MapScripts.Map12
         public static Dictionary<TeamId, IFountain> FountainList = new Dictionary<TeamId, IFountain>();
         public static Dictionary<TeamId, Dictionary<LaneID, MapObject>> SpawnBarracks = new Dictionary<TeamId, Dictionary<LaneID, MapObject>> { { TeamId.TEAM_BLUE, new Dictionary<LaneID, MapObject>() }, { TeamId.TEAM_PURPLE, new Dictionary<LaneID, MapObject>() } };
         public static Dictionary<LaneID, List<Vector2>> MinionPaths = new Dictionary<LaneID, List<Vector2>> { { LaneID.MIDDLE, new List<Vector2>() } };
+        static Dictionary<TeamId, Dictionary<IInhibitor, float>> DeadInhibitors = new Dictionary<TeamId, Dictionary<IInhibitor, float>> { { TeamId.TEAM_BLUE, new Dictionary<IInhibitor, float>() }, { TeamId.TEAM_PURPLE, new Dictionary<IInhibitor, float>() } };
         static List<INexus> NexusList = new List<INexus>();
         static string LaneTurretAI = "TurretAI";
 
@@ -100,18 +100,15 @@ namespace MapScripts.Map12
             }
         }
 
-        static Dictionary<TeamId, List<IChampion>> Players = new Dictionary<TeamId, List<IChampion>>();
         public static void OnMatchStart()
         {
             LoadShops();
 
-            foreach (var nexus in NexusList)
+            Dictionary<TeamId, List<IChampion>> Players = new Dictionary<TeamId, List<IChampion>>
             {
-                ApiEventManager.OnDeath.AddListener(nexus, nexus, OnNexusDeath, true);
-            }
-
-            Players.Add(TeamId.TEAM_BLUE, GetAllPlayersFromTeam(TeamId.TEAM_BLUE));
-            Players.Add(TeamId.TEAM_PURPLE, GetAllPlayersFromTeam(TeamId.TEAM_PURPLE));
+                {TeamId.TEAM_BLUE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_BLUE) },
+                {TeamId.TEAM_PURPLE, ApiFunctionManager.GetAllPlayersFromTeam(TeamId.TEAM_PURPLE) }
+            };
 
             IStatsModifier TurretHealthModifier = new StatsModifier();
             foreach (var team in TurretList.Keys)
@@ -154,12 +151,37 @@ namespace MapScripts.Map12
             {
                 UpdateTowerStats();
             }
+
+            foreach (var team in DeadInhibitors.Keys)
+            {
+                foreach (var inhibitor in DeadInhibitors[team].Keys.ToList())
+                {
+                    DeadInhibitors[team][inhibitor] -= diff;
+                    if (DeadInhibitors[team][inhibitor] <= 0)
+                    {
+                        inhibitor.Stats.CurrentHealth = inhibitor.Stats.HealthPoints.Total;
+                        inhibitor.NotifyState();
+                        DeadInhibitors[inhibitor.Team].Remove(inhibitor);
+                    }
+                    else if (DeadInhibitors[team][inhibitor] <= 15.0f * 1000)
+                    {
+                        inhibitor.SetState(InhibitorState.ALIVE);
+                    }
+                }
+            }
         }
 
         static void OnNexusDeath(IDeathData deathaData)
         {
             var nexus = deathaData.Unit;
             EndGame(nexus.Team, new Vector3(nexus.Position.X, nexus.GetHeight(), nexus.Position.Y), deathData: deathaData);
+        }
+
+        public static void OnInhibitorDeath(IDeathData deathData)
+        {
+            var inhibitor = deathData.Unit as IInhibitor;
+
+            DeadInhibitors[inhibitor.Team].Add(inhibitor, inhibitor.RespawnTime * 1000);
         }
 
         static float timeCheck = 0.0f * 1000;
@@ -222,6 +244,7 @@ namespace MapScripts.Map12
                 var position = new Vector2(nexusObj.CentralPoint.X, nexusObj.CentralPoint.Z);
 
                 var nexus = CreateNexus(nexusObj.Name, NexusModels[teamId], position, teamId, 353, 1700);
+                ApiEventManager.OnDeath.AddListener(nexus, nexus, OnNexusDeath, true);
                 NexusList.Add(nexus);
                 AddObject(nexus);
             }
@@ -233,6 +256,10 @@ namespace MapScripts.Map12
                 var position = new Vector2(inhibitorObj.CentralPoint.X, inhibitorObj.CentralPoint.Z);
 
                 var inhibitor = CreateInhibitor(inhibitorObj.Name, InhibitorModels[teamId], position, teamId, lane, 214, 0);
+                ApiEventManager.OnDeath.AddListener(inhibitor, inhibitor, OnInhibitorDeath, false);
+                inhibitor.RespawnTime = 300.0f;
+                inhibitor.Stats.CurrentHealth = 4000.0f;
+                inhibitor.Stats.HealthPoints.BaseValue = 4000.0f;
                 InhibitorList.Add(teamId, inhibitor);
                 AddObject(inhibitor);
             }
@@ -252,7 +279,6 @@ namespace MapScripts.Map12
                 }
 
                 var turretType = GetTurretType(turretObj.ParseIndex());
-                LogInfo(turretObj.Name + ": " + turretType.ToString());
 
                 var turret = CreateLaneTurret(turretObj.Name + "_A", TowerModels[teamId][turretType], position, teamId, turretType, LaneID.MIDDLE, LaneTurretAI, turretObj);
                 TurretList[teamId][LaneID.MIDDLE].Add(turret);

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScript.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScript.cs
@@ -22,7 +22,9 @@ namespace MapScripts.Map8
             RecallSpellItemId = 2005,
             GoldPerSecond = 5.6f,
             FirstGoldTime = 90.0f * 1000,
-            InitialLevel = 3
+            InitialLevel = 3,
+            ExpRange = 1250.0f,
+            GoldRange = 0.0f
         };
 
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScriptObjects.cs
@@ -1,12 +1,9 @@
 ﻿using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
-using LeagueSandbox.GameServer.API;
 using static LeagueSandbox.GameServer.API.ApiMapFunctionManager;
-using LeagueSandbox.GameServer.GameObjects.Stats;
 using System.Collections.Generic;
 using GameServerCore.Domain;
 using System.Numerics;
-using System.Linq;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
 namespace MapScripts.Map8

--- a/GameServerCore/Domain/GameObjects/IInhibitor.cs
+++ b/GameServerCore/Domain/GameObjects/IInhibitor.cs
@@ -4,10 +4,11 @@ namespace GameServerCore.Domain.GameObjects
 {
     public interface IInhibitor : IObjAnimatedBuilding
     {
-        bool RespawnAnnounced { get; }
+        float RespawnTime { get; set; }
+        bool RespawnAnimationAnnounced { get; set; }
         InhibitorState InhibitorState { get; }
         LaneID Lane { get; }
-        void SetState(InhibitorState state, IDeathData data = null);
-        double GetRespawnTimer();
+        void SetState(InhibitorState state);
+        void NotifyState(IDeathData data = null);
     }
 }

--- a/GameServerCore/Domain/GameObjects/IMonsterCamp.cs
+++ b/GameServerCore/Domain/GameObjects/IMonsterCamp.cs
@@ -18,7 +18,7 @@ namespace GameServerCore.Domain
         bool IsAlive { get; set; }
         float RespawnTimer { get; set; }
         List<IMonster> Monsters { get; }
-        void AddMonster(IMonster monster);
+        IMonster AddMonster(IMonster monster);
         void NotifyCampActivation();
     }
 }

--- a/GameServerCore/Domain/GameObjects/IStats.cs
+++ b/GameServerCore/Domain/GameObjects/IStats.cs
@@ -32,6 +32,7 @@ namespace GameServerCore.Domain.GameObjects
         IStat CooldownReduction { get; }
         IStat CriticalChance { get; }
         IStat CriticalDamage { get; }
+        IStat ExpGivenOnDeath { get; }
         IStat GoldPerSecond { get; }
         IStat GoldGivenOnDeath { get; }
         IStat HealthPoints { get; }

--- a/GameServerCore/IObjectManager.cs
+++ b/GameServerCore/IObjectManager.cs
@@ -166,6 +166,15 @@ namespace GameServerCore
         List<IChampion> GetChampionsInRange(Vector2 checkPos, float range, bool onlyAlive = false);
 
         /// <summary>
+        /// Gets a list of all GameObjects of type Champion from a specific team that are within a certain distance from a specified position.
+        /// </summary>
+        /// <param name="checkPos">Vector2 position to check.</param>
+        /// <param name="range">Distance to check.</param>
+        /// <param name="onlyAlive">Whether dead Champions should be excluded or not.</param>
+        /// <returns>List of all Champions within the specified range of the position and of the specified alive status.</returns>
+        List<IChampion> GetChampionsInRangeFromTeam(Vector2 checkPos, float range, TeamId team, bool onlyAlive = false);
+
+        /// <summary>
         /// Removes a GameObject of type Champion from the list of Champions in ObjectManager.
         /// </summary>
         /// <param name="champion">Champion to remove.</param>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -243,11 +243,6 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players.</param>
         void NotifyGameStart(int userId = 0);
         /// <summary>
-        /// Sends a packet to all players which announces that the team which owns the specified inhibitor has an inhibitor which is respawning soon.
-        /// </summary>
-        /// <param name="inhibitor">Inhibitor that is respawning soon.</param>
-        void NotifyInhibitorSpawningSoon(IInhibitor inhibitor);
-        /// <summary>
         /// Sends a packet to all players detailing the state (DEAD/ALIVE) of the specified inhibitor.
         /// </summary>
         /// <param name="inhibitor">Inhibitor to check.</param>

--- a/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
+++ b/GameServerCore/Scripting/CSharp/IMapScriptMetadata.cs
@@ -18,6 +18,10 @@ namespace GameServerCore.Scripting.CSharp
         /// </summary>
         float ChampionMinGoldValue { get; }
         /// <summary>
+        /// Max range where you can receive XP when a minion dies (Default: 1400.0f)
+        /// </summary>
+        float ExpRange { get; }
+        /// <summary>
         /// The ammount of gold a player should be rewarded for getting the first blood (Default: 100.0f)
         /// </summary>
         float FirstBloodExtraGold { get; }
@@ -37,6 +41,10 @@ namespace GameServerCore.Scripting.CSharp
         /// Ammount of gold per second for all players (Default: 1.9f)
         /// </summary>
         float GoldPerSecond { get; }
+        /// <summary>
+        /// Functionality still unknown, I thought it was used in ARAM, but it's map script sets it to 0 (Default: 1250.0f)
+        /// </summary>
+        float GoldRange { get; }
         /// <summary>
         /// Maximum level a player can reach (Default: 18)
         /// </summary>

--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -398,7 +398,7 @@ namespace LeagueSandbox.GameServer.API
         /// Returns the average level of all players in the game
         /// </summary>
         /// <returns></returns>
-        public static int GetAverageLevel()
+        public static int GetPlayerAverageLevel()
         {
             float average = 0;
             var players = _game.PlayerManager.GetPlayers(true);

--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -11,12 +11,9 @@ using LeagueSandbox.GameServer.Handlers;
 using LeagueSandbox.GameServer.Logging;
 using log4net;
 using PacketDefinitions420;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 using System.Text;
-using static MapData;
 
 namespace LeagueSandbox.GameServer.API
 {
@@ -122,59 +119,6 @@ namespace LeagueSandbox.GameServer.API
             }
 
             return turretItemList[type];
-        }
-
-        /// <summary>
-        /// Changes the lane of a tower in the _tower list, in order to fix missplaced towers due to riot's seemingly random naming scheme
-        /// </summary>
-        /// <param name="towerName"></param>
-        /// <param name="team"></param>
-        /// <param name="currentLaneId"></param>
-        /// <param name="desiredLaneID"></param>
-        public static void ChangeTowerOnMapList(Dictionary<TeamId, Dictionary<LaneID, List<ILaneTurret>>> turretList, string towerName, TeamId team, LaneID currentLaneId, LaneID desiredLaneID)
-        {
-            var tower = turretList[team][currentLaneId].Find(x => x.Name == towerName);
-            tower.SetLaneID(desiredLaneID);
-            turretList[team][currentLaneId].Remove(tower);
-            turretList[team][desiredLaneID].Add(tower);
-        }
-
-        public static IInhibitor GetInhibitorById(Dictionary<TeamId, Dictionary<LaneID, IInhibitor>> inhibitorList, uint id)
-        {
-            foreach (TeamId team in inhibitorList.Keys)
-            {
-                foreach (var inhibitor in inhibitorList[team].Values)
-                {
-                    if (inhibitor.NetId == id)
-                    {
-                        if (inhibitor.NetId == id)
-                        {
-                            return inhibitor;
-                        }
-                    }
-                }
-            }
-            return null;
-        }
-
-        /// <summary>
-        /// Checks is all inhibitors of a specific team are dead
-        /// </summary>
-        /// <param name="team"></param>
-        /// <returns></returns>
-        public static bool AllInhibitorsDestroyedFromTeam(Dictionary<TeamId, Dictionary<LaneID, IInhibitor>> inhibitorList, TeamId team)
-        {
-            foreach (var inhibitor in inhibitorList[team].Values)
-            {
-                if (inhibitor.Team == team && inhibitor.InhibitorState == InhibitorState.ALIVE)
-                {
-                    if (inhibitor.Team == team && inhibitor.InhibitorState == InhibitorState.ALIVE)
-                    {
-                        return false;
-                    }
-                }
-            }
-            return true;
         }
 
         /// <summary>
@@ -448,6 +392,21 @@ namespace LeagueSandbox.GameServer.API
         public static void AddObject(IGameObject obj)
         {
             _game.ObjectManager.AddObject(obj);
+        }
+
+        /// <summary>
+        /// Returns the average level of all players in the game
+        /// </summary>
+        /// <returns></returns>
+        public static int GetAverageLevel()
+        {
+            float average = 0;
+            var players = _game.PlayerManager.GetPlayers(true);
+            foreach (var player in players)
+            {
+                average += player.Item2.Champion.Stats.Level / players.Count;
+            }
+            return (int)average;
         }
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -26,11 +26,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         private float _statUpdateTimer;
         private object _buffsLock;
         private IDeathData _death;
-
-        // Utility Vars.
-        internal const float DETECT_RANGE = 475.0f;
-        internal const int EXP_RANGE = 1400;
         protected readonly ILog Logger;
+
+        //TODO: Find out where this variable came from and if it can be unhardcoded
+        internal const float DETECT_RANGE = 475.0f;
 
         /// <summary>
         /// Whether or not this Unit is dead. Refer to TakeDamage() and Die().
@@ -702,13 +701,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             ApiEventManager.OnDeath.Publish(data);
             if (data.Unit is IObjAiBase obj)
             {
-                var champs = _game.ObjectManager.GetChampionsInRange(Position, EXP_RANGE, true);
+                var champs = _game.ObjectManager.GetChampionsInRange(Position, _game.Map.MapScript.MapScriptMetadata.ExpRange, true);
                 //Cull allied champions
                 champs.RemoveAll(l => l.Team == Team);
 
                 if (champs.Count > 0)
                 {
-                    var expPerChamp = obj.CharData.ExpGivenOnDeath / champs.Count;
+                    var expPerChamp = obj.Stats.ExpGivenOnDeath.Total / champs.Count;
                     foreach (var c in champs)
                     {
                         c.AddExperience(expPerChamp);

--- a/GameServerLib/GameObjects/MonsterCamp.cs
+++ b/GameServerLib/GameObjects/MonsterCamp.cs
@@ -46,7 +46,7 @@ namespace GameServerLib.GameObjects
             game.PacketNotifier.NotifyS2C_CreateMinionCamp(this);
         }
 
-        public void AddMonster(IMonster monster)
+        public IMonster AddMonster(IMonster monster)
         {
             var aiscript = monster.AIScript.ToString().Remove(0, 10);
             var campMonster = new Monster
@@ -56,11 +56,15 @@ namespace GameServerLib.GameObjects
                     monster.SpawnAnimation, monster.IsTargetable, monster.IgnoresCollision, aiscript,
                     monster.DamageBonus, monster.HealthBonus, monster.InitialLevel
                     );
-
+            while(campMonster.Stats.Level < monster.InitialLevel)
+            {
+                campMonster.Stats.LevelUp();
+            }
             Monsters.Add(campMonster);
             ApiEventManager.OnDeath.AddListener(campMonster, campMonster, OnMonsterDeath, true);
             _game.ObjectManager.AddObject(campMonster);
             NotifyCampActivation();
+            return campMonster;
         }
 
         public void OnMonsterDeath(IDeathData deathData)

--- a/GameServerLib/GameObjects/Stats/Stats.cs
+++ b/GameServerLib/GameObjects/Stats/Stats.cs
@@ -39,6 +39,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
         public IStat CooldownReduction { get; }
         public IStat CriticalChance { get; }
         public IStat CriticalDamage { get; }
+        public IStat ExpGivenOnDeath { get; }
         public IStat GoldPerSecond { get; }
         public IStat GoldGivenOnDeath { get; }
         public IStat HealthPoints { get; }
@@ -92,6 +93,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             CooldownReduction = new Stat();
             CriticalChance = new Stat();
             CriticalDamage = new Stat(2, 0, 0, 0, 0);
+            ExpGivenOnDeath = new Stat();
             GoldPerSecond = new Stat();
             GoldGivenOnDeath = new Stat();
             HealthPoints = new Stat();
@@ -118,6 +120,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             AttackDamage.BaseValue = charData.BaseDamage;
             // AttackSpeedFlat = GlobalAttackSpeed / CharAttackDelay
             AttackSpeedFlat = (1.0f / charData.GlobalCharData.AttackDelay) / (1.0f + charData.AttackDelayOffsetPercent[0]);
+            ExpGivenOnDeath.BaseValue = charData.ExpGivenOnDeath;
             GoldGivenOnDeath.BaseValue = charData.GoldGivenOnDeath;
             GrowthAttackSpeed = charData.AttackSpeedPerLevel;
             HealthPerLevel = charData.HpPerLevel;

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -681,8 +681,29 @@ namespace LeagueSandbox.GameServer
             foreach (var kv in _champions)
             {
                 var c = kv.Value;
-                if (Vector2.DistanceSquared(checkPos, c.Position) <= range * range)
+                if (Vector2.DistanceSquared(checkPos, c.Position) <= Math.Sqrt(range))
                     if (onlyAlive && !c.IsDead || !onlyAlive)
+                        champs.Add(c);
+            }
+
+            return champs;
+        }
+
+        /// <summary>
+        /// Gets a list of all GameObjects of type Champion that are within a certain distance from a specified position.
+        /// </summary>
+        /// <param name="checkPos">Vector2 position to check.</param>
+        /// <param name="range">Distance to check.</param>
+        /// <param name="onlyAlive">Whether dead Champions should be excluded or not.</param>
+        /// <returns>List of all Champions within the specified range of the position and of the specified alive status.</returns>
+        public List<IChampion> GetChampionsInRangeFromTeam(Vector2 checkPos, float range, TeamId team, bool onlyAlive = false)
+        {
+            var champs = new List<IChampion>();
+            foreach (var kv in _champions)
+            {
+                var c = kv.Value;
+                if (Vector2.DistanceSquared(checkPos, c.Position) <= Math.Sqrt(range))
+                    if (c.Team == team && (onlyAlive && !c.IsDead || !onlyAlive))
                         champs.Add(c);
             }
 

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -681,7 +681,7 @@ namespace LeagueSandbox.GameServer
             foreach (var kv in _champions)
             {
                 var c = kv.Value;
-                if (Vector2.DistanceSquared(checkPos, c.Position) <= Math.Sqrt(range))
+                if (Vector2.DistanceSquared(checkPos, c.Position) <= Math.Pow(range, 2))
                     if (onlyAlive && !c.IsDead || !onlyAlive)
                         champs.Add(c);
             }
@@ -702,7 +702,7 @@ namespace LeagueSandbox.GameServer
             foreach (var kv in _champions)
             {
                 var c = kv.Value;
-                if (Vector2.DistanceSquared(checkPos, c.Position) <= Math.Sqrt(range))
+                if (Vector2.DistanceSquared(checkPos, c.Position) <= Math.Pow(range, 2))
                     if (c.Team == team && (onlyAlive && !c.IsDead || !onlyAlive))
                         champs.Add(c);
             }

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -681,7 +681,7 @@ namespace LeagueSandbox.GameServer
             foreach (var kv in _champions)
             {
                 var c = kv.Value;
-                if (Vector2.DistanceSquared(checkPos, c.Position) <= Math.Pow(range, 2))
+                if (Vector2.DistanceSquared(checkPos, c.Position) <= range * range)
                     if (onlyAlive && !c.IsDead || !onlyAlive)
                         champs.Add(c);
             }
@@ -702,7 +702,7 @@ namespace LeagueSandbox.GameServer
             foreach (var kv in _champions)
             {
                 var c = kv.Value;
-                if (Vector2.DistanceSquared(checkPos, c.Position) <= Math.Pow(range, 2))
+                if (Vector2.DistanceSquared(checkPos, c.Position) <= range * range)
                     if (c.Team == team && (onlyAlive && !c.IsDead || !onlyAlive))
                         champs.Add(c);
             }

--- a/GameServerLib/Scripting/CSharp/MapScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/MapScriptMetadata.cs
@@ -12,9 +12,11 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         public float ChampionBaseGoldValue { get; set; } = 300.0f;
         public float ChampionMaxGoldValue { get; set; } = 500.0f;
         public float ChampionMinGoldValue { get; set; } = 50.0f;
+        public float ExpRange { get; set; } = 1400.0f;
         public float FirstBloodExtraGold { get; set; } = 100.0f;
         public float FirstGoldTime { get; set; } = 90 * 1000;
         public float GoldPerSecond { get; set; } = 1.9f;
+        public float GoldRange { get; set; } = 1250.0f;
         public int InitialLevel { get; set; } = 1;
         public bool IsKillGoldRewardReductionActive { get; set; } = true;
         public int MaxLevel { get; set; } = 18;

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -572,8 +572,7 @@ namespace PacketDefinitions420
             {
                 SenderNetID = inhibitor.NetId,
                 State = (byte)inhibitor.InhibitorState,
-                //Not sure if this is right
-                Duration = (ushort)inhibitor.GetRespawnTimer()
+                Duration = (ushort)inhibitor.RespawnTime
             };
             _packetHandlerManager.BroadcastPacket(inhibState.GetBytes(), Channel.CHL_S2C);
         }
@@ -1131,20 +1130,6 @@ namespace PacketDefinitions420
             {
                 _packetHandlerManager.SendPacket(userId, start.GetBytes(), Channel.CHL_S2C);
             }
-        }
-
-        /// <summary>
-        /// Sends a packet to all players which announces that the team which owns the specified inhibitor has an inhibitor which is respawning soon.
-        /// </summary>
-        /// <param name="inhibitor">Inhibitor that is respawning soon.</param>
-        public void NotifyInhibitorSpawningSoon(IInhibitor inhibitor)
-        {
-            //I'm not sure about any of these NetIds, the values i saw on packets seemed random, without any mention to the creation of that entity
-            var dampenerRespawnSoon = new OnDampenerRespawnSoon
-            {
-                OtherNetID = inhibitor.NetId
-            };
-            NotifyS2C_OnEventWorld(dampenerRespawnSoon, inhibitor.NetId);
         }
 
         /// <summary>
@@ -3275,7 +3260,7 @@ namespace PacketDefinitions420
         /// <summary>
         /// Calls for the appropriate spawn packet to be sent given the specified GameObject's type and calls for a vision packet to be sent for the specified GameObject.
         /// </summary>
-        /// <param name="o">GameObject that has spawned.</param>
+        /// <param name="obj">GameObject that has spawned.</param>
         /// <param name="team">The team the user belongs to.</param>
         /// <param name="userId">UserId to send the packet to.</param>
         /// <param name="gameTime">Time elapsed since the start of the game</param>


### PR DESCRIPTION
* Inhibitors
    - Removed the timer to respawn
    - Respawn is now handled by Map Scripts
    - Separated `SetState` into `SetState` and `NotifyState`
    - Introduced `RespawnTime` and `RespawnAnimationAnnounced`

* PacketNotifier
    - Removed `NotifyInhibitorSpawningSoon`, deemed unnecessary. The annoucement is done automatically client-side, with it's timer being defined in DampenerSwitchStates.

* APIMapFunctionManager
    - Removed `ChangeTowerOnMapList`, `GetInhibitorById` and `AllInhibitorsDestroyedFromTeam`, as they were deemed unnecessary
    - Introduced `GetPlayerAverageLevel`

* AttackableUnit
    - Unhardcoded the ExpRange variable
    - The EXP ammount is now defined by the unit's `Stats`, not `CharData`
    - Monsters no longer share EXP in the area they died.

* MonsterCamps
    - `AddMonster` now returns the monster just created.

* Stats
    - Introduced `ExpGivenOnDeath `

* MapScriptMetaData
    - Introduced `ExpRange` and `GoldRange`

* MonsterDataTable
    - Introduced `MonsterDataTable` so it can properly handle Monster's stats based on their level
   
* Scripts
    - Updated all MapScripts to handle Inhibitor respawning and use MonsterDataTables.
