### PR TITLE
Progress #1407 -- `HandleSpawn` and `Champion` refactor

### DIFF
--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -544,7 +544,8 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// <param name="clientInfo">Information about the client which had their hero created.</param>
         /// <param name="userId">User to send the packet to. Set to -1 to broadcast.</param>
-        void NotifyS2C_CreateHero(ClientInfo clientInfo, int userId = -1);
+        /// <param name="doVision">Whether or not to package the packets into a vision packet.</param>
+        void NotifyS2C_CreateHero(ClientInfo clientInfo, int userId = -1, bool doVision = false);
         void NotifyS2C_CreateMinionCamp(IMonsterCamp monsterCamp);
         void NotifyS2C_CreateNeutral(IMonster monster, float time);
         /// <summary>
@@ -808,7 +809,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="userId">UserId to send the packet to.</param>
         /// <param name="gameTime">Time elapsed since the start of the game</param>
         /// <param name="doVision">Whether or not to package the packets into a vision packet.</param>
-        void NotifySpawn(IGameObject obj, TeamId team, int userId, float gameTime, bool doVision = true);
+        void NotifySpawn(IGameObject obj, TeamId team, int userId, float gameTime, bool doVision = false);
         /// <summary>
         /// Sends a packet to the specified player detailing that the spawning (of champions & buildings) that occurs at the start of the game has ended.
         /// </summary>

--- a/GameServerLib/Chatbox/Commands/SpawnCommand.cs
+++ b/GameServerLib/Chatbox/Commands/SpawnCommand.cs
@@ -173,18 +173,8 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             c.UpdateMoveOrder(OrderType.Stop);
             c.LevelUp();
 
-            Game.PacketNotifier.NotifyS2C_CreateHero(clientInfoTemp);
-            Game.PacketNotifier.NotifyAvatarInfo(clientInfoTemp);
             Game.ObjectManager.AddObject(c);
-            Game.PacketNotifier.NotifyEnterLocalVisibilityClient(c, ignoreVision: true);
-            Game.PacketNotifier.NotifyOnReplication(c, partial: false);
-
-            c.Stats.SetSpellEnabled(13, true);
-            c.Stats.SetSummonerSpellEnabled(0, true);
-            c.Stats.SetSummonerSpellEnabled(1, true);
-
-            Game.PacketNotifier.NotifyEnterVisibilityClient(c, 0, true, true);
-
+            
             ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "Spawned Bot" + clientInfoTemp.Name + " as " + c.Model + " with NetID: " + c.NetId + ".");
         }
 

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -291,7 +291,7 @@ namespace LeagueSandbox.GameServer.GameObjects
                     OnSync(userId, team);
                 }
             }
