### PR TITLE
Multi-unit OnReplication and WaypointGroup creation support

### DIFF
--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -15,10 +15,6 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         bool IsDead { get; }
         /// <summary>
-        /// Whether or not this Unit's model has been changeds this tick. Resets to False when the next tick update happens in ObjectManager.
-        /// </summary>
-        bool IsModelUpdated { get; set; }
-        /// <summary>
         /// Number of minions this Unit has killed. Unused besides in replication which is used for packets, refer to NotifyOnReplication in PacketNotifier.
         /// </summary>
         /// TODO: Verify if we want to move this to ObjAIBase since AttackableUnits cannot attack or kill anything.

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -464,7 +464,7 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// <param name="u">Unit who's stats have been updated.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
-        /// <param name="partial">Whether or not the packet should be counted as a partial update (whether the stats have actually changed or not). *NOTE*: Use case for this parameter is unknown.</param>
+        /// <param name="partial">Whether or not the packet should only include stats marked as changed.</param>
         /// TODO: Replace with LeaguePackets and preferably move all uses of this function to a central EventHandler class (if one is fully implemented).
         void NotifyOnReplication(IAttackableUnit u, int userId = 0, bool partial = true);
         /// <summary>
@@ -933,9 +933,27 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="becameVisible">Whether or not the change was an entry into vision.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to the team.</param>
         void NotifyVisibilityChange(IGameObject obj, TeamId team, bool becameVisible, int userId = 0);
+        /// <summary>
+        /// Creates a package and puts it in the queue that will be emptied with the NotifyWaypointGroup call.
+        /// </summary>
+        /// <param name="u">AttackableUnit that is moving.</param>
+        /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
+        /// <param name="useTeleportID">Whether or not to teleport the unit to its current position in its path.</param>
         void HoldMovementDataUntilWaypointGroupNotification(IAttackableUnit u, int userId, bool useTeleportID = false);
+        /// <summary>
+        /// Sends all packets queued by HoldMovementDataUntilWaypointGroupNotification and clears queue.
+        /// </summary>
         void NotifyWaypointGroup();
+        /// <summary>
+        /// Creates a package and puts it in the queue that will be emptied with the NotifyOnReplication call.
+        /// </summary>
+        /// <param name="u">Unit who's stats have been updated.</param>
+        /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
+        /// <param name="partial">Whether or not the packet should only include stats marked as changed.</param>
         void HoldReplicationDataUntilOnReplicationNotification(IAttackableUnit u, int userId, bool partial = true);
+        /// <summary>
+        /// Sends all packets queued by HoldReplicationDataUntilOnReplicationNotification and clears queue.
+        /// </summary>
         void NotifyOnReplication();
         /// <summary>
         /// Sends a packet to all players that have vision of the specified unit that it has made a movement.

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -933,6 +933,10 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="becameVisible">Whether or not the change was an entry into vision.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to the team.</param>
         void NotifyVisibilityChange(IGameObject obj, TeamId team, bool becameVisible, int userId = 0);
+        void HoldMovementDataUntilWaypointGroupNotification(IAttackableUnit u, int userId, bool useTeleportID = false);
+        void NotifyWaypointGroup();
+        void HoldReplicationDataUntilOnReplicationNotification(IAttackableUnit u, int userId, bool partial = true);
+        void NotifyOnReplication();
         /// <summary>
         /// Sends a packet to all players that have vision of the specified unit that it has made a movement.
         /// </summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -36,10 +36,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// </summary>
         public bool IsDead { get; protected set; }
         /// <summary>
-        /// Whether or not this Unit's model has been changeds this tick. Resets to False when the next tick update happens in ObjectManager.
-        /// </summary>
-        public bool IsModelUpdated { get; set; }
-        /// <summary>
         /// Number of minions this Unit has killed. Unused besides in replication which is used for packets, refer to NotifyOnReplication in PacketNotifier.
         /// </summary>
         /// TODO: Verify if we want to move this to ObjAIBase since AttackableUnits cannot attack or kill anything.
@@ -739,7 +735,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 return false;
             }
             Model = model;
-            IsModelUpdated = true;
+            _game.PacketNotifier.NotifyS2C_ChangeCharacterData(this);
             return true;
         }
 

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -128,10 +128,12 @@ namespace LeagueSandbox.GameServer
                 if (obj is IAttackableUnit u)
                 {
                     u.Replication.MarkAsUnchanged();
-                    u.IsModelUpdated = false;
                     u.ClearMovementUpdated();
                 }
             }
+
+            _game.PacketNotifier.NotifyOnReplication();
+            _game.PacketNotifier.NotifyWaypointGroup();
 
             _currentlyInUpdate = false;
         }
