### PR TITLE
Progress #1280 -- Kinda. Small package rework. Part I

### DIFF
--- a/GameServerCore/Domain/GameObjects/Spell/ISpellData.cs
+++ b/GameServerCore/Domain/GameObjects/Spell/ISpellData.cs
@@ -144,6 +144,5 @@ namespace GameServerCore.Domain.GameObjects.Spell
             float attackMaximumDelay = 5.0f
         );
         void SetTargetingType(TargetingType newType);
-        void Load(string name);
     }
 }

--- a/GameServerCore/Domain/ICharData.cs
+++ b/GameServerCore/Domain/ICharData.cs
@@ -57,6 +57,5 @@ namespace GameServerCore.Domain
         int[] MaxLevels { get; }
         string[] ExtraSpells { get; }
         // TODO: Verify if we want this to be an array.
-        void Load(string name);
     }
 }

--- a/GameServerLib/Chatbox/Commands/SpawnCommand.cs
+++ b/GameServerLib/Chatbox/Commands/SpawnCommand.cs
@@ -65,7 +65,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
                     try
                     {
-                        Game.Config.ContentManager.GetContentFileFromJson("Stats", championModel);
+                        Game.Config.ContentManager.GetCharData(championModel);
                     }
                     catch (ContentNotFoundException)
                     {

--- a/GameServerLib/Content/CharData.cs
+++ b/GameServerLib/Content/CharData.cs
@@ -1,12 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text.RegularExpressions;
 using GameServerCore.Domain;
 using GameServerCore.Enums;
-using LeagueSandbox.GameServer.Logging;
-using log4net;
-using Newtonsoft.Json;
 
 namespace LeagueSandbox.GameServer.Content
 {
@@ -22,13 +16,6 @@ namespace LeagueSandbox.GameServer.Content
 
     public class CharData : ICharData
     {
-        private readonly ILog _logger;
-
-        public CharData(ILog logger)
-        {
-            _logger = logger;
-        }
-
         public IGlobalData GlobalCharData { get; private set; } = new GlobalData();
 
         public float AcquisitionRange { get; private set; } = 475;
@@ -98,11 +85,7 @@ namespace LeagueSandbox.GameServer.Content
 
         public CharData Load(ContentFile file)
         {
-            string name;
-            if (file == null || string.IsNullOrEmpty(name = file.Name))
-            {
-                return this;
-            }
+            string name = file.Name;
 
             AcquisitionRange = file.GetFloat("Data", "AcquisitionRange", AcquisitionRange);
             Armor = file.GetFloat("Data", "Armor", Armor);

--- a/GameServerLib/Content/CharData.cs
+++ b/GameServerLib/Content/CharData.cs
@@ -22,13 +22,11 @@ namespace LeagueSandbox.GameServer.Content
 
     public class CharData : ICharData
     {
-        private readonly ContentManager _contentManager;
         private readonly ILog _logger;
 
-        public CharData(ContentManager contentManager)
+        public CharData(ILog logger)
         {
-            _contentManager = contentManager;
-            _logger = LoggerProvider.GetLogger();
+            _logger = logger;
         }
 
         public IGlobalData GlobalCharData { get; private set; } = new GlobalData();
@@ -98,24 +96,12 @@ namespace LeagueSandbox.GameServer.Content
         // TODO: Verify if we want this to be an array.
         public IPassiveData PassiveData { get; private set; } = new PassiveData();
 
-        public void Load(string name)
+        public CharData Load(ContentFile file)
         {
-            if (string.IsNullOrEmpty(name))
+            string name;
+            if (file == null || string.IsNullOrEmpty(name = file.Name))
             {
-                return;
-            }
-
-            var file = new ContentFile();
-            List<IPackage> packages;
-            try
-            {
-                file = (ContentFile)_contentManager.GetContentFileFromJson("Stats", name);
-                packages = new List<IPackage>(_contentManager.GetAllLoadedPackages());
-            }
-            catch (ContentNotFoundException exception)
-            {
-                _logger.Warn(exception.Message);
-                return;
+                return this;
             }
 
             AcquisitionRange = file.GetFloat("Data", "AcquisitionRange", AcquisitionRange);
@@ -291,6 +277,8 @@ namespace LeagueSandbox.GameServer.Content
                     }
                 }
             }
+
+            return this;
         }
     }
 }

