### PR TITLE
Resolve #1374, Resolve #1375 -- Fix Movement After Spell/Dash

### DIFF
--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -88,6 +88,10 @@ namespace GameServerCore.Domain.GameObjects
         /// <returns></returns>
         bool CanMove();
         /// <summary>
+        /// Whether or not this unit can modify its Waypoints.
+        /// </summary>
+        bool CanChangeWaypoints();
+        /// <summary>
         /// Whether or not this unit can take damage of the given type.
         /// </summary>
         /// <param name="type">Type of damage to check.</param>

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -877,16 +877,7 @@ namespace LeagueSandbox.GameServer.API
         /// <param name="enabled">Whether or not the status should be enabled.</param>
         public static void SetStatus(IAttackableUnit unit, StatusFlags status, bool enabled)
         {
-            // Loop over all possible status flags and set them individually.
-            for (int i = 0; i < 30; i++)
-            {
-                StatusFlags currentFlag = (StatusFlags)(1 << i);
-
-                if (status.HasFlag(currentFlag))
-                {
-                    unit.SetStatus(currentFlag, enabled);
-                }
-            }
+            unit.SetStatus(status, enabled);
         }
 
         public static void SetTargetingType(IObjAiBase target, SpellSlotType slotType, int slot, TargetingType newType)

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -291,19 +291,17 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
         public override bool CanMove()
         {
-            // TODO: Verify if Dashes should bypass this.
-            return !IsDead
-                // TODO: Verify if priority is still maintained with the MovementParameters checks.
-                && ((Status.HasFlag(StatusFlags.CanMove) && Status.HasFlag(StatusFlags.CanMoveEver)) || MovementParameters != null)
-                && ((MoveOrder != OrderType.CastSpell && _castingSpell == null) || MovementParameters != null)
+            return (!IsDead
+                && MovementParameters != null)
+                || (Status.HasFlag(StatusFlags.CanMove) && Status.HasFlag(StatusFlags.CanMoveEver)
+                && (MoveOrder != OrderType.CastSpell && _castingSpell == null)
                 && (ChannelSpell == null || (ChannelSpell != null && ChannelSpell.SpellData.CanMoveWhileChanneling))
                 && (!IsAttacking || !AutoAttackSpell.SpellData.CantCancelWhileWindingUp)
-                && (!(Status.HasFlag(StatusFlags.Netted)
+                && !(Status.HasFlag(StatusFlags.Netted)
                 || Status.HasFlag(StatusFlags.Rooted)
                 || Status.HasFlag(StatusFlags.Sleep)
                 || Status.HasFlag(StatusFlags.Stunned)
-                || Status.HasFlag(StatusFlags.Suppressed))
-                || MovementParameters != null);
+                || Status.HasFlag(StatusFlags.Suppressed)));
         }
 
         public override bool CanChangeWaypoints()

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -935,6 +935,11 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 CreateSpellSector();
             }
 
+            if (CastInfo.Owner.GetCastSpell() == this)
+            {
+                CastInfo.Owner.SetCastSpell(null);
+            }
+
             if (CastInfo.Owner.SpellToCast != null && CastInfo.Owner.SpellToCast == this)
             {
                 CastInfo.Owner.SetSpellToCast(null, Vector2.Zero);

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -369,6 +369,11 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             // TODO: Verify if we should also do this for manual SpellCasts
             if (!CastInfo.IsAutoAttack)
             {
+                if (!SpellData.DoesntBreakChannels)
+                {
+                    CastInfo.Owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.Casting);
+                }
+
                 if (!SpellData.Flags.HasFlag(SpellDataFlags.InstantCast))
                 {
                     CastInfo.Owner.SetCastSpell(this);
@@ -766,6 +771,30 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
 
         public void ChannelCancelCheck()
         {
+            if (CastInfo.Owner.IsDead)
+            {
+                CastInfo.Owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.Die);
+                return;
+            }
+
+            // TODO: Verify if this should only be checked at the start of channeling.
+            if (CastInfo.Owner.MovementParameters != null)
+            {
+                CastInfo.Owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.Move);
+            }
+
+            // TODO: Verify if Taunted should be handled by the Taunt buff script instead.
+            var status = CastInfo.Owner.Status;
+            if (status.HasFlag(StatusFlags.Charmed)
+            || status.HasFlag(StatusFlags.Feared)
+            || status.HasFlag(StatusFlags.Silenced)
+            || status.HasFlag(StatusFlags.Stunned)
+            || status.HasFlag(StatusFlags.Suppressed)
+            || status.HasFlag(StatusFlags.Taunted))
+            {
+                CastInfo.Owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.StunnedOrSilencedOrTaunted);
+            }
+
             // Uncancellable
             if (SpellData.CantCancelWhileChanneling)
             {
@@ -777,35 +806,17 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 var spellTarget = CastInfo.Targets[0].Unit;
 
                 if (spellTarget != null
-                && !spellTarget.IsVisibleByTeam(CastInfo.Owner.Team))
+                && (!spellTarget.IsVisibleByTeam(CastInfo.Owner.Team)
+                || spellTarget.IsDead))
                 {
                     CastInfo.Owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.LostTarget);
                     return;
                 }
             }
 