@@ -222,20 +224,12 @@ namespace LeagueSandbox.GameServer
             {
                 if(u.Replication.Changed)
                 {
-                    _game.PacketNotifier.NotifyOnReplication(u, userId, true);
-                }
-
-                if (u.IsModelUpdated)
-                {
-                    _game.PacketNotifier.NotifyS2C_ChangeCharacterData(u, userId);
+                    _game.PacketNotifier.HoldReplicationDataUntilOnReplicationNotification(u, userId, true);
                 }
 
                 if (u.IsMovementUpdated())
                 {
-                    // TODO: Verify which one we want to use. WaypointList does not require conversions, however WaypointGroup does (and it has TeleportID functionality).
-                    //_game.PacketNotifier.NotifyWaypointList(u);
-                    // TODO: Verify if we want to use TeleportID.
-                    _game.PacketNotifier.NotifyWaypointGroup(u, userId, false);
+                    _game.PacketNotifier.HoldMovementDataUntilWaypointGroupNotification(u, userId, false);
                 }
             }
         }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3783,7 +3783,8 @@ namespace PacketDefinitions420
 
             var wpGroup = new WaypointGroup()
             {
-                SyncID = unit.SyncId,
+                SenderNetID = 0,
+                SyncID = Environment.TickCount,
                 Movements = new List<MovementDataNormal> { md }
             };
 