--- a/GameServerLib/Content/ContentFile.cs
+++ b/GameServerLib/Content/ContentFile.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using GameServerCore.Content;
 using GameServerCore.Domain;
@@ -12,6 +13,10 @@ namespace LeagueSandbox.GameServer.Content
 
         public Dictionary<string, object> MetaData { get; set; }
             = new Dictionary<string, object>();
+
+        //TODO: move to Item/Char/Spell Data
+        public int Id => Convert.ToInt32(MetaData["Id"]);
+        public string Name => Convert.ToString(MetaData["Name"]);
 
         private uint Hash(string section, string name)
         {

--- a/GameServerLib/Content/ContentFile.cs
+++ b/GameServerLib/Content/ContentFile.cs
@@ -14,8 +14,6 @@ namespace LeagueSandbox.GameServer.Content
         public Dictionary<string, object> MetaData { get; set; }
             = new Dictionary<string, object>();
 
-        //TODO: move to Item/Char/Spell Data
-        public int Id => Convert.ToInt32(MetaData["Id"]);
         public string Name => Convert.ToString(MetaData["Name"]);
 
         private uint Hash(string section, string name)

--- a/GameServerLib/Content/ContentManager.cs
+++ b/GameServerLib/Content/ContentManager.cs
@@ -145,7 +145,6 @@ namespace LeagueSandbox.GameServer.Content
             throw new ContentNotFoundException($"No map spawns found for map with id: {mapId}");
         }
 
-        //TODO: get rid of this
         public IContentFile GetContentFileFromJson(string contentType, string itemName, string subPath = null)
         {
             foreach (var dataPackage in _loadedPackages)
@@ -190,10 +189,7 @@ namespace LeagueSandbox.GameServer.Content
                 }
             }
 
-            //throw new ContentNotFoundException($"No Spell Data found with name: {spellName}");
-            _logger.Warn($"No Spell Data found with name: {spellName}");
-            //TODO: move logger arg to Load
-            return new SpellData(_logger);
+            throw new ContentNotFoundException($"No Spell Data found with name: {spellName}");
         }
 
         public ICharData GetCharData(string characterName)
@@ -208,10 +204,7 @@ namespace LeagueSandbox.GameServer.Content
                 }
             }
             
-            //throw new ContentNotFoundException($"No Character found with name: {characterName}");
-            _logger.Warn($"No Character found with name: {characterName}");
-            //TODO: move logger arg to Load
-            return new CharData(_logger);
+            throw new ContentNotFoundException($"No Character found with name: {characterName}");
         }
 
         private void GetDependenciesRecursively(List<string> resultList, string packageName, string contentPath)

--- a/GameServerLib/Content/ContentManager.cs
+++ b/GameServerLib/Content/ContentManager.cs
@@ -101,14 +101,14 @@ namespace LeagueSandbox.GameServer.Content
 
         public bool LoadScripts()
         {
-            List<bool> packageLoadingResults = new List<bool>();
+            bool packageLoadingResults = true;
 
             foreach (var dataPackage in _loadedPackages)
             {
-                packageLoadingResults.Add(dataPackage.LoadScripts());
+                packageLoadingResults = packageLoadingResults && dataPackage.LoadScripts();
             }
 
-            return packageLoadingResults.Contains(false);
+            return packageLoadingResults;
         }
 
         public MapData GetMapData(int mapId)
@@ -145,6 +145,7 @@ namespace LeagueSandbox.GameServer.Content
             throw new ContentNotFoundException($"No map spawns found for map with id: {mapId}");
         }
 
