### PR TITLE
Setting a `IS_GHOSTED` `ActionFlag` when sending a stats update

### DIFF
--- a/GameServerLib/GameObjects/Stats/Replication/ReplicationAiTurret.cs
+++ b/GameServerLib/GameObjects/Stats/Replication/ReplicationAiTurret.cs
@@ -13,7 +13,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
         {
             // UpdateFloat(Stats.ManaPoints.Total, 1, 0); //mMaxMP
             // UpdateFloat(Stats.CurrentMana, 1, 1); //mMP
-            UpdateUint((uint)Stats.ActionState, 1, 2); //ActionState
+            UpdateUint((uint)(Stats.ActionState | GameServerCore.Enums.ActionState.IS_GHOSTED), 1, 2); //ActionState
             UpdateBool(Stats.IsMagicImmune, 1, 3); //MagicImmune
             UpdateBool(Stats.IsInvulnerable, 1, 4); //IsInvulnerable
             UpdateBool(Stats.IsPhysicalImmune, 1, 5); //IsPhysicalImmune

--- a/GameServerLib/GameObjects/Stats/Replication/ReplicationHero.cs
+++ b/GameServerLib/GameObjects/Stats/Replication/ReplicationHero.cs
@@ -26,7 +26,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             {
                 UpdateFloat(Stats.ManaCost[45 + i], 0, 12 + i); //ManaCost_Ex{i}
             }
-            UpdateUint((uint)Stats.ActionState, 1, 0); //ActionState
+            UpdateUint((uint)(Stats.ActionState | GameServerCore.Enums.ActionState.IS_GHOSTED), 1, 0); //ActionState
             UpdateBool(Stats.IsMagicImmune, 1, 1); //MagicImmune
             UpdateBool(Stats.IsInvulnerable, 1, 2); //IsInvulnerable
             UpdateBool(Stats.IsPhysicalImmune, 1, 3); //IsPhysicalImmune

--- a/GameServerLib/GameObjects/Stats/Replication/ReplicationLaneMinion.cs
+++ b/GameServerLib/GameObjects/Stats/Replication/ReplicationLaneMinion.cs
@@ -17,7 +17,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             // UpdateFloat(Stats.LifeTimeTicks, 1, 4); //mLifetimeTicks
             // UpdateFloat(Stats.ManaPoints.Total, 1, 5); //mMaxMP
             // UpdateFloat(Stats.CurrentMana, 1, 6); //mMP
-            UpdateUint((uint)Stats.ActionState, 1, 7); //ActionState
+            UpdateUint((uint)(Stats.ActionState | GameServerCore.Enums.ActionState.IS_GHOSTED), 1, 7); //ActionState
             UpdateBool(Stats.IsMagicImmune, 1, 8); //MagicImmune
             UpdateBool(Stats.IsInvulnerable, 1, 9); //IsInvulnerable
             UpdateBool(Stats.IsPhysicalImmune, 1, 10); //IsPhysicalImmune

--- a/GameServerLib/GameObjects/Stats/Replication/ReplicationMinion.cs
+++ b/GameServerLib/GameObjects/Stats/Replication/ReplicationMinion.cs
@@ -17,7 +17,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             // UpdateFloat(Stats.LifeTimeTicks, 1, 4); //mLifetimeTicks
             // UpdateFloat(Stats.ManaPoints.Total, 1, 5); //mMaxMP
             // UpdateFloat(Stats.CurrentMana, 1, 6); //mMP
-            UpdateUint((uint)Stats.ActionState, 1, 7); //ActionState
+            UpdateUint((uint)(Stats.ActionState | GameServerCore.Enums.ActionState.IS_GHOSTED), 1, 7); //ActionState
             UpdateBool(Stats.IsMagicImmune, 1, 8); //MagicImmune
             UpdateBool(Stats.IsInvulnerable, 1, 9); //IsInvulnerable
             UpdateBool(Stats.IsPhysicalImmune, 1, 10); //IsPhysicalImmune


### PR DESCRIPTION
The solution to [problems](https://github.com/LeagueSandbox/GameServer/pull/1367) with the collision avoidance algorithm that does not have a twin brother on the server is to disable it. You can also multiply the navigation radius of units by zero, but this will require modification of the game files.