### PR TITLE
Resolve #1426 -- Fix getting xp from the wrong team

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -700,13 +700,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             {
                 if (!(obj is IMonster))
                 {
-                    var enemyTeam = TeamId.TEAM_BLUE;
-                    if (Team == TeamId.TEAM_BLUE)
-                    {
-                        enemyTeam = TeamId.TEAM_PURPLE;
-                    }
-
-                    var champs = _game.ObjectManager.GetChampionsInRangeFromTeam(Position, _game.Map.MapScript.MapScriptMetadata.AIVars.EXPRadius, enemyTeam, true);
+                    var champs = _game.ObjectManager.GetChampionsInRangeFromTeam(Position, _game.Map.MapScript.MapScriptMetadata.AIVars.EXPRadius, CustomConvert.GetEnemyTeam(Team), true);
                     if (champs.Count > 0)
                     {
                         var expPerChamp = obj.Stats.ExpGivenOnDeath.Total / champs.Count;

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -700,7 +700,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             {
                 if (!(obj is IMonster))
                 {
-                    var champs = _game.ObjectManager.GetChampionsInRangeFromTeam(Position, _game.Map.MapScript.MapScriptMetadata.AIVars.EXPRadius, Team, true);
+                    var enemyTeam = TeamId.TEAM_BLUE;
+                    if (Team == TeamId.TEAM_BLUE)
+                    {
+                        enemyTeam = TeamId.TEAM_PURPLE;
+                    }
+
+                    var champs = _game.ObjectManager.GetChampionsInRangeFromTeam(Position, _game.Map.MapScript.MapScriptMetadata.AIVars.EXPRadius, enemyTeam, true);
                     if (champs.Count > 0)
                     {
                         var expPerChamp = obj.Stats.ExpGivenOnDeath.Total / champs.Count;


### PR DESCRIPTION
Fix getting xp from allied minions/champions instead of enemies