+        //TODO: get rid of this
         public IContentFile GetContentFileFromJson(string contentType, string itemName, string subPath = null)
         {
             foreach (var dataPackage in _loadedPackages)
@@ -189,7 +190,10 @@ namespace LeagueSandbox.GameServer.Content
                 }
             }
 
-            throw new ContentNotFoundException($"No Spell Data found with name: {spellName}");
+            //throw new ContentNotFoundException($"No Spell Data found with name: {spellName}");
+            _logger.Warn($"No Spell Data found with name: {spellName}");
+            //TODO: move logger arg to Load
+            return new SpellData(_logger);
         }
 
         public ICharData GetCharData(string characterName)
@@ -204,7 +208,10 @@ namespace LeagueSandbox.GameServer.Content
                 }
             }
             
-            throw new ContentNotFoundException($"No Character found with name: {characterName}");
+            //throw new ContentNotFoundException($"No Character found with name: {characterName}");
+            _logger.Warn($"No Character found with name: {characterName}");
+            //TODO: move logger arg to Load
+            return new CharData(_logger);
         }
 
         private void GetDependenciesRecursively(List<string> resultList, string packageName, string contentPath)

--- a/GameServerLib/Content/Package.cs
+++ b/GameServerLib/Content/Package.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json.Linq;
 using LeagueSandbox.GameServer.Content.Navigation;
 using GameServerCore.Domain.GameObjects.Spell;
 using System.Numerics;
+using LeagueSandbox.GameServer.Inventory;
 
 namespace LeagueSandbox.GameServer.Content
 {
@@ -17,8 +18,9 @@ namespace LeagueSandbox.GameServer.Content
         public string PackagePath { get; private set; }
         public string PackageName { get; private set; }
 
-        private readonly Dictionary<string, ISpellData> _spellData = new Dictionary<string, ISpellData>();
-        private readonly Dictionary<string, ICharData> _charData = new Dictionary<string, ICharData>();
+        private readonly Dictionary<string, CharData> _charData = new Dictionary<string, CharData>();
+        private readonly Dictionary<string, SpellData> _spellData = new Dictionary<string, SpellData>();
+        private readonly Dictionary<string, ItemData> _itemData = new Dictionary<string, ItemData>();
 
         private readonly Game _game;
         private readonly ILog _logger;
@@ -26,12 +28,11 @@ namespace LeagueSandbox.GameServer.Content
         private readonly Dictionary<string, Dictionary<string, List<string>>> _content = new Dictionary<string, Dictionary<string, List<string>>>();
 
         private static readonly string[] ContentTypes = {
-            "Champions",
-            "Items",
+            "Items",    // v
             "Buffs",
             "Maps",
-            "Spells",
-            "Stats"
+            "Spells",   // v
+            "Stats"     // v
         };
 
         public Package(string packagePath, Game game)
@@ -48,7 +49,6 @@ namespace LeagueSandbox.GameServer.Content
 
             InitializeContent();
             LoadPackage();
-            LoadItems();
             LoadTalents();
             LoadScripts();
         }
@@ -82,20 +82,24 @@ namespace LeagueSandbox.GameServer.Content
             }
 
             var filePath = $"{GetContentTypePath(contentType)}/{fileName}";
-            var fileText = File.ReadAllText(filePath);
+            
+            return GetContentFileFromJson(filePath);
+        }
 
-            IContentFile toReturnContentFile;
-
+        private ContentFile GetContentFileFromJson(string filePath)
+        {
+            var file = new ContentFile();
             try
             {
-                toReturnContentFile = JsonConvert.DeserializeObject<ContentFile>(fileText);
+                var fileText = File.ReadAllText(filePath);
+                file = JsonConvert.DeserializeObject<ContentFile>(fileText);
             }
-            catch (JsonSerializationException)
+            catch (System.Exception e)
             {
+                _logger.Warn(e.Message);
                 return null;
             }
-
-            return toReturnContentFile;
+            return file;
         }
 
         /// <summary>
@@ -323,7 +327,6 @@ namespace LeagueSandbox.GameServer.Content
             var contentType = "Maps";
             var toReturnMapSpawns = new Dictionary<string, JArray>();
 
