### PR TITLE
Introducing SpellAmmo

### DIFF
--- a/Content/LeagueSandbox-Scripts/Characters/Corki/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Corki/R.cs
@@ -16,8 +16,13 @@ namespace Spells
         public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
             PersistsThroughDeath = true,
+            IsNonDispellable = true,
             TriggersSpellCasts = true,
-            CooldownIsAffectedByCDR = false
+            CooldownIsAffectedByCDR = false,
+            SpellFXOverrideSkins = new string[]
+            {
+                "FireworksCorki"
+            }
         };
 
         public void OnActivate(IObjAiBase owner, ISpell spell)
@@ -36,7 +41,7 @@ namespace Spells
         {
             var owner = spell.CastInfo.Owner;
             FaceDirection(new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z), owner, true);
-            var targetPos = GetPointFromUnit(spell.CastInfo.Owner, 1300.0f);
+            var targetPos = GetPointFromUnit(spell.CastInfo.Owner, spell.SpellData.CastRange[0]);
             SpellCast(owner, 1, SpellSlotType.ExtraSlots, owner.Position, targetPos, false, Vector2.Zero);
         }
 
@@ -70,7 +75,11 @@ namespace Spells
                 Type = MissileType.Circle
             },
             DoesntBreakShields = false,
-            TriggersSpellCasts = true
+            TriggersSpellCasts = false,
+            SpellFXOverrideSkins = new string[]
+            {
+                "FireworksCorki"
+            }
         };
 
 