-            else if (visible || !SpawnShouldBeHidden)
+            else if (forceSpawn || visible || !SpawnShouldBeHidden)
             {
                 OnSpawn(userId, team, visible);
                 SetVisibleForPlayer(userId, visible);

--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -28,86 +28,10 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
         private bool _firstSpawn = true;
         public override bool HandlePacket(int userId, SpawnRequest req)
         {
-            var players = _playerManager.GetPlayers(true);
-
-            if (_firstSpawn)
-            {
-                _firstSpawn = false;
-
-                var bluePill = _itemManager.GetItemType(_game.Map.MapScript.MapScriptMetadata.RecallSpellItemId);
-
-                foreach (var kv in players)
-                {
-                    var peerInfo = kv.Item2;
-
-                    var itemInstance = peerInfo.Champion.Inventory.SetExtraItem(7, bluePill);
-
-                    // Runes
-                    byte runeItemSlot = 14;
-                    foreach (var rune in peerInfo.Champion.RuneList.Runes)
-                    {
-                        var runeItem = _itemManager.GetItemType(rune.Value);
-                        var newRune = peerInfo.Champion.Inventory.SetExtraItem(runeItemSlot, runeItem);
-                        peerInfo.Champion.Stats.AddModifier(runeItem);
-                        runeItemSlot++;
-                    }
-
-                    peerInfo.Champion.Stats.SetSummonerSpellEnabled(0, true);
-                    peerInfo.Champion.Stats.SetSummonerSpellEnabled(1, true);
-
-                    _game.ObjectManager.AddObject(peerInfo.Champion);
-                }
-            }
-
             _logger.Debug("Spawning map");
             _game.PacketNotifier.NotifyS2C_StartSpawn(userId);
 
             var userInfo = _playerManager.GetPeerInfo(userId);
-
-            foreach (var kv in players)
-            {
-                var peerInfo = kv.Item2;
-                var champ = peerInfo.Champion;
-
-                _game.PacketNotifier.NotifyS2C_CreateHero(peerInfo, userId);
-                _game.PacketNotifier.NotifyAvatarInfo(peerInfo, userId);
-
-                // Buy blue pill
-                var itemInstance = peerInfo.Champion.Inventory.GetItem(7);
-                _game.PacketNotifier.NotifyBuyItem(userId, peerInfo.Champion, itemInstance);
-
-                champ.SetSpawnedForPlayer(userId);
-
-                if (_game.IsRunning)
-                {
-                    bool ownChamp = peerInfo.PlayerId == userId;
-                    if (ownChamp || champ.IsVisibleForPlayer(userId))
-                    {
-                        _game.PacketNotifier.NotifyVisibilityChange(champ, userInfo.Team, true, userId);
-                    }
-                    if (ownChamp)
-                    {
-                        // Set spell levels
-                        foreach (var spell in champ.Spells)
-                        {
-                            var castInfo = spell.Value.CastInfo;
-                            if (castInfo.SpellLevel > 0)
-                            {
-                                // NotifyNPC_UpgradeSpellAns has no effect here 
-                                _game.PacketNotifier.NotifyS2C_SetSpellLevel(userId, champ.NetId, castInfo.SpellSlot, castInfo.SpellLevel);
-
-                                float currentCD = spell.Value.CurrentCooldown;
-                                float totalCD = spell.Value.GetCooldown();
-                                if (currentCD > 0)
-                                {
-                                    _game.PacketNotifier.NotifyCHAR_SetCooldown(champ, castInfo.SpellSlot, currentCD, totalCD, userId);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
             var om = _game.ObjectManager as ObjectManager;
             if (_game.IsRunning)
             {

--- a/GameServerLib/Players/PlayerManager.cs
+++ b/GameServerLib/Players/PlayerManager.cs
@@ -66,6 +66,8 @@ namespace LeagueSandbox.GameServer.Players
             c.StopMovement();
             c.UpdateMoveOrder(OrderType.Stop);
 
+            _game.ObjectManager.AddObject(c);
+
             player.Champion = c;
             var pair = new Tuple<uint, ClientInfo> ((uint)player.PlayerId, player);
             _players.Add(pair);

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -773,7 +773,7 @@ namespace PacketDefinitions420
                 };
             }
 
-            if (userId < 0)
+            if (userId <= 0)
             {
                 _packetHandlerManager.BroadcastPacket(avatar.GetBytes(), Channel.CHL_S2C);
                 return;
@@ -1026,7 +1026,7 @@ namespace PacketDefinitions420
             {
                 cdPacket.IsSummonerSpell = true; // TODO: Verify functionality
             }
-            if (userId == 0)
+            if (userId <= 0)
             {
                 _packetHandlerManager.BroadcastPacketVision(u, cdPacket.GetBytes(), Channel.CHL_S2C);
             }
@@ -1144,7 +1144,7 @@ namespace PacketDefinitions420
                 Message = floatTextData.Message
             };
 
-            if (userId == 0)
+            if (userId <= 0)
             {
                 if (team != 0)
                 {
@@ -1202,7 +1202,7 @@ namespace PacketDefinitions420
         {
             var enterLocalVis = ConstructEnterLocalVisibilityClientPacket(o);
 
-            if (userId == 0)
+            if (userId <= 0)
             {
                 if (ignoreVision)
                 {
@@ -1297,7 +1297,7 @@ namespace PacketDefinitions420
         {
             var fxPacket = ConstructFXCreateGroupPacket(particle);
 
-            if (userId == 0)
+            if (userId <= 0)
             {
                 // Broadcast only to specific team.
                 if (particle.SpecificTeam != TeamId.TEAM_NEUTRAL)
@@ -1394,7 +1394,7 @@ namespace PacketDefinitions420
                 fxVisPacket.VisibilityTeam = 1;
             }
 
-            if (userId == 0)
+            if (userId <= 0)
             {
                 _packetHandlerManager.BroadcastPacketTeam(team, fxVisPacket.GetBytes(), Channel.CHL_S2C);
             }
@@ -1414,7 +1414,7 @@ namespace PacketDefinitions420
             {
                 EnablePause = true
             };
-            if (userId == 0)
+            if (userId <= 0)
             {
                 _packetHandlerManager.BroadcastPacket(start.GetBytes(), Channel.CHL_S2C);
             }
@@ -1662,7 +1662,7 @@ namespace PacketDefinitions420
                 }
             };
 
-            if (userId == 0)
+            if (userId <= 0)
             {
                 _packetHandlerManager.BroadcastPacketVision(obj, newCharData.GetBytes(), Channel.CHL_S2C);
             }
@@ -2242,7 +2242,7 @@ namespace PacketDefinitions420
                 CritSlot = critSlot
             };
 
-            if (critSlot == 0)
+            if (critSlot <= 0)
             {
                 autoCast.CritSlot = autoCast.Slot;
             }
@@ -2267,7 +2267,7 @@ namespace PacketDefinitions420
                 CritSlot = critSlot
             };
 
-            if (critSlot == 0)
+            if (critSlot <= 0)
             {
                 autoCast.CritSlot = autoCast.Slot;
             }
@@ -2295,7 +2295,7 @@ namespace PacketDefinitions420
                     }
                 };
                 var channel = Channel.CHL_LOW_PRIORITY;
-                if (userId == 0)
+                if (userId <= 0)
                 {
                     _packetHandlerManager.BroadcastPacketVision(u, us.GetBytes(), channel, PacketFlags.UNSEQUENCED);
                 }
@@ -2584,7 +2584,7 @@ namespace PacketDefinitions420
         /// </summary>
         /// <param name="clientInfo">Information about the client which had their hero created.</param>
         /// <param name="userId">User to send the packet to. Set to -1 to broadcast.</param>
-        public void NotifyS2C_CreateHero(ClientInfo clientInfo, int userId = -1)
+        public void NotifyS2C_CreateHero(ClientInfo clientInfo, int userId = -1, bool doVision = false)
         {
             var champion = clientInfo.Champion;
             var heroPacket = new S2C_CreateHero()
@@ -2604,25 +2604,22 @@ namespace PacketDefinitions420
                 Skin = champion.Model,
                 DeathDurationRemaining = champion.RespawnTimer,
                 // TimeSinceDeath
+                TeamIsOrder = champion.Team == TeamId.TEAM_BLUE,
             };
-
-            if (champion.Team == TeamId.TEAM_BLUE)
+            if (doVision)
             {
-                heroPacket.TeamIsOrder = true;
+                NotifyEnterTeamVision(champion, 0, userId, heroPacket);
+            }
+            else if (userId <= 0)
+            {
+                _packetHandlerManager.BroadcastPacket(heroPacket.GetBytes(), Channel.CHL_S2C);
             }
             else
             {
-                heroPacket.TeamIsOrder = false;
+                _packetHandlerManager.SendPacket(userId, heroPacket.GetBytes(), Channel.CHL_S2C);
             }
-
-            if (userId < 0)
-            {
-                _packetHandlerManager.BroadcastPacket(heroPacket.GetBytes(), Channel.CHL_S2C);
-                return;
-            }
-
-            _packetHandlerManager.SendPacket(userId, heroPacket.GetBytes(), Channel.CHL_S2C);
         }
+
         public void NotifyS2C_CreateMinionCamp(IMonsterCamp monsterCamp)
         {
             var packet = new S2C_CreateMinionCamp
@@ -2900,7 +2897,7 @@ namespace PacketDefinitions420
         {
             var enterTeamVis = ConstructOnEnterTeamVisibilityPacket(o, team);
 
-            if (userId == 0)
+            if (userId <= 0)
             {
                 // TODO: Verify if we should use BroadcastPacketTeam instead.
                 _packetHandlerManager.BroadcastPacket(enterTeamVis.GetBytes(), Channel.CHL_S2C);
@@ -2952,7 +2949,7 @@ namespace PacketDefinitions420
                 leaveTeamVis.VisibilityTeam = 1;
             }
 
-            if (userId == 0)
+            if (userId <= 0)
             {
                 // TODO: Verify if we should use BroadcastPacketTeam instead.
                 _packetHandlerManager.BroadcastPacket(leaveTeamVis.GetBytes(), Channel.CHL_S2C);
@@ -3161,7 +3158,7 @@ namespace PacketDefinitions420
                 BotCountOrder = 0,
                 BotCountChaos = 0
             };
-            if (userId == 0)
+            if (userId <= 0)
             {
                 _packetHandlerManager.BroadcastPacket(start.GetBytes(), Channel.CHL_S2C);
             }
@@ -3499,7 +3496,7 @@ namespace PacketDefinitions420
         /// <param name="userId">UserId to send the packet to.</param>
         /// <param name="gameTime">Time elapsed since the start of the game</param>
         /// <param name="doVision">Whether or not to package the packets into a vision packet.</param>
-        public void NotifySpawn(IGameObject obj, TeamId team, int userId, float gameTime, bool doVision = true)
+        public void NotifySpawn(IGameObject obj, TeamId team, int userId, float gameTime, bool doVision = false)
         {
             var spawnPacket = ConstructSpawnPacket(obj, gameTime);
             if (spawnPacket != null)
@@ -3975,7 +3972,7 @@ namespace PacketDefinitions420
                     }
                 };
 
-                if (userId == 0)
+                if (userId <= 0)
                 {
                     _packetHandlerManager.BroadcastPacketTeam(team, visibilityPacket.GetBytes(), Channel.CHL_S2C);
                     _packetHandlerManager.BroadcastPacketTeam(team, healthbarPacket.GetBytes(), Channel.CHL_S2C);
@@ -4002,7 +3999,7 @@ namespace PacketDefinitions420
                         packet = ConstructOnEnterTeamVisibilityPacket(obj, team); // Generic visibility packet
                     }
                 };
-                if (userId == 0)
+                if (userId <= 0)
                 {
                     _packetHandlerManager.BroadcastPacketTeam(team, packet.GetBytes(), Channel.CHL_S2C);
                 }
@@ -4133,7 +4130,7 @@ namespace PacketDefinitions420
                 Movements = new List<MovementDataNormal>() { move }
             };
 
-            if (userId == 0)
+            if (userId <= 0)
             {
                 _packetHandlerManager.BroadcastPacketVision(u, packet.GetBytes(), Channel.CHL_LOW_PRIORITY);
             }


### PR DESCRIPTION
I refactored the `HandleSpawn` class and unified the spawning of champions with the spawning of other objects, moving most of the code into the appropriate class.

Other changes:
- The `NotifyS2C_CreateHero` function now accepts an optional parameter that allows the packet to be wrapped in a vision packet when sent, similar to the `NotifySpawn` function.
- The same setting for `NotifySpawn` is now set to false by default.
- All comparisons of `userId` with `0` are reduced to the form `<=`.