-
             if (!_content.ContainsKey(contentType) || !_content[contentType].ContainsKey(mapName))
             {
                 return null;
@@ -376,26 +379,12 @@ namespace LeagueSandbox.GameServer.Content
 
         public ISpellData GetSpellData(string spellName)
         {
-            if (_spellData.ContainsKey(spellName))
-            {
-                return _spellData[spellName];
-            }
-
-            _spellData[spellName] = new SpellData(_game.Config.ContentManager);
-            _spellData[spellName].Load(spellName);
-            return _spellData[spellName];
+            return _spellData.GetValueOrDefault(spellName, null);
         }
 
         public ICharData GetCharData(string characterName)
         {
-            if (_charData.ContainsKey(characterName))
-            {
-                return _charData[characterName];
-            }
-
-            _charData[characterName] = new CharData(_game.Config.ContentManager);
-            _charData[characterName].Load(characterName);
-            return _charData[characterName];
+            return _charData.GetValueOrDefault(characterName, null);
         }
 
         public bool LoadScripts()
@@ -434,19 +423,60 @@ namespace LeagueSandbox.GameServer.Content
         {
             foreach (var contentType in ContentTypes)
             {
-                LoadData(contentType);
-            }
-        }
+                
+                var contentTypePath = GetContentTypePath(contentType);
 
-        private void LoadItems()
-        {
-            try
-            {
-                _game.ItemManager.AddItems(ItemContentCollection.LoadItemsFrom($"{PackagePath}/Items"));
-            }
-            catch (DirectoryNotFoundException)
-            {
-                _logger.Debug($"Package: {PackageName} does not contain any items, skipping...");
+                if (!Directory.Exists(contentTypePath))
+                {
+                    _logger.Debug($"Package {PackageName} does not contain {contentType}, skipping...");
+                    continue;
+                }
+
+                var fileList = Directory.EnumerateFiles(contentTypePath, "*.json", SearchOption.AllDirectories);
+
+                foreach (var filePath in fileList)
+                {
+                    if(contentType == "Stats" || contentType == "Spells" || contentType == "Items")
+                    {
+                        var file = GetContentFileFromJson(filePath);
+                        if(file != null)
+                        {
+                            var name = file.Name;
+
+                            switch(contentType)
+                            {
+                                case "Stats":
+                                {
+                                    _charData[name] = (new CharData(_logger)).Load(file);
+                                    break;
+                                }
+
+                                case "Spells":
+                                {
+                                    _spellData[name] = (new SpellData(_logger)).Load(file);
+                                    break;
+                                }
+
+                                case "Items":
+                                {
+                                    var itemData = (new ItemData()).Load(file);
+                                    _game.ItemManager.AddItemType(itemData);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var fileName = Path.GetFileNameWithoutExtension(filePath);
+                        if (fileName != null)
+                        {
+                            //TODO: get rid of this
+                            System.Console.WriteLine($"_content[{contentType}][{fileName}] = {PackageName}");
+                            _content[contentType][fileName] = new List<string> { PackageName };
+                        }
+                    }
+                }
             }
         }
 
@@ -459,31 +489,6 @@ namespace LeagueSandbox.GameServer.Content
             catch (DirectoryNotFoundException)
             {
                 _logger.Debug($"Package: {PackageName} does not contain any Talents, skipping...");
-            }
-        }
-
-        private void LoadData(string contentType)
-        {
-            var contentTypePath = GetContentTypePath(contentType);
-
-            if (!Directory.Exists(contentTypePath))
-            {
-                _logger.Debug($"Package {PackageName} does not contain {contentType}, skipping...");
-                return;
-            }
-
-            var fileList = Directory.GetFiles(contentTypePath, "*.json", SearchOption.AllDirectories);
-
-            foreach (var jsonFile in fileList)
-            {
-                var fileName = Path.GetFileNameWithoutExtension(jsonFile);
-
-                if (fileName == null)
-                {
-                    continue;
-                }
-
-                _content[contentType][fileName] = new List<string> { PackageName };
             }
         }
 

--- a/GameServerLib/Content/Package.cs
+++ b/GameServerLib/Content/Package.cs
@@ -28,11 +28,11 @@ namespace LeagueSandbox.GameServer.Content
         private readonly Dictionary<string, Dictionary<string, List<string>>> _content = new Dictionary<string, Dictionary<string, List<string>>>();
 
         private static readonly string[] ContentTypes = {
-            "Items",    // v
-            "Buffs",
+            "Items",
             "Maps",
-            "Spells",   // v
-            "Stats"     // v
+            "Spells",
+            "Stats",
+            "Talents"
         };
 
         public Package(string packagePath, Game game)
@@ -447,13 +447,13 @@ namespace LeagueSandbox.GameServer.Content
                             {
                                 case "Stats":
                                 {
-                                    _charData[name] = (new CharData(_logger)).Load(file);
+                                    _charData[name] = (new CharData()).Load(file);
                                     break;
                                 }
 
                                 case "Spells":
                                 {
-                                    _spellData[name] = (new SpellData(_logger)).Load(file);
+                                    _spellData[name] = (new SpellData()).Load(file);
                                     break;
                                 }
 
@@ -471,8 +471,6 @@ namespace LeagueSandbox.GameServer.Content
                         var fileName = Path.GetFileNameWithoutExtension(filePath);
                         if (fileName != null)
                         {
-                            //TODO: get rid of this
-                            System.Console.WriteLine($"_content[{contentType}][{fileName}] = {PackageName}");
                             _content[contentType][fileName] = new List<string> { PackageName };
                         }
                     }

--- a/GameServerLib/Content/SpellData.cs
+++ b/GameServerLib/Content/SpellData.cs
@@ -20,13 +20,11 @@ namespace LeagueSandbox.GameServer.Content
 
     public class SpellData : ISpellData
     {
-        private readonly ContentManager _contentManager;
         private readonly ILog _logger;
 
-        public SpellData(ContentManager contentManager)
+        public SpellData(ILog logger)
         {
-            _contentManager = contentManager;
-            _logger = LoggerProvider.GetLogger();
+            _logger = logger;
         }
 
         public string AfterEffectName { get; set; } = "";
@@ -343,23 +341,12 @@ namespace LeagueSandbox.GameServer.Content
             TargetingType = newType;
         }
 
-        public void Load(string name)
+        public SpellData Load(ContentFile file)
         {
-            if (string.IsNullOrEmpty(name))
+            string name;
+            if (file == null || string.IsNullOrEmpty(name = file.Name))
             {
-                return;
-            }
-
-            var file = new ContentFile();
-            try
-            {
-                file = (ContentFile)_contentManager.GetContentFileFromJson("Spells", name);
-            }
-
-            catch (ContentNotFoundException exception)
-            {
-                _logger.Warn(exception.Message);
-                return;
+                return this;
             }
 
             AfterEffectName = file.GetString("SpellData", "AfterEffectName", AfterEffectName);
@@ -538,6 +525,8 @@ namespace LeagueSandbox.GameServer.Content
             UseChargeTargeting = file.GetBool("SpellData", "UseChargeTargeting", UseChargeTargeting);
             UseGlobalLineIndicator = file.GetBool("SpellData", "UseGlobalLineIndicator", UseGlobalLineIndicator);
             UseMinimapTargeting = file.GetBool("SpellData", "UseMinimapTargeting", UseMinimapTargeting);
+        
+            return this;
         }
     }
 }

--- a/GameServerLib/Content/SpellData.cs
+++ b/GameServerLib/Content/SpellData.cs
@@ -1,9 +1,8 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Enums;
-using LeagueSandbox.GameServer.Logging;
-using log4net;
 
 namespace LeagueSandbox.GameServer.Content
 {
@@ -20,13 +19,6 @@ namespace LeagueSandbox.GameServer.Content
 
     public class SpellData : ISpellData
     {
-        private readonly ILog _logger;
-
-        public SpellData(ILog logger)
-        {
-            _logger = logger;
-        }
-
         public string AfterEffectName { get; set; } = "";
         //AIEndOnly
         //AILifetime
@@ -343,11 +335,7 @@ namespace LeagueSandbox.GameServer.Content
 
         public SpellData Load(ContentFile file)
         {
-            string name;
-            if (file == null || string.IsNullOrEmpty(name = file.Name))
-            {
-                return this;
-            }
+            string name = file.Name;
 
             AfterEffectName = file.GetString("SpellData", "AfterEffectName", AfterEffectName);
             //AIEndOnly

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -15,6 +15,7 @@ using LeagueSandbox.GameServer.Scripting.CSharp;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using LeagueSandbox.GameServer.Content;
 
 namespace LeagueSandbox.GameServer.GameObjects.Spell
 {
@@ -102,7 +103,15 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 CastInfo.IsAutoAttack = true;
             }
 
-            SpellData = game.Config.ContentManager.GetSpellData(spellName);
+            try
+            {
+                SpellData = game.Config.ContentManager.GetSpellData(spellName);
+            }
+            catch (ContentNotFoundException)
+            {
+                SpellData = new SpellData();
+            }
+            
             //Checks if the spell is in the passive slot, so it doesn't try to load it twice under the "Spells" and "Passives" namespaces
             if (CastInfo.SpellSlot != (int)SpellSlotType.PassiveSpellSlot)
             {

--- a/GameServerLib/Inventory/ItemData.cs
+++ b/GameServerLib/Inventory/ItemData.cs
@@ -1,3 +1,4 @@
+using System;
 using GameServerCore.Domain;
 using LeagueSandbox.GameServer.Content;
 using LeagueSandbox.GameServer.GameObjects.Stats;
@@ -49,8 +50,9 @@ namespace LeagueSandbox.GameServer.Inventory
 
         public ItemData Load(ContentFile file)
         {
-            ItemId = file.Id;
             Name = file.Name;
+
+            ItemId = Convert.ToInt32(file.MetaData["Id"]);
             MaxStacks = file.GetInt("Data", "MaxStack");
             Price = file.GetInt("Data", "Price");
             ItemGroup = file.GetString("Data", "ItemGroup");

--- a/GameServerLib/Inventory/ItemData.cs
+++ b/GameServerLib/Inventory/ItemData.cs
@@ -42,104 +42,52 @@ namespace LeagueSandbox.GameServer.Inventory
         public IItemRecipe Recipe { get; private set; }
         public int TotalPrice => Recipe.TotalPrice;
 
-        private ItemData()
-        {
-            
-        }
-
-        private void CreateRecipe(ItemManager manager)
+        public void CreateRecipe(ItemManager manager)
         {
             Recipe = ItemRecipe.FromItemType(this, manager);
         }
 
-        public static ItemData Load(ItemManager owner, ItemContentCollectionEntry itemInfo)
+        public ItemData Load(ContentFile file)
         {
-            // Because IntelliSense is nice to have
-            var result = new ItemData()
-            {
-                ItemId = itemInfo.ItemId,
-                Name = itemInfo.Name,
-                MaxStacks = itemInfo.GetInt("Data", "MaxStack"),
-                Price = itemInfo.GetInt("Data", "Price"),
-                ItemGroup = itemInfo.GetString("Data", "ItemGroup"),
-                Consumed = itemInfo.GetBool("Data", "Consumed"),
-                SpellName = itemInfo.GetString("Data", "SpellName"),
-                SellBackModifier = itemInfo.GetFloat("Data", "SellBackModifier", 0.7f),
+            ItemId = file.Id;
+            Name = file.Name;
+            MaxStacks = file.GetInt("Data", "MaxStack");
+            Price = file.GetInt("Data", "Price");
+            ItemGroup = file.GetString("Data", "ItemGroup");
+            Consumed = file.GetBool("Data", "Consumed");
+            SpellName = file.GetString("Data", "SpellName");
+            SellBackModifier = file.GetFloat("Data", "SellBackModifier", 0.7f);
 
-                RecipeItem1 = itemInfo.GetInt("Data", "RecipeItem1", -1),
-                RecipeItem2 = itemInfo.GetInt("Data", "RecipeItem2", -1),
-                RecipeItem3 = itemInfo.GetInt("Data", "RecipeItem3", -1),
-                RecipeItem4 = itemInfo.GetInt("Data", "RecipeItem4", -1),
-                Armor =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "FlatArmorMod"),
-                    PercentBonus = itemInfo.GetFloat("Data", "PercentArmorMod")
-                },
-                CriticalChance =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "FlatCritChanceMod")
-                },
-                HealthPoints =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "FlatHPPoolMod"),
-                    PercentBonus = itemInfo.GetFloat("Data", "PercentHPPoolMod")
-                },
-                ManaPoints =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "FlatMPPoolMod"),
-                    PercentBonus = itemInfo.GetFloat("Data", "PercentMPPoolMod")
-                },
-                AbilityPower =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "FlatMagicDamageMod"),
-                    PercentBonus = itemInfo.GetFloat("Data", "PercentMagicDamageMod")
-                },
-                MagicPenetration =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "FlatMagicPenetrationMod")
-                },
-                MoveSpeed =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "FlatMovementSpeedMod"),
-                    PercentBonus = itemInfo.GetFloat("Data", "PercentMovementSpeedMod")
-                },
-                AttackDamage =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "FlatPhysicalDamageMod"),
-                    PercentBonus = itemInfo.GetFloat("Data", "PercentPhysicalDamageMod")
-                },
-                MagicResist =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "FlatSpellBlockMod"),
-                    PercentBonus = itemInfo.GetFloat("Data", "PercentSpellBlockMod")
-                },
-                AttackSpeed =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "PercentAttackSpeedMod")
-                },
-                HealthRegeneration =
-                {
-                    PercentBonus = itemInfo.GetFloat("Data", "PercentBaseHPRegenMod")
-                },
-                ManaRegeneration =
-                {
-                    PercentBonus = itemInfo.GetFloat("Data", "PercentBaseMPRegenMod")
-                },
-                CriticalDamage =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "FlatCritDamageMod"),
-                    PercentBonus = itemInfo.GetFloat("Data", "PercentCritDamageMod")
-                },
-                LifeSteal =
-                {
-                    FlatBonus = itemInfo.GetFloat("Data", "PercentLifeStealMod")
-                }
-            };
+            RecipeItem1 = file.GetInt("Data", "RecipeItem1", -1);
+            RecipeItem2 = file.GetInt("Data", "RecipeItem2", -1);
+            RecipeItem3 = file.GetInt("Data", "RecipeItem3", -1);
+            RecipeItem4 = file.GetInt("Data", "RecipeItem4", -1);
+            Armor.FlatBonus = file.GetFloat("Data", "FlatArmorMod");
+            Armor.PercentBonus = file.GetFloat("Data", "PercentArmorMod");
+            CriticalChance.FlatBonus = file.GetFloat("Data", "FlatCritChanceMod");
+            HealthPoints.FlatBonus = file.GetFloat("Data", "FlatHPPoolMod");
+            HealthPoints.PercentBonus = file.GetFloat("Data", "PercentHPPoolMod");
+            ManaPoints.FlatBonus = file.GetFloat("Data", "FlatMPPoolMod");
+            ManaPoints.PercentBonus = file.GetFloat("Data", "PercentMPPoolMod");
+            AbilityPower.FlatBonus = file.GetFloat("Data", "FlatMagicDamageMod");
+            AbilityPower.PercentBonus = file.GetFloat("Data", "PercentMagicDamageMod");
+            MagicPenetration.FlatBonus = file.GetFloat("Data", "FlatMagicPenetrationMod");
+            MoveSpeed.FlatBonus = file.GetFloat("Data", "FlatMovementSpeedMod");
+            MoveSpeed.PercentBonus = file.GetFloat("Data", "PercentMovementSpeedMod");
+            AttackDamage.FlatBonus = file.GetFloat("Data", "FlatPhysicalDamageMod");
+            AttackDamage.PercentBonus = file.GetFloat("Data", "PercentPhysicalDamageMod");
+            MagicResist.FlatBonus = file.GetFloat("Data", "FlatSpellBlockMod");
+            MagicResist.PercentBonus = file.GetFloat("Data", "PercentSpellBlockMod");
+            AttackSpeed.FlatBonus = file.GetFloat("Data", "PercentAttackSpeedMod");
+            HealthRegeneration.PercentBonus = file.GetFloat("Data", "PercentBaseHPRegenMod");
+            ManaRegeneration.PercentBonus = file.GetFloat("Data", "PercentBaseMPRegenMod");
+            CriticalDamage.FlatBonus = file.GetFloat("Data", "FlatCritDamageMod");
+            CriticalDamage.PercentBonus = file.GetFloat("Data", "PercentCritDamageMod");
+            LifeSteal.FlatBonus = file.GetFloat("Data", "PercentLifeStealMod");
 
             //itemInfo.SafeGetFloat("Data", "PercentEXPBonus"); // TODO
 