--- a/Content/LeagueSandbox-Scripts/Characters/Corki/R.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Corki/R.cs
@@ -1,0 +1,135 @@
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Domain.GameObjects.Spell;
+using GameServerCore.Domain.GameObjects.Spell.Missile;
+using GameServerCore.Domain.GameObjects.Spell.Sector;
+using GameServerCore.Enums;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using System.Numerics;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+
+namespace Spells
+{
+    public class MissileBarrage : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            PersistsThroughDeath = true,
+            TriggersSpellCasts = true,
+            CooldownIsAffectedByCDR = false
+        };
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+            var owner = spell.CastInfo.Owner;
+            FaceDirection(new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z), owner, true);
+            var targetPos = GetPointFromUnit(spell.CastInfo.Owner, 1300.0f);
+            SpellCast(owner, 1, SpellSlotType.ExtraSlots, owner.Position, targetPos, false, Vector2.Zero);
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+
+    public class MissileBarrageMissile : ISpellScript
+    {
+        public ISpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            MissileParameters = new MissileParameters
+            {
+                Type = MissileType.Circle
+            },
+            DoesntBreakShields = false,
+            TriggersSpellCasts = true
+        };
+
+
+        public void OnActivate(IObjAiBase owner, ISpell spell)
+        {
+            ApiEventManager.OnSpellHit.AddListener(this, spell, OnSpellHit, false);
+        }
+
+        public void OnSpellHit(ISpell spell, IAttackableUnit target, ISpellMissile missile, ISpellSector sector)
+        {
+            var owner = spell.CastInfo.Owner;
+
+            var spellLevel = owner.Spells[3].CastInfo.SpellLevel;
+            float AP = owner.Stats.AbilityPower.Total * 0.3f;
+            float AD = owner.Stats.AttackDamage.Total * (0.1f + (0.1f * spellLevel));
+            float totalDamage = 20 + (80 * spellLevel) + AP + AD;
+
+            var targets = GetUnitsInRange(target.Position, 75.0f, true);
+            foreach (var unit in targets)
+            {
+                unit.TakeDamage(owner, totalDamage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELLAOE, false);
+            }
+
+            AddParticle(owner, null, "corki_misslebarrage_std_tar", target.Position);
+
+            missile.SetToRemove();
+        }
+
+        public void OnDeactivate(IObjAiBase owner, ISpell spell)
+        {
+        }
+
+        public void OnSpellPreCast(IObjAiBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
+        {
+            FaceDirection(end, owner, true);
+        }
+
+        public void OnSpellCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellPostCast(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannel(ISpell spell)
+        {
+        }
+
+        public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
+        {
+        }
+
+        public void OnSpellPostChannel(ISpell spell)
+        {
+        }
+
+        public void OnUpdate(float diff)
+        {
+        }
+    }
+}

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/URFMutator.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/URFMutator.cs
@@ -24,6 +24,7 @@ namespace MapScripts.Map1
 
         public override void OnMatchStart()
         {
+            base.OnMatchStart();
             foreach(var player in GetAllPlayers())
             {
                 //There are mentions to a "rewindcof" buff being loaded too, but it's functions are yet unknown

--- a/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/ISpell.cs
@@ -13,6 +13,8 @@ namespace GameServerCore.Domain.GameObjects.Spell
         /// General information about this spell when it is cast. Refer to CastInfo class.
         /// </summary>
         ICastInfo CastInfo { get; }
+        int CurrentAmmo { get; }
+        float CurrentAmmoCooldown { get; }
         /// <summary>
         /// Current cooldown of this spell.
         /// </summary>
@@ -125,6 +127,7 @@ namespace GameServerCore.Domain.GameObjects.Spell
         ISpellSector CreateSpellSector(ISectorParameters parameters);
 
         float GetCooldown();
+        float GetAmmoRechageTime();
 
         /// <summary>
         /// Gets the cast range for this spell (based on level).

--- a/GameServerCore/Domain/GameObjects/Spell/ISpellData.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/ISpellData.cs
@@ -78,7 +78,7 @@ namespace GameServerCore.Domain.GameObjects.Spell
         float LuaOnMissileUpdateDistanceInterval { get; }
         float MagicDamageCoefficient { get; }
         float[] ManaCost { get; }
-        int[] MaxAmmo { get; }
+        int MaxAmmo { get; }
         float MissileAccel { get; }
         string MissileBoneName { get; }
         string MissileEffect { get; }

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -528,6 +528,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="showWindow">Whether or not to show a window before unpausing (delay).</param>
         void NotifyResumePacket(IChampion unpauser, ClientInfo player, bool isDelayed);
         void NotifyS2C_ActivateMinionCamp(IMonsterCamp monsterCamp);
+        void NotifyS2C_AmmoUpdate(ISpell spell);
         /// <summary>
         /// Sends a packet to all players with vision of the given chain missile that it has updated (unit/position).
         /// </summary>

--- a/GameServerCore/Scripting/CSharp/ISpellScriptMetadata.cs
+++ b/GameServerCore/Scripting/CSharp/ISpellScriptMetadata.cs
@@ -5,33 +5,23 @@ namespace GameServerCore.Scripting.CSharp
 {
     public interface ISpellScriptMetadata
     {
+        public int AmmoPerCharge { get; }
         string AutoAuraBuffName { get; }
-
         string AutoBuffActivateEvent { get; }
-
         float[] AutoCooldownByLevel { get; }
-
         string AutoItemActivateEffect { get; }
-
         /// <summary>
         /// Whether or not the caster should automatically face the end position of the spell.
         /// </summary>
         bool AutoFaceDirection { get; }
-
         float[] AutoTargetDamageByLevel { get; }
-
         float CastTime { get; }
         bool CastingBreaksStealth { get; }
-
-        IMissileParameters MissileParameters { get; }
-
-        ISectorParameters SectorParameters { get; }
-
         /// <summary>
         /// Determines how how long the spell should be channeled (overrides content based channel duration). Triggers on channel (and post) if value is above 0.
         /// </summary>
         float ChannelDuration { get; }
-        
+        bool CooldownIsAffectedByCDR { get; }
         bool DoOnPreDamageInExpirationOrder { get; }
         bool DoesntBreakShields { get; }
         bool IsDamagingSpell { get; }
@@ -39,26 +29,20 @@ namespace GameServerCore.Scripting.CSharp
         bool IsDebugMode { get; }
         bool IsPetDurationBuff { get; }
         bool IsNonDispellable { get; }
-
+        IMissileParameters MissileParameters { get; }
         bool NotSingleTargetSpell { get; }
-        
         int OnPreDamagePriority { get; }
-
         bool OverrideCooldownCheck { get; }
         bool PermeatesThroughDeath { get; }
+        //Move this to BuffMetaData
         bool PersistsThroughDeath { get; }
-
         string PopupMessage1 { get; }
-        
         float SetSpellDamageRatio { get; }
         float SpellDamageRatio { get; }
-
+        ISectorParameters SectorParameters { get; }
         string[] SpellFXOverrideSkins { get; }
-
         int SpellToggleSlot { get; }
-
         string[] SpellVOOverrideSkins { get; }
-
         /// <summary>
         /// Determines whether or not the spell stops movement and triggers spell casts (and post).
         /// Usually should not be true if the spell is an item active, summoner spell, missile spell, or otherwise purely buff related spell.

--- a/GameServerLib/Content/SpellData.cs
+++ b/GameServerLib/Content/SpellData.cs
@@ -136,7 +136,7 @@ namespace LeagueSandbox.GameServer.Content
         public float MagicDamageCoefficient { get; set; }
         public float[] ManaCost { get; set; } = { 0, 0, 0, 0, 0, 0, 0 };
         //Map_X_EffectYLevelZAmmount
-        public int[] MaxAmmo { get; set; } = { 0, 0, 0, 0, 0, 0, 0 };
+        public int MaxAmmo { get; set; } = 1;
         //MaxGrowthRangeTextureName
         //MinimapIcon
         //MinimapIconDisplayFlag
@@ -373,6 +373,21 @@ namespace LeagueSandbox.GameServer.Content
             AlwaysSnapFacing = file.GetBool("SpellData", "AlwaysSnapFacing", AlwaysSnapFacing);
             //AmmoCountHiddenInUI
             AmmoRechargeTime = file.GetMultiFloat("SpellData", "AmmoRechargeTime", 6, AmmoRechargeTime[0]);
+            float lastValidTime = 0;
+            for (var i = 1; i <= 6 + 1; i++)
+            {
+                float time = file.GetFloat("SpellData", $"AmmoRechargeTime{i}", 0);
+
+                if(time > 0)
+                {
+                    AmmoRechargeTime[i - 1] = time;
+                    lastValidTime = time;
+                }
+                else
+                {
+                    AmmoRechargeTime[i - 1] = lastValidTime;
+                }
+            }
             AmmoUsed = file.GetMultiInt("SpellData", "AmmoUsed", 6, AmmoUsed[0]);
             AnimationLeadOutName = file.GetString("SpellData", "AnimationLeadOutName", name);
             AnimationLoopName = file.GetString("SpellData", "AnimationLoopName", name);
@@ -469,7 +484,7 @@ namespace LeagueSandbox.GameServer.Content
             MagicDamageCoefficient = file.GetFloat("SpellData", "Coefficient2", MagicDamageCoefficient);
             ManaCost = file.GetMultiFloat("SpellData", "ManaCost", 6, ManaCost[0]);
             //Map_X_EffectYLevelZAmmount
-            MaxAmmo = file.GetMultiInt("SpellData", "MaxAmmo", 6, MaxAmmo[0]);
+            MaxAmmo = file.GetInt("SpellData", "MaxAmmo", MaxAmmo);
             //MaxGrowthRangeTextureName
             //MinimapIcon
             //MinimapIconDisplayFlag

--- a/GameServerLib/Content/SpellData.cs
+++ b/GameServerLib/Content/SpellData.cs
@@ -372,7 +372,6 @@ namespace LeagueSandbox.GameServer.Content
             AlternateName = file.GetString("SpellData", "AlternateName", name);
             AlwaysSnapFacing = file.GetBool("SpellData", "AlwaysSnapFacing", AlwaysSnapFacing);
             //AmmoCountHiddenInUI
-            AmmoRechargeTime = file.GetMultiFloat("SpellData", "AmmoRechargeTime", 6, AmmoRechargeTime[0]);
             float lastValidTime = 0;
             for (var i = 1; i <= 6 + 1; i++)
             {

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -1065,64 +1065,64 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             switch (parameters.Type)
             {
                 case MissileType.Target:
-                    {
-                        p = new SpellMissile(
-                            _game,
-                            (int)SpellData.LineWidth,
-                            this,
-                            CastInfo,
-                            SpellData.MissileSpeed,
-                            SpellData.Flags,
-                            netId,
-                            isServerOnly
-                        );
-                        break;
-                    }
+                {
+                    p = new SpellMissile(
+                        _game,
+                        (int)SpellData.LineWidth,
+                        this,
+                        CastInfo,
+                        SpellData.MissileSpeed,
+                        SpellData.Flags,
+                        netId,
+                        isServerOnly
+                    );
+                    break;
+                }
                 case MissileType.Chained:
-                    {
-                        p = new SpellChainMissile(
-                            _game,
-                            (int)SpellData.LineWidth,
-                            this,
-                            CastInfo,
-                            parameters,
-                            SpellData.MissileSpeed,
-                            SpellData.Flags,
-                            netId,
-                            isServerOnly
-                        );
-                        break;
-                    }
+                {
+                    p = new SpellChainMissile(
+                        _game,
+                        (int)SpellData.LineWidth,
+                        this,
+                        CastInfo,
+                        parameters,
+                        SpellData.MissileSpeed,
+                        SpellData.Flags,
+                        netId,
+                        isServerOnly
+                    );
+                    break;
+                }
                 case MissileType.Circle:
-                    {
-                        p = new SpellCircleMissile(
-                            _game,
-                            (int)SpellData.LineWidth,
-                            this,
-                            CastInfo,
-                            SpellData.MissileSpeed,
-                            parameters.OverrideEndPosition,
-                            SpellData.Flags,
-                            netId,
-                            isServerOnly
-                        );
-                        break;
-                    }
+                {
+                    p = new SpellCircleMissile(
+                        _game,
+                        (int)SpellData.LineWidth,
+                        this,
+                        CastInfo,
+                        SpellData.MissileSpeed,
+                        parameters.OverrideEndPosition,
+                        SpellData.Flags,
+                        netId,
+                        isServerOnly
+                    );
+                    break;
+                }
                 case MissileType.Arc:
-                    {
-                        p = new SpellLineMissile(
-                            _game,
-                            (int)SpellData.LineWidth,
-                            this,
-                            CastInfo,
-                            SpellData.MissileSpeed,
-                            parameters.OverrideEndPosition,
-                            SpellData.Flags,
-                            netId,
-                            isServerOnly
-                        );
-                        break;
-                    }
+                {
+                    p = new SpellLineMissile(
+                        _game,
+                        (int)SpellData.LineWidth,
+                        this,
+                        CastInfo,
+                        SpellData.MissileSpeed,
+                        parameters.OverrideEndPosition,
+                        SpellData.Flags,
+                        netId,
+                        isServerOnly
+                    );
+                    break;
+                }
             }
 
             // If the position is the same as the destination, the server will have destroyed the missile before notifying of creation, causing the client to crash.
@@ -1175,43 +1175,43 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             switch (parameters.Type)
             {
                 case SectorType.Area:
-                    {
-                        s = new SpellSector(
-                            _game,
-                            parameters,
-                            this,
-                            CastInfo,
-                            netId
-                        );
-                        break;
-                    }
+                {
+                    s = new SpellSector(
+                        _game,
+                        parameters,
+                        this,
+                        CastInfo,
+                        netId
+                    );
+                    break;
+                }
                 case SectorType.Cone:
-                    {
-                        s = new SpellSectorCone(
-                            _game,
-                            parameters,
-                            this,
-                            CastInfo,
-                            netId
-                        );
-                        break;
-                    }
+                {
+                    s = new SpellSectorCone(
+                        _game,
+                        parameters,
+                        this,
+                        CastInfo,
+                        netId
+                    );
+                    break;
+                }
                 case SectorType.Polygon:
-                    {
-                        s = new SpellSectorPolygon(
-                            _game,
-                            parameters,
-                            this,
-                            CastInfo,
-                            netId
-                        );
-                        break;
-                    }
+                {
+                    s = new SpellSectorPolygon(
+                        _game,
+                        parameters,
+                        this,
+                        CastInfo,
+                        netId
+                    );
+                    break;
+                }
                 case SectorType.Ring:
-                    {
-                        // TODO
-                        break;
-                    }
+                {
+                    // TODO
+                    break;
+                }
             }
 
             _game.ObjectManager.AddObject(s);

--- a/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
+++ b/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
@@ -9,34 +9,24 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
 {
     public class SpellScriptMetadata : ISpellScriptMetadata
     {
+        public int AmmoPerCharge { get; set; } = 1;
         public string AutoAuraBuffName { get; set; } = "";
-
         // TODO: Replace string with empty event class.
         public string AutoBuffActivateEvent { get; set; } = "";
-
         public float[] AutoCooldownByLevel { get; set; } = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
-
         public string AutoItemActivateEffect { get; set; } = "";
-
         /// <summary>
         /// Whether or not the caster should automatically face the end position of the spell.
         /// </summary>
         public bool AutoFaceDirection { get; set; } = true;
-
         public float[] AutoTargetDamageByLevel { get; set; } = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
-
         public float CastTime { get; set; } = 0.0f;
         public bool CastingBreaksStealth { get; set; } = false;
-
-        public IMissileParameters MissileParameters { get; set; } = null;
-
-        public ISectorParameters SectorParameters { get; set; } = null;
-
         /// <summary>
         /// Determines how how long the spell should be channeled (overrides content based channel duration). Triggers on channel (and post) if value is above 0.
         /// </summary>
         public float ChannelDuration { get; set; } = 0.0f;
-
+        public bool CooldownIsAffectedByCDR { get; set; } = true;
         public bool DoOnPreDamageInExpirationOrder { get; set; } = false;
         public bool DoesntBreakShields { get; set; } = false;
         // TODO: Find a use for this.
@@ -45,17 +35,15 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         public bool IsDebugMode { get; set; } = false;
         public bool IsPetDurationBuff { get; set; } = false;
         public bool IsNonDispellable { get; set; } = false;
+        public IMissileParameters MissileParameters { get; set; } = null;
         public bool NotSingleTargetSpell { get; set; } = false;
-
         // Never appears below 2?
         public int OnPreDamagePriority { get; set; } = 0;
-
         public bool OverrideCooldownCheck { get; set; } = false;
         public bool PermeatesThroughDeath { get; set; } = false;
         public bool PersistsThroughDeath { get; set; } = false;
-
         public string PopupMessage1 { get; set; } = "";
-
+        public ISectorParameters SectorParameters { get; set; } = null;
         public float SetSpellDamageRatio { get; set; } = 0.0f;
         public float SpellDamageRatio { get; set; } = 0.0f;
 

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -2512,7 +2512,7 @@ namespace PacketDefinitions420
                     IsSummonerSpell = spell.SpellName.StartsWith("Summoner"),
                     SpellSlot = spell.CastInfo.SpellSlot,
                     CurrentAmmo = spell.CurrentAmmo,
-                    //This was the only value found on replays
+                    // TODO: Implement this. Example spell which uses it is Syndra R.
                     MaxAmmo = -1,
                     SenderNetID = spell.CastInfo.Owner.NetId
                 };

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -2380,6 +2380,30 @@ namespace PacketDefinitions420
             _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
         }
 
+        public void NotifyS2C_AmmoUpdate(ISpell spell)
+        {
+            if(spell.CastInfo.Owner is IChampion ch)
+            {
+                var packet = new S2C_AmmoUpdate
+                {
+                    IsSummonerSpell = spell.SpellName.StartsWith("Summoner"),
+                    SpellSlot = spell.CastInfo.SpellSlot,
+                    CurrentAmmo = spell.CurrentAmmo,
+                    //This was the only value found on replays
+                    MaxAmmo = -1,
+                    SenderNetID = spell.CastInfo.Owner.NetId
+                };
+
+                if (spell.CurrentAmmo < spell.SpellData.MaxAmmo)
+                {
+                    packet.AmmoRecharge = spell.CurrentAmmoCooldown;
+                    packet.AmmoRechargeTotalTime = spell.GetAmmoRechageTime();
+                }
+
+              _packetHandlerManager.SendPacket((int)ch.GetPlayerId(), packet.GetBytes(), Channel.CHL_S2C);
+            }
+        }
+
         /// <summary>
         /// Sends a packet to all players with vision of the given chain missile that it has updated (unit/position).
         /// </summary>


### PR DESCRIPTION
* Packets
    - Introduced `S2C_AmmoUpdate`.

* SpellData
    - Changed `MaxAmmo` from an `int[]` to `int` (Why was this an array exactly?)
    - Changed how `AmmoRechargeTime` is loaded

* SpellScriptMetaData
    - Introduced `CooldownIsAffectedByCDR` to be used as an exception to `Spell.GetCooldown()`.
    - Reorganized all the variables in alphabetical order.

* Spells
    - Networked `SpellAmmo` Adition, Removal and Recharging.

* Scripts
    - Introduced Corki's R as an example of the implementation of `SpellAmmo`.