@@ -4130,8 +4131,8 @@ namespace PacketDefinitions420
             // TODO: Implement support for multiple movements.
             var packet = new WaypointGroup
             {
-                SenderNetID = u.NetId,
-                SyncID = u.SyncId,
+                SenderNetID = 0,
+                SyncID = Environment.TickCount,
                 Movements = new List<MovementDataNormal>() { move }
             };
 

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -1813,7 +1813,6 @@ namespace PacketDefinitions420
         {
             var addGroupPacket = new NPC_BuffAddGroup
             {
-                SenderNetID = 0,
                 BuffType = (byte)buffType,
                 BuffNameHash = HashFunctions.HashString(buffName),
                 PackageHash = target.GetObjHash(), // TODO: Verify
@@ -1870,7 +1869,6 @@ namespace PacketDefinitions420
         {
             var removeGroupPacket = new NPC_BuffRemoveGroup
             {
-                SenderNetID = 0,
                 BuffNameHash = HashFunctions.HashString(buffName),
             };
             var entries = new List<BuffRemoveGroupEntry>();
@@ -1923,7 +1921,6 @@ namespace PacketDefinitions420
         {
             var replaceGroupPacket = new NPC_BuffReplaceGroup
             {
-                SenderNetID = 0,
                 RunningTime = runningtime,
                 Duration = duration
             };
@@ -1984,7 +1981,6 @@ namespace PacketDefinitions420
         {
             var updateGroupPacket = new NPC_BuffUpdateCountGroup
             {
-                SenderNetID = 0,
                 Duration = duration,
                 RunningTime = runningTime
             };
@@ -2319,8 +2315,7 @@ namespace PacketDefinitions420
         {
             var pg = new PausePacket
             {
-                //Check if sender ID should be the person that requested the pause or just 0
-                SenderNetID = 0,
+                //Check if SenderNetID should be the person that requested the pause or just 0
                 ClientID = (int)player.ClientId,
                 IsTournament = isTournament,
                 PauseTimeRemaining = seconds
@@ -2475,14 +2470,11 @@ namespace PacketDefinitions420
         {
             var resume = new ResumePacket
             {
+                SenderNetID = 0,
                 Delayed = isDelayed,
                 ClientID = (int)player.ClientId
             };
-            if (unpauser == null)
-            {
-                resume.SenderNetID = 0;
-            }
-            else
+            if (unpauser != null)
             {
                 resume.SenderNetID = unpauser.NetId;
             }
@@ -2494,7 +2486,6 @@ namespace PacketDefinitions420
         {
             var packet = new S2C_ActivateMinionCamp
             {
-                SenderNetID = 0,
                 Position = monsterCamp.Position,
                 CampIndex = monsterCamp.CampIndex,
                 SpawnDuration = monsterCamp.SpawnDuration,
@@ -2637,7 +2628,6 @@ namespace PacketDefinitions420
             var packet = new S2C_CreateMinionCamp
             {
                 Position = monsterCamp.Position,
-                SenderNetID = 0,
                 CampIndex = monsterCamp.CampIndex,
                 MinimapIcon = monsterCamp.MinimapIcon,
                 RevealAudioVOComponentEvent = monsterCamp.RevealEvent,
@@ -2678,7 +2668,7 @@ namespace PacketDefinitions420
         /// <param name="player"></param>
         public void NotifyS2C_DisableHUDForEndOfGame(Tuple<uint, ClientInfo> player)
         {
-            var disableHud = new S2C_DisableHUDForEndOfGame { SenderNetID = 0 };
+            var disableHud = new S2C_DisableHUDForEndOfGame();
             _packetHandlerManager.SendPacket((int)player.Item2.PlayerId, disableHud.GetBytes(), Channel.CHL_S2C);
         }
 
@@ -2847,7 +2837,6 @@ namespace PacketDefinitions420
         {
             var packet = new S2C_Neutral_Camp_Empty
             {
-                SenderNetID = 0,
                 KillerNetID = 0,
                 //Investigate what this does, from what i see on packets, my guess is a check if the enemy team had vision of the camp dying
                 DoPlayVO = true,
@@ -2935,7 +2924,6 @@ namespace PacketDefinitions420
             }
             var packet = new S2C_OnEventWorld
             {
-                SenderNetID = 0,
                 EventWorld = new EventWorld
                 {
                     Event = mapEvent,
@@ -3074,7 +3062,6 @@ namespace PacketDefinitions420
         {
             var response = new S2C_QueryStatusAns
             {
-                SenderNetID = 0,
                 Response = true
             };
             _packetHandlerManager.SendPacket(userId, response.GetBytes(), Channel.CHL_S2C);
@@ -3370,8 +3357,7 @@ namespace PacketDefinitions420
             var dm = new S2C_SystemMessage
             {
                 SourceNetID = 0,
-                //TODO: Ivestigate the cases where sender NetID is used
-                SenderNetID = 0,
+                //TODO: Ivestigate the cases where SenderNetID is used
                 Message = htmlDebugMessage
             };
             _packetHandlerManager.BroadcastPacket(dm.GetBytes(), Channel.CHL_S2C);
@@ -3387,8 +3373,7 @@ namespace PacketDefinitions420
             var dm = new S2C_SystemMessage
             {
                 SourceNetID = 0,
-                //TODO: Ivestigate the cases where sender NetID is used
-                SenderNetID = 0,
+                //TODO: Ivestigate the cases where SenderNetID is used
                 Message = message
             };
             _packetHandlerManager.SendPacket(userId, dm.GetBytes(), Channel.CHL_S2C);
@@ -3404,8 +3389,7 @@ namespace PacketDefinitions420
             var dm = new S2C_SystemMessage
             {
                 SourceNetID = 0,
-                //TODO: Ivestigate the cases where sender NetID is used
-                SenderNetID = 0,
+                //TODO: Ivestigate the cases where SenderNetID is used
                 Message = message
             };
             _packetHandlerManager.BroadcastPacketTeam(team, dm.GetBytes(), Channel.CHL_S2C);
@@ -3415,7 +3399,6 @@ namespace PacketDefinitions420
         {
             var packet = new S2C_UnitSetMinimapIcon
             {
-                SenderNetID = 0,
                 UnitNetID = unit.NetId,
                 IconCategory = iconCategory,
                 ChangeIcon = changeIcon,
@@ -3785,7 +3768,6 @@ namespace PacketDefinitions420
 
             var wpGroup = new WaypointGroup()
             {
-                SenderNetID = 0,
                 SyncID = Environment.TickCount,
                 Movements = new List<MovementDataNormal> { md }
             };
@@ -3923,7 +3905,6 @@ namespace PacketDefinitions420
         {
             var packet = new UpdateLevelPropS2C
             {
-                SenderNetID = 0,
                 UpdateLevelPropData = propData
             };
             _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
@@ -4080,7 +4061,6 @@ namespace PacketDefinitions420
                 {
                     var packet = new WaypointGroup
                     {
-                        SenderNetID = 0,
                         SyncID = Environment.TickCount,
                         Movements = list
                     };
@@ -4149,7 +4129,6 @@ namespace PacketDefinitions420
             // TODO: Implement support for multiple movements.
             var packet = new WaypointGroup
             {
-                SenderNetID = 0,
                 SyncID = Environment.TickCount,
                 Movements = new List<MovementDataNormal>() { move }
             };
@@ -4195,7 +4174,6 @@ namespace PacketDefinitions420
 
             var speedWpGroup = new WaypointGroupWithSpeed
             {
-                SenderNetID = 0,
                 SyncID = u.SyncId,
                 // TOOD: Implement support for multiple speed-based movements (functionally known as dashes).
                 Movements = new List<MovementDataWithSpeed> { md }


### PR DESCRIPTION
According to the records, the original league never (or almost never) sends updates one by one, but instead collects them and sends them all at once.
- Added functions to `PacketNotifier`:
`HoldMovementDataUntilWaypointGroupNotification` and `NotifyWaypointGroup`
`HoldReplicationDataUntilOnReplicationNotification` and `NotifyOnReplication`.
- The `ChangeModel` function now immediately sends `S2C_ChangeCharacterData` without waiting for the end of the frame
(who would think of changing it several times per frame?)
- `WaypointGroup` now only uses zero `SenderNetID`. This matches the records and otherwise there are bugs.