### PR TITLE
`CreateMovementData` split

### DIFF
--- a/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSpawn.cs
@@ -25,7 +25,6 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             _networkIdManager = game.NetworkIdManager;
         }
 
-        private bool _firstSpawn = true;
         public override bool HandlePacket(int userId, SpawnRequest req)
         {
             _logger.Debug("Spawning map");


### PR DESCRIPTION
Did a couple of TODOs found in the code:
```cs
// TODO: Verify if casts correctly
var move = (MovementDataNormal)PacketExtensions.CreateMovementData(u, _navGrid, MovementDataType.Normal, useTeleportID: useTeleportID);
...
// TODO: Verify if cast works.
var md = (MovementDataWithSpeed)PacketExtensions.CreateMovementData(u, _navGrid, MovementDataType.WithSpeed, speeds);
```
The function has been split into 6, the return type of 4 is known in compile time. Also, now the `SpeedParams` are created right inside the `CreateMovementDataWithSpeed` function.

By the way, these functions are not used anywhere outside of `PacketNotifier`, should I move them all there?