### PR TITLE
Resolve #1423 -- Fix NotifyUnitApplyDamage.

### DIFF
--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3879,7 +3879,21 @@ namespace PacketDefinitions420
                 Damage = amount
             };
 
-            _packetHandlerManager.BroadcastPacket(damagePacket.GetBytes(), Channel.CHL_S2C);
+            if (isGlobal)
+            {
+                _packetHandlerManager.BroadcastPacket(damagePacket.GetBytes(), Channel.CHL_S2C);
+            }
+            else
+            {
+                if (sourceId > 0)
+                {
+                    _packetHandlerManager.SendPacket(sourceId, damagePacket.GetBytes(), Channel.CHL_S2C);
+                }
+                if (targetId > 0)
+                {
+                    _packetHandlerManager.SendPacket(targetId, damagePacket.GetBytes(), Channel.CHL_S2C);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The packet is now only sent to the players that did or received damage.
Fixes all minions combat damages being shown for everyone
implement IsDamageTextGlobal setting