-            result.CreateRecipe(owner);
-            return result;
+            return this;
         }
     }
 

--- a/GameServerLib/Inventory/ItemManager.cs
+++ b/GameServerLib/Inventory/ItemManager.cs
@@ -30,8 +30,18 @@ namespace LeagueSandbox.GameServer.Inventory
 
         public void AddItemType(ItemData itemType)
         {
-            itemType.CreateRecipe(this);
             _itemTypes.Add(itemType.ItemId, itemType);
+            itemType.CreateRecipe(this);
+        }
+
+        public void AddItems(ItemContentCollection contentCollection)
+        {
+            foreach (var entry in contentCollection)
+            {
+                var itemType = (new ItemData()).Load(entry.Value);
+                _itemTypes.Add(entry.Key, itemType);
+                itemType.CreateRecipe(this);
+            }
         }
     }
 }

--- a/GameServerLib/Inventory/ItemManager.cs
+++ b/GameServerLib/Inventory/ItemManager.cs
@@ -18,19 +18,9 @@ namespace LeagueSandbox.GameServer.Inventory
             return _itemTypes[itemId];
         }
 
-        public IItemData SafeGetItemType(int itemId, IItemData defaultValue)
-        {
-            if (!_itemTypes.ContainsKey(itemId))
-            {
-                return defaultValue;
-            }
-
-            return _itemTypes[itemId];
-        }
-
         public IItemData SafeGetItemType(int itemId)
         {
-            return SafeGetItemType(itemId, null);
+            return _itemTypes.GetValueOrDefault(itemId, null);
         }
 
         public void ResetItems()
@@ -38,13 +28,10 @@ namespace LeagueSandbox.GameServer.Inventory
             _itemTypes.Clear();
         }
 
-        public void AddItems(ItemContentCollection contentCollection)
+        public void AddItemType(ItemData itemType)
         {
-            foreach (var entry in contentCollection)
-            {
-                var itemType = ItemData.Load(this, entry.Value);
-                _itemTypes.Add(entry.Key, itemType);
-            }
+            itemType.CreateRecipe(this);
+            _itemTypes.Add(itemType.ItemId, itemType);
         }
     }
 }


### PR DESCRIPTION
- Unified way to load and store `Item`/`Spell`/`CharData`. Now all their files are read and parsed during server startup. Files are read as soon as they are found by the `LoadPackage` function, eliminating the need for `_content`.
- Fixed a bug where a package would create an empty `SpellData` object instead of returning `null`, which would prevent other packages from looking up and raising an `Exception` by the `ContentManager`.
- Fixed a bug that could cause all packages to read the file of the first package if several packages have a file with the same name (but the first one is returned anyway by the `ContentManager`).
- Fixed strange behavior of the `LoadScripts` function (now returns `true` if everything loaded).