### PR TITLE
Quickfix: non-removable missiles

### DIFF
--- a/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
+++ b/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
@@ -69,7 +69,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Missile
 
         public override void Update(float diff)
         {
-            if (HasTarget())
+            if (HasTarget() && !TargetUnit.IsDead && TargetUnit.Status.HasFlag(StatusFlags.Targetable))
             {
                 _timeSinceCreation += diff;
                 Move(diff);
@@ -77,9 +77,10 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell.Missile
             }
             else
             {
+                // Destroy any missiles which are targeting an untargetable unit.
+                // TODO: Verify if this should apply to SpellSector.
                 //Direction = new Vector3();
                 SetToRemove();
-                return;
             }
         }
 

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -243,18 +243,7 @@ namespace LeagueSandbox.GameServer
 
         void LateUpdate(IGameObject obj, float diff)
         {
-            // Destroy any missiles which are targeting an untargetable unit.
-            // TODO: Verify if this should apply to SpellSector.
-            // TODO: Should it be moved to SpellMissile.Update?
-            if (obj is ISpellMissile m)
-            {
-                if (m.TargetUnit == null || m.TargetUnit.IsDead || !m.TargetUnit.Status.HasFlag(StatusFlags.Targetable))
-                {
-                    m.SetToRemove();
-                }
-            }
-
-            else if (obj is IAttackableUnit u)
+            if (obj is IAttackableUnit u)
             {
                 if (u is IObjAiBase ai)
                 {

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -245,9 +245,10 @@ namespace LeagueSandbox.GameServer
         {
             // Destroy any missiles which are targeting an untargetable unit.
             // TODO: Verify if this should apply to SpellSector.
+            // TODO: Should it be moved to SpellMissile.Update?
             if (obj is ISpellMissile m)
             {
-                if (m.TargetUnit != null && !m.TargetUnit.Status.HasFlag(StatusFlags.Targetable))
+                if (m.TargetUnit == null || m.TargetUnit.IsDead || !m.TargetUnit.Status.HasFlag(StatusFlags.Targetable))
                 {
                     m.SetToRemove();
                 }


### PR DESCRIPTION
Missiles are only removed when they collide with their target. If the target dies early, the missile stays and continues to check its visibility. Ordinary missiles don't have to check for collision at all, but simply move towards the enemy or the last point where he was, and then disappear. And perhaps should not check the vision. But this is a topic for future commits