-            var status = CastInfo.Owner.Status;
-
-            if (status == StatusFlags.Charmed
-            || status == StatusFlags.Feared
-            || status == StatusFlags.Silenced
-            || status == StatusFlags.Stunned
-            || status == StatusFlags.Suppressed
-            || status == StatusFlags.Taunted)
-            {
-                CastInfo.Owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.StunnedOrSilencedOrTaunted);
-            }
-
-            if (CastInfo.Owner.IsDead)
-            {
-                CastInfo.Owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.Die);
-                return;
-            }
-
             // TODO: ChannelingStopSource.HeroReincarnate
 
             var order = CastInfo.Owner.MoveOrder;
-
             if (!SpellData.CanMoveWhileChanneling
             && (order == OrderType.MoveTo
                 || order == OrderType.AttackMove
@@ -829,8 +840,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 return;
             }
 
-            if (CastInfo.Owner.GetCastSpell() != null
-            && !CastInfo.Owner.GetCastSpell().SpellData.DoesntBreakChannels
+            var castSpell = CastInfo.Owner.GetCastSpell();
+            if (castSpell != null
+            && !castSpell.SpellData.DoesntBreakChannels
             && (order == OrderType.CastSpell
             || order == OrderType.TempCastSpell))
             {
@@ -873,6 +885,10 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             if (CastInfo.Owner.ChannelSpell == this)
             {
                 CastInfo.Owner.SetChannelSpell(null);
+            }
+            if (CastInfo.Owner.SpellToCast == this)
+            {
+                CastInfo.Owner.SetSpellToCast(null, Vector2.Zero);
             }
 
             Script.OnDeactivate(CastInfo.Owner, this);
@@ -1164,7 +1180,10 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
         {
             ApiEventManager.OnSpellPostChannel.Publish(this);
 
-            CastInfo.Owner.SetChannelSpell(null);
+            if (CastInfo.Owner.ChannelSpell == this)
+            {
+                CastInfo.Owner.SetChannelSpell(null);
+            }
 
             CastInfo.Owner.UpdateMoveOrder(OrderType.Hold, true);
 
@@ -1398,10 +1417,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             {
                 case SpellState.STATE_READY:
                 {
-                    if (CastInfo.Owner.GetCastSpell() == this)
-                    {
-                        CastInfo.Owner.SetCastSpell(null);
-                    }
                     break;
                 }
                 case SpellState.STATE_CASTING:
@@ -1412,10 +1427,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                     }
                     if (!CastInfo.IsAutoAttack && !CastInfo.UseAttackCastTime)
                     {
-                        if (!SpellData.Flags.HasFlag(SpellDataFlags.InstantCast) && CastInfo.Owner.GetCastSpell() != this)
-                        {
-                            CastInfo.Owner.SetCastSpell(this);
-                        }
                         CurrentCastTime -= diff / 1000.0f;
                         if (CurrentCastTime <= 0)
                         {


### PR DESCRIPTION
* Units have their currently casting spell reset after the cast has finished, rather than when the spell state is set to READY.
* Channels are now canceled more accurately (particularly related to forced movements).