### PR TITLE
SetSpell QuickFix

### DIFF
--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -838,7 +838,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             {
                 // Use any existing spells before making a new one.
                 bool exists = false;
-                foreach(var spell in Spells.Values)
+                foreach (var spell in Spells.Values)
                 {
                     if (spell.SpellName == name)
                     {
@@ -858,10 +858,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     }
 
                     toReturn.SetLevel(Spells[slot].CastInfo.SpellLevel);
-
-                    Spells[slot] = toReturn;
-                    Stats.SetSpellEnabled(slot, enabled);
                 }
+
+                Spells[slot] = toReturn;
+                Stats.SetSpellEnabled(slot, enabled);
             }
 
             if (this is IChampion champion)


### PR DESCRIPTION
* Fixed an issue where if the desired spell already existed in the spell inventory, it wouldn't actually get swapped.