### PR TITLE
Fixes + Small camps rework + New teams introduction

### DIFF
--- a/Content/LeagueSandbox-Scripts/Maps/Map1/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/NeutralMinionSpawn.cs
@@ -118,14 +118,14 @@ namespace MapScripts.Map1
             });
 
             //Blue Side GreatWraith (Old gromp)
-            var blueGreatGromp = CreateJungleCamp(new Vector3(1684.0f, 60.0f, 8207.0f), 13, TeamId.TEAM_BLUE, "LesserCamp", 125.0f * 1000);
+            var blueGreatGromp = CreateJungleCamp(new Vector3(1684.0f, 60.0f, 8207.0f), 13, TeamId.TEAM_UNKNOWN, "LesserCamp", 125.0f * 1000);
             MonsterCamps.Add(blueGreatGromp, new List<IMonster>
             {
                 CreateJungleMonster("GreatWraith13.1.1", "GreatWraith", new Vector2(1684.0f, 8207.0f), new Vector3(2300.0f, 53.0f, 9720.0f), blueGreatGromp, aiScript: "BasicJungleMonsterAi")
             });
 
             //Red Side GreatWraith (Old gromp)
-            var redGreatGromp = CreateJungleCamp(new Vector3(12337.0f, 60.0f, 6263.0f), 14, TeamId.TEAM_BLUE, "LesserCamp", 125.0f * 1000);
+            var redGreatGromp = CreateJungleCamp(new Vector3(12337.0f, 60.0f, 6263.0f), 14, TeamId.TEAM_UNKNOWN, "LesserCamp", 125.0f * 1000);
             MonsterCamps.Add(redGreatGromp, new List<IMonster>
             {
                 CreateJungleMonster("GreatWraith14.1.1", "GreatWraith", new Vector2(12337.0f, 6263.0f), new Vector3(11826.0f, 52.0f, 4788.0f), redGreatGromp, aiScript: "BasicJungleMonsterAi")

--- a/Content/LeagueSandbox-Scripts/Maps/Map1/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/NeutralMinionSpawn.cs
@@ -59,7 +59,7 @@ namespace MapScripts.Map1
             });
 
             //Dragon
-            var dragon = CreateJungleCamp(new Vector3(9459.52f, 60.0f, 4193.03f), 6, 0, "Dragon", 150.0f * 1000);
+            var dragon = CreateJungleCamp(new Vector3(9459.52f, 60.0f, 4193.03f), 6, TeamId.TEAM_UNKNOWN, "Dragon", 150.0f * 1000);
             MonsterCamps.Add(dragon, new List<IMonster>
             {
                 CreateJungleMonster("Dragon6.1.1", "Dragon", new Vector2(9459.52f, 4193.03f), new Vector3(9622.0f, -69.0f, 4490.0f), dragon, aiScript: "BasicJungleMonsterAi")
@@ -111,7 +111,7 @@ namespace MapScripts.Map1
             });
 
             //Baron
-            var baron = CreateJungleCamp(new Vector3(4600.495f, 60.0f, 10250.462f), 12, 0, "Baron", 900.0f * 1000);
+            var baron = CreateJungleCamp(new Vector3(4600.495f, 60.0f, 10250.462f), 12, TeamId.TEAM_UNKNOWN, "Baron", 900.0f * 1000);
             MonsterCamps.Add(baron, new List<IMonster>
             {
                 CreateJungleMonster("Worm12.1.1", "Worm", new Vector2(4600.495f, 10250.462f), new Vector3(4329.43f, -71.0f, 9887.0f), baron, aiScript: "BasicJungleMonsterAi")

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/NeutralMinionSpawn.cs
@@ -68,7 +68,7 @@ namespace MapScripts.Map10
             });
 
             //Center of the Map Health Pack
-            var healthPack = CreateJungleCamp(new Vector3(7711.15f, 60.0f, 6722.67f), groupNumber: 7, teamSideOfTheMap: 0, campTypeIcon: "HealthPack", 115.0f * 1000);
+            var healthPack = CreateJungleCamp(new Vector3(7711.15f, 60.0f, 6722.67f), groupNumber: 7, teamSideOfTheMap: TeamId.TEAM_UNKNOWN, campTypeIcon: "HealthPack", 115.0f * 1000);
             MonsterCamps.Add(healthPack, new List<IMonster>
             {
                 CreateJungleMonster("TT_Relic7.1.1", "TT_Relic", new Vector2(7711.15f, 6722.67f), new Vector3(7711.15f, -112.716f, 6322.67f), healthPack)
@@ -76,7 +76,7 @@ namespace MapScripts.Map10
 
             //Vilemaw
             //TODO: VIle maw needs it's own Special A.I Script, for now it'll be just a dummy.
-            var spiderBoss = CreateJungleCamp(new Vector3(7711.15f, 60.0f, 10080.0f), groupNumber: 8, teamSideOfTheMap: 0, campTypeIcon: "Epic", 600.0f * 1000);
+            var spiderBoss = CreateJungleCamp(new Vector3(7711.15f, 60.0f, 10080.0f), groupNumber: 8, teamSideOfTheMap: TeamId.TEAM_UNKNOWN, campTypeIcon: "Epic", 600.0f * 1000);
             MonsterCamps.Add(spiderBoss, new List<IMonster>
             {
                 CreateJungleMonster("TT_Spiderboss8.1.1", "TT_Spiderboss", new Vector2(7711.15f, 10080.0f), new Vector3(7726.41f, -108.603f, 9234.69f), spiderBoss)

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/NeutralMinionSpawn.cs
@@ -61,7 +61,7 @@ namespace MapScripts.Map11
             });
 
             //Dragon
-            var dragon = CreateJungleCamp(new Vector3(9866.14846f, 60.0f, 4414.01403f), 6, 0, "Dragon", 143.5f * 1000, revealEvent: 43, spawnDuration: 6.5f);
+            var dragon = CreateJungleCamp(new Vector3(9866.14846f, 60.0f, 4414.01403f), 6, TeamId.TEAM_UNKNOWN, "Dragon", 143.5f * 1000, revealEvent: 43, spawnDuration: 6.5f);
             MonsterCamps.Add(dragon, new List<IMonster>
             {
                 CreateJungleMonster("Dragon6.1.1", "SRU_Dragon", new Vector2(9866.14846f, 4414.01403f), new Vector3(10517.62846f, -67.0f, 5171.98403f), dragon, spawnAnimation: "spawn", aiScript: "BasicJungleMonsterAi")
@@ -113,7 +113,7 @@ namespace MapScripts.Map11
             });
 
             //Baron
-            var baron = CreateJungleCamp(new Vector3(5007.123577f, 60.0f, 10471.445944f), 12, 0, "Baron", 1191.5f * 1000, revealEvent: 42, spawnDuration: 8.5f);
+            var baron = CreateJungleCamp(new Vector3(5007.123577f, 60.0f, 10471.445944f), 12, TeamId.TEAM_UNKNOWN, "Baron", 1191.5f * 1000, revealEvent: 42, spawnDuration: 8.5f);
             MonsterCamps.Add(baron, new List<IMonster>
             {
                 CreateJungleMonster("SRU_Baron12.1.1", "SRU_Baron", new Vector2(5007.123577f, 10471.445944f), new Vector3(4736.05846f, -71.0f, 10107.98403f), baron, spawnAnimation: "spawn", aiScript: "BasicJungleMonsterAi"),
@@ -121,28 +121,28 @@ namespace MapScripts.Map11
             });
 
             //Blue Side Gromp
-            var blueGreatGromp = CreateJungleCamp(new Vector3(2090.62846f, 60.0f, 8427.98403f), 13, 0, "LesserCamp", 111.8f * 1000, spawnDuration: 3.2f);
+            var blueGreatGromp = CreateJungleCamp(new Vector3(2090.62846f, 60.0f, 8427.98403f), 13, TeamId.TEAM_UNKNOWN, "LesserCamp", 111.8f * 1000, spawnDuration: 3.2f);
             MonsterCamps.Add(blueGreatGromp, new List<IMonster>
             {
                 CreateJungleMonster("SRU_Gromp13.1.1", "SRU_Gromp", new Vector2(2090.62846f, 8427.98403f), new Vector3(2338.01846f, 51.7773f, 8448.13403f), blueGreatGromp, spawnAnimation: "spawn", aiScript: "BasicJungleMonsterAi")
             });
 
             //Red Side Gromp
-            var redGreatGromp = CreateJungleCamp(new Vector3(12703.62846f, 60.0f, 6443.98403f), 14, 0, "LesserCamp", 111.8f * 1000, spawnDuration: 3.2f);
+            var redGreatGromp = CreateJungleCamp(new Vector3(12703.62846f, 60.0f, 6443.98403f), 14, TeamId.TEAM_UNKNOWN, "LesserCamp", 111.8f * 1000, spawnDuration: 3.2f);
             MonsterCamps.Add(redGreatGromp, new List<IMonster>
             {
                 CreateJungleMonster("SRU_Gromp14.1.1", "SRU_Gromp", new Vector2(12703.62846f, 6443.98403f), new Vector3(12323.82846f, 55.5656f, 6272.77403f), redGreatGromp, spawnAnimation: "spawn", aiScript: "BasicJungleMonsterAi")
             });
 
             //Dragon pit Scuttle Crab
-            var dragScuttle = CreateJungleCamp(new Vector3(10500.0f, 60.0f, 5170.0f), 15, 0, "LesserCamp", 147.8f * 1000, spawnDuration: 2.2f);
+            var dragScuttle = CreateJungleCamp(new Vector3(10500.0f, 60.0f, 5170.0f), 15, TeamId.TEAM_UNKNOWN, "LesserCamp", 147.8f * 1000, spawnDuration: 2.2f);
             MonsterCamps.Add(dragScuttle, new List<IMonster>
             {
                 CreateJungleMonster("Sru_Crab15.1.1", "Sru_Crab", new Vector2(10500.0f, 5170.0f), new Vector3(9830.0f, 0.0f, 5780.0f), dragScuttle, spawnAnimation: "crab_hide")
             });
 
             //Baron pit Scuttle Crab
-            var baronScuttle = CreateJungleCamp(new Vector3(4400.0f, 60.0f, 9600.0f), 16, 0, "LesserCamp", 147.8f * 1000, spawnDuration: 2.2f);
+            var baronScuttle = CreateJungleCamp(new Vector3(4400.0f, 60.0f, 9600.0f), 16, TeamId.TEAM_UNKNOWN, "LesserCamp", 147.8f * 1000, spawnDuration: 2.2f);
             MonsterCamps.Add(baronScuttle, new List<IMonster>
             {
                 CreateJungleMonster("Sru_Crab16.1.1", "Sru_Crab", new Vector2(4400.0f, 9600.0f), new Vector3(5240.0f, 0.0f, 8950.0f), baronScuttle, spawnAnimation: "crab_hide")

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/NeutralMinionSpawn.cs
@@ -25,7 +25,7 @@ namespace MapScripts.Map11
             });
 
             //Blue side Wolfs
-            var blueWolves = CreateJungleCamp(new Vector3(3780.6284f, 60.0f, 6443.984f), 2, TeamId.TEAM_BLUE, "LesserCamp", 114.34f * 1000, spawnDuration: 0.66f);
+            var blueWolves = CreateJungleCamp(new Vector3(3780.6284f, 60.0f, 6443.984f), 2, TeamId.TEAM_UNKNOWN, "LesserCamp", 114.34f * 1000, spawnDuration: 0.66f);
             MonsterCamps.Add(blueWolves, new List<IMonster>
             {
                 CreateJungleMonster("SRU_Murkwolf2.1.1", "SRU_Murkwolf", new Vector2(3780.6284f, 6443.984f), new Vector3(3700.62846f, 46.0f, 6385.98403f), blueWolves, spawnAnimation: "Spawn", aiScript: "BasicJungleMonsterAi"),
@@ -34,7 +34,7 @@ namespace MapScripts.Map11
             });
 
             //Blue Side Wraiths
-            var blueWraiths = CreateJungleCamp(new Vector3(6706.67846f, 60.0f, 5521.04403f), 3, TeamId.TEAM_BLUE, "LesserCamp", 114.0f * 1000, spawnDuration: 1.0f);
+            var blueWraiths = CreateJungleCamp(new Vector3(6706.67846f, 60.0f, 5521.04403f), 3, TeamId.TEAM_UNKNOWN, "LesserCamp", 114.0f * 1000, spawnDuration: 1.0f);
             MonsterCamps.Add(blueWraiths, new List<IMonster>
             {
                 CreateJungleMonster("SRU_Razorbeak3.1.1", "SRU_Razorbeak", new Vector2(6706.67846f, 5521.04403f), new Vector3(6958.62846f, 48.0f, 5460.98403f), blueWraiths, spawnAnimation: "Spawn", aiScript: "BasicJungleMonsterAi"),
@@ -53,7 +53,7 @@ namespace MapScripts.Map11
             });
             
             //Blue Side Golems
-            var blueGolems = CreateJungleCamp(new Vector3(8323.470745f, 60.0f, 2754.947409f), 5, TeamId.TEAM_BLUE, "LesserCamp", 114.14f * 1000, spawnDuration: 0.86f);
+            var blueGolems = CreateJungleCamp(new Vector3(8323.470745f, 60.0f, 2754.947409f), 5, TeamId.TEAM_UNKNOWN, "LesserCamp", 114.14f * 1000, spawnDuration: 0.86f);
             MonsterCamps.Add(blueGolems, new List<IMonster>
             {
                 CreateJungleMonster("SRU_KrugMini5.1.1", "SRU_KrugMini", new Vector2(8323.471f, 2754.9475f), new Vector3(8319.62846f, 45.0f, 2641.98403f), blueGolems, spawnAnimation: "spawn", aiScript: "BasicJungleMonsterAi"),
@@ -77,7 +77,7 @@ namespace MapScripts.Map11
             });
 
             //Red side Wolfs
-            var redWolves = CreateJungleCamp(new Vector3(11008.151898f, 60.0f, 8387.408346f), 8, TeamId.TEAM_PURPLE, "LesserCamp", 114.34f * 1000, spawnDuration: 0.66f);
+            var redWolves = CreateJungleCamp(new Vector3(11008.151898f, 60.0f, 8387.408346f), 8, TeamId.TEAM_UNKNOWN, "LesserCamp", 114.34f * 1000, spawnDuration: 0.66f);
             MonsterCamps.Add(redWolves, new List<IMonster>
             {
                 CreateJungleMonster("SRU_Murkwolf8.1.1", "SRU_Murkwolf", new Vector2(11008.151898f, 8387.408346f), new Vector3(11127.62846f, 53.0f, 8502.98403f), redWolves, spawnAnimation: "Spawn", aiScript: "BasicJungleMonsterAi"),
@@ -86,7 +86,7 @@ namespace MapScripts.Map11
             });
 
             //Red Side Wraiths
-            var redWraiths = CreateJungleCamp(new Vector3(7986.996624f, 60.0f, 9471.389059f), 9, TeamId.TEAM_PURPLE, "LesserCamp", 114.33f * 1000, spawnDuration: 0.67f);
+            var redWraiths = CreateJungleCamp(new Vector3(7986.996624f, 60.0f, 9471.389059f), 9, TeamId.TEAM_UNKNOWN, "LesserCamp", 114.33f * 1000, spawnDuration: 0.67f);
             MonsterCamps.Add(redWraiths, new List<IMonster>
             {
                 CreateJungleMonster("SRU_Razorbeak9.1.1", "SRU_Razorbeak", new Vector2(7986.996624f, 9471.389059f), new Vector3(7901.62846f, 46.0f, 9479.98403f), redWraiths, spawnAnimation: "North_Spawn", aiScript: "BasicJungleMonsterAi"),
@@ -105,7 +105,7 @@ namespace MapScripts.Map11
             });
 
             //Red Side Krugs
-            var redGolems = CreateJungleCamp(new Vector3(6317.092327f, 60.0f, 12146.457663f), 11, TeamId.TEAM_PURPLE, "LesserCamp", 114.14f * 1000, spawnDuration: 0.86f);
+            var redGolems = CreateJungleCamp(new Vector3(6317.092327f, 60.0f, 12146.457663f), 11, TeamId.TEAM_UNKNOWN, "LesserCamp", 114.14f * 1000, spawnDuration: 0.86f);
             MonsterCamps.Add(redGolems, new List<IMonster>
             {
                 CreateJungleMonster("SRU_KrugMini11.1.1", "SRU_KrugMini", new Vector2(6317.092327f, 12146.457663f), new Vector3(6365.62846f, 30.0f, 12226.98403f), redGolems, spawnAnimation: "spawn", aiScript: "BasicJungleMonsterAi"),

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/NeutralMinionSpawn.cs
@@ -24,7 +24,7 @@ namespace MapScripts.Map12
             for(byte i = 1; i <= _champPositions.Length; i++)
             {
                 Vector3 pos = _champPositions[i - 1];
-                var camp = CreateJungleCamp(pos, i, TeamId.TEAM_NEUTRAL, "HealthPack", 190.0f * 1000f);
+                var camp = CreateJungleCamp(pos, i, TeamId.TEAM_UNKNOWN, "HealthPack", 190.0f * 1000f);
                 var monster = CreateJungleMonster(
                     $"HA_AP_HealthRelic{i}.1.1", "HA_AP_HealthRelic",
                     new Vector2(pos.X, pos.Z), Vector3.Zero,

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/NeutralMinionSpawn.cs
@@ -80,44 +80,44 @@ namespace MapScripts.Map8
 
         public static void SetupCamps()
         {
-            var speedShrine1 = CreateJungleCamp(new Vector3(5022.9287f, 60.0f, 7778.2695f), 102, 0, "Shrine", 0);
+            var speedShrine1 = CreateJungleCamp(new Vector3(5022.9287f, 60.0f, 7778.2695f), 102, TeamId.TEAM_UNKNOWN, "Shrine", 0);
             SpeedShrines.Add(speedShrine1, CreateJungleMonster("OdinSpeedShrine", "OdinSpeedShrine", new Vector2(5022.9287f, 7778.2695f), new Vector3(-0.0f, 0.0f, 1.0f), speedShrine1, isTargetable: false, ignoresCollision: true));
 
-            var speedShrine2 = CreateJungleCamp(new Vector3(8859.897f, 60.0f, 7788.1064f), 103, 0, "Shrine", 0);
+            var speedShrine2 = CreateJungleCamp(new Vector3(8859.897f, 60.0f, 7788.1064f), 103, TeamId.TEAM_UNKNOWN, "Shrine", 0);
             SpeedShrines.Add(speedShrine2, CreateJungleMonster("OdinSpeedShrine", "OdinSpeedShrine", new Vector2(8859.897f, 7788.1064f), new Vector3(-0.0f, 0.0f, 1.0f), speedShrine2, isTargetable: false, ignoresCollision: true));
 
-            var speedShrine3 = CreateJungleCamp(new Vector3(6962.6934f, 60.0f, 4089.48f), 104, 0, "Shrine", 0);
+            var speedShrine3 = CreateJungleCamp(new Vector3(6962.6934f, 60.0f, 4089.48f), 104, TeamId.TEAM_UNKNOWN, "Shrine", 0);
             SpeedShrines.Add(speedShrine3, CreateJungleMonster("OdinSpeedShrine", "OdinSpeedShrine", new Vector2(6962.6934f, 4089.48f), new Vector3(-0.0f, 0.0f, 1.0f), speedShrine3, isTargetable: false, ignoresCollision: true));
 
 
-            var healthPacket1 = CreateJungleCamp(new Vector3(4948.231f, 60.0f, 9329.905f), 100, 0, "HealthPack", 120.0f * 1000f);
+            var healthPacket1 = CreateJungleCamp(new Vector3(4948.231f, 60.0f, 9329.905f), 100, TeamId.TEAM_UNKNOWN, "HealthPack", 120.0f * 1000f);
             HealthPacks.Add(healthPacket1, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(4948.231f, 9329.905f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket1));
 
-            var healthPacket2 = CreateJungleCamp(new Vector3(8972.231f, 60.0f, 9329.905f), 101, 0, "HealthPack", 120.0f * 1000f);
+            var healthPacket2 = CreateJungleCamp(new Vector3(8972.231f, 60.0f, 9329.905f), 101, TeamId.TEAM_UNKNOWN, "HealthPack", 120.0f * 1000f);
             HealthPacks.Add(healthPacket2, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(8972.231f, 9329.905f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket2));
 
-            var healthPacket3 = CreateJungleCamp(new Vector3(6949.8193f, 60.0f, 2855.0513f), 112, 0, "HealthPack", 120.0f * 1000f);
+            var healthPacket3 = CreateJungleCamp(new Vector3(6949.8193f, 60.0f, 2855.0513f), 112, TeamId.TEAM_UNKNOWN, "HealthPack", 120.0f * 1000f);
             HealthPacks.Add(healthPacket3, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(6949.8193f, 2855.0513f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket3));
 
-            var healthPacket4 = CreateJungleCamp(new Vector3(6947.838f, 60.0f, 12116.367f), 108, 0, "HealthPack", 120.0f * 1000f);
+            var healthPacket4 = CreateJungleCamp(new Vector3(6947.838f, 60.0f, 12116.367f), 108, TeamId.TEAM_UNKNOWN, "HealthPack", 120.0f * 1000f);
             HealthPacks.Add(healthPacket4, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(6947.838f, 12116.367f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket4));
 
-            var healthPacket5 = CreateJungleCamp(new Vector3(12881.534f, 60.0f, 8294.764f), 109, 0, "HealthPack", 120.0f * 1000f);
+            var healthPacket5 = CreateJungleCamp(new Vector3(12881.534f, 60.0f, 8294.764f), 109, TeamId.TEAM_UNKNOWN, "HealthPack", 120.0f * 1000f);
             HealthPacks.Add(healthPacket5, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(12881.534f, 8294.764f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket5));
 
-            var healthPacket6 = CreateJungleCamp(new Vector3(10242.127f, 60.0f, 1519.5938f), 105, 0, "HealthPack", 120.0f * 1000f);
+            var healthPacket6 = CreateJungleCamp(new Vector3(10242.127f, 60.0f, 1519.5938f), 105, TeamId.TEAM_UNKNOWN, "HealthPack", 120.0f * 1000f);
             HealthPacks.Add(healthPacket6, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(10242.127f, 1519.5938f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket6));
 
-            var healthPacket7 = CreateJungleCamp(new Vector3(3639.7327f, 60.0f, 1490.0762f), 106, 0, "HealthPack", 120.0f * 1000f);
+            var healthPacket7 = CreateJungleCamp(new Vector3(3639.7327f, 60.0f, 1490.0762f), 106, TeamId.TEAM_UNKNOWN, "HealthPack", 120.0f * 1000f);
             HealthPacks.Add(healthPacket7, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(3639.7327f, 1490.0762f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket7));
 
-            var healthPacket8 = CreateJungleCamp(new Vector3(1027.4365f, 60.0f, 8288.714f), 107, 0, "HealthPack", 120.0f * 1000f);
+            var healthPacket8 = CreateJungleCamp(new Vector3(1027.4365f, 60.0f, 8288.714f), 107, TeamId.TEAM_UNKNOWN, "HealthPack", 120.0f * 1000f);
             HealthPacks.Add(healthPacket8, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(1027.4365f, 8288.714f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket8));
 
-            var healthPacket9 = CreateJungleCamp(new Vector3(4324.928f, 60.0f, 5500.919f), 110, 0, "HealthPack", 120.0f * 1000f);
+            var healthPacket9 = CreateJungleCamp(new Vector3(4324.928f, 60.0f, 5500.919f), 110, TeamId.TEAM_UNKNOWN, "HealthPack", 120.0f * 1000f);
             HealthPacks.Add(healthPacket9, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(4324.928f, 5500.919f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket9));
 
-            var healthPacket10 = CreateJungleCamp(new Vector3(9573.432f, 60.0f, 5530.13f), 111, 0, "HealthPack", 120.0f * 1000f);
+            var healthPacket10 = CreateJungleCamp(new Vector3(9573.432f, 60.0f, 5530.13f), 111, TeamId.TEAM_UNKNOWN, "HealthPack", 120.0f * 1000f);
             HealthPacks.Add(healthPacket10, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(9573.432f, 5530.13f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket10));
         }
     }

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/NeutralMinionSpawnAscension.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/NeutralMinionSpawnAscension.cs
@@ -89,32 +89,32 @@ namespace MapScripts.Map8
             CaptureCrystals.Add(new AscensionCrystal(new Vector2(8838.0f, 7760.0f)));
             CaptureCrystals.Add(new AscensionCrystal(new Vector2(6960.0f, 4080.0f)));
 
-            var speedShrine1 = CreateJungleCamp(new Vector3(5022.9287f, 60.0f, 7778.2695f), 102, 0, "NoIcon", 0);
+            var speedShrine1 = CreateJungleCamp(new Vector3(5022.9287f, 60.0f, 7778.2695f), 102, TeamId.TEAM_UNKNOWN, "NoIcon", 0);
             SpeedShrines.Add(speedShrine1, CreateJungleMonster("OdinSpeedShrine", "OdinSpeedShrine", new Vector2(5022.9287f, 7778.2695f), new Vector3(-0.0f, 0.0f, 1.0f), speedShrine1, isTargetable: false, ignoresCollision: true));
 
-            var speedShrine2 = CreateJungleCamp(new Vector3(8859.897f, 60.0f, 7788.1064f), 103, 0, "NoIcon", 0);
+            var speedShrine2 = CreateJungleCamp(new Vector3(8859.897f, 60.0f, 7788.1064f), 103, TeamId.TEAM_UNKNOWN, "NoIcon", 0);
             SpeedShrines.Add(speedShrine2, CreateJungleMonster("OdinSpeedShrine", "OdinSpeedShrine", new Vector2(8859.897f, 7788.1064f), new Vector3(-0.0f, 0.0f, 1.0f), speedShrine2, isTargetable: false, ignoresCollision: true));
 
-            var speedShrine3 = CreateJungleCamp(new Vector3(6962.6934f, 60.0f, 4089.48f), 104, 0, "NoIcon", 0);
+            var speedShrine3 = CreateJungleCamp(new Vector3(6962.6934f, 60.0f, 4089.48f), 104, TeamId.TEAM_UNKNOWN, "NoIcon", 0);
             SpeedShrines.Add(speedShrine3, CreateJungleMonster("OdinSpeedShrine", "OdinSpeedShrine", new Vector2(6962.6934f, 4089.48f), new Vector3(-0.0f, 0.0f, 1.0f), speedShrine3, isTargetable: false, ignoresCollision: true));
 
 
-            var healthPacket1 = CreateJungleCamp(new Vector3(4948.231f, 60.0f, 9329.905f), 100, 0, "HealthPack", 10.0f * 1000f);
+            var healthPacket1 = CreateJungleCamp(new Vector3(4948.231f, 60.0f, 9329.905f), 100, TeamId.TEAM_UNKNOWN, "HealthPack", 10.0f * 1000f);
             HealthPacks.Add(healthPacket1, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(4948.231f, 9329.905f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket1));
 
-            var healthPacket2 = CreateJungleCamp(new Vector3(8972.231f, 60.0f, 9329.905f), 101, 0, "HealthPack", 10.0f * 1000f);
+            var healthPacket2 = CreateJungleCamp(new Vector3(8972.231f, 60.0f, 9329.905f), 101, TeamId.TEAM_UNKNOWN, "HealthPack", 10.0f * 1000f);
             HealthPacks.Add(healthPacket2, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(8972.231f, 9329.905f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket2));
 
-            var healthPacket3 = CreateJungleCamp(new Vector3(6949.8193f, 60.0f, 2855.0513f), 112, 0, "HealthPack", 10.0f * 1000f);
+            var healthPacket3 = CreateJungleCamp(new Vector3(6949.8193f, 60.0f, 2855.0513f), 112, TeamId.TEAM_UNKNOWN, "HealthPack", 10.0f * 1000f);
             HealthPacks.Add(healthPacket3, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(6949.8193f, 2855.0513f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket3));
 
-            var healthPacket4 = CreateJungleCamp(new Vector3(4324.928f, 60.0f, 5500.919f), 110, 0, "HealthPack", 10.0f * 1000f);
+            var healthPacket4 = CreateJungleCamp(new Vector3(4324.928f, 60.0f, 5500.919f), 110, TeamId.TEAM_UNKNOWN, "HealthPack", 10.0f * 1000f);
             HealthPacks.Add(healthPacket4, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(4324.928f, 5500.919f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket4));
 
-            var healthPacket5 = CreateJungleCamp(new Vector3(9573.432f, 60.0f, 5530.13f), 111, 0, "HealthPack", 10.0f * 1000f);
+            var healthPacket5 = CreateJungleCamp(new Vector3(9573.432f, 60.0f, 5530.13f), 111, TeamId.TEAM_UNKNOWN, "HealthPack", 10.0f * 1000f);
             HealthPacks.Add(healthPacket5, CreateJungleMonster("OdinShieldRelic", "OdinShieldRelic", new Vector2(9573.432f, 5530.13f), new Vector3(-0.0f, 0.0f, 1.0f), healthPacket5));
 
-            var xerath = CreateJungleCamp(new Vector3(6930.0f, 60.0f, 6443.0f), 0, 0, "Dragon", 30.0f * 1000);
+            var xerath = CreateJungleCamp(new Vector3(6930.0f, 60.0f, 6443.0f), 0, TeamId.TEAM_UNKNOWN, "Dragon", 30.0f * 1000);
             Xerath = new AscXerath(CreateJungleMonster("AscXerath", "AscXerath", new Vector2(6930.0f, 6443.0f), new Vector3(-0.0f, 0.0f, 1.0f), xerath, TeamId.TEAM_NEUTRAL));
         }
     }

--- a/GameServerCore/Domain/GameObjects/IMonsterCamp.cs
+++ b/GameServerCore/Domain/GameObjects/IMonsterCamp.cs
@@ -19,6 +19,5 @@ namespace GameServerCore.Domain
         float RespawnTimer { get; set; }
         List<IMonster> Monsters { get; }
         IMonster AddMonster(IMonster monster);
-        void NotifyCampActivation();
     }
 }

--- a/GameServerCore/Enums/TeamId.cs
+++ b/GameServerCore/Enums/TeamId.cs
@@ -1,9 +1,12 @@
 ﻿namespace GameServerCore.Enums
 {
-    public enum TeamId
+    public enum TeamId: uint
     {
-        TEAM_BLUE = 0x64,
-        TEAM_PURPLE = 0xC8,
-        TEAM_NEUTRAL = 0x12C
+        TEAM_UNKNOWN = 0x0,
+        TEAM_BLUE = 0x64, // 100
+        TEAM_PURPLE = 0xC8, // 200
+        TEAM_NEUTRAL = 0x12C, // 300
+        TEAM_MAX = 0x190, // 400
+        TEAM_ALL = 0xFFFFFF9C,
     }
 }

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -527,7 +527,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="unpauser">Unit that unpaused the game.</param>
         /// <param name="showWindow">Whether or not to show a window before unpausing (delay).</param>
         void NotifyResumePacket(IChampion unpauser, ClientInfo player, bool isDelayed);
-        void NotifyS2C_ActivateMinionCamp(IMonsterCamp monsterCamp);
+        void NotifyS2C_ActivateMinionCamp(IMonsterCamp monsterCamp, int userId = 0);
         void NotifyS2C_AmmoUpdate(ISpell spell);
         /// <summary>
         /// Sends a packet to all players with vision of the given chain missile that it has updated (unit/position).
@@ -546,7 +546,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="userId">User to send the packet to. Set to -1 to broadcast.</param>
         /// <param name="doVision">Whether or not to package the packets into a vision packet.</param>
         void NotifyS2C_CreateHero(ClientInfo clientInfo, int userId = -1, bool doVision = false);
-        void NotifyS2C_CreateMinionCamp(IMonsterCamp monsterCamp);
+        void NotifyS2C_CreateMinionCamp(IMonsterCamp monsterCamp, int userId = 0);
         void NotifyS2C_CreateNeutral(IMonster monster, float time);
         /// <summary>
         /// Sends a packet to either all players or the specified player detailing that the specified LaneTurret has spawned.
@@ -608,7 +608,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="startFromCurretPosition">Wheter or not it starts from current position</param>
         /// <param name="unlockCamera">Whether or not the camera is unlocked</param>
         void NotifyS2C_MoveCameraToPoint(Tuple<uint, ClientInfo> player, Vector3 startPosition, Vector3 endPosition, float travelTime = 0, bool startFromCurretPosition = true, bool unlockCamera = false);
-        void NotifyS2C_Neutral_Camp_Empty(IMonsterCamp monsterCamp, IDeathData deathData = null);
+        void NotifyS2C_Neutral_Camp_Empty(IMonsterCamp monsterCamp, IDeathData deathData = null, int userId = 0);
         /// <summary>
         /// Sends a packet to all players detailing that the specified unit has been killed by the specified killer.
         /// </summary>

--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -203,7 +203,9 @@ namespace LeagueSandbox.GameServer.API
         /// <returns></returns>
         public static IMonsterCamp CreateJungleCamp(Vector3 position, byte groupNumber, TeamId teamSideOfTheMap, string campTypeIcon, float respawnTimer, bool doPlayVO = false, byte revealEvent = 74, float spawnDuration = 0.0f)
         {
-            return new MonsterCamp(_game, position, groupNumber, teamSideOfTheMap, campTypeIcon, respawnTimer, doPlayVO, revealEvent, spawnDuration);
+            var camp = new MonsterCamp(_game, position, groupNumber, teamSideOfTheMap, campTypeIcon, respawnTimer, doPlayVO, revealEvent, spawnDuration);
+            _game.ObjectManager.AddObject(camp);
+            return camp;
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -22,9 +22,10 @@ namespace LeagueSandbox.GameServer.GameObjects
         // Function Vars
         protected bool _toRemove;
         protected bool _movementUpdated;
-        private Dictionary<TeamId, bool> _visibleByTeam;
-        private HashSet<int> _spawnedForPlayers = new HashSet<int>();
-        private Dictionary<int, bool> _visibleForPlayers = new Dictionary<int, bool>();
+
+        protected Dictionary<TeamId, bool> _visibleByTeam;
+        protected HashSet<int> _spawnedForPlayers = new HashSet<int>();
+        protected Dictionary<int, bool> _visibleForPlayers = new Dictionary<int, bool>();
         /// <summary>
         /// A set of players with vision of this GameObject.
         /// Can be iterated through.
@@ -291,7 +292,7 @@ namespace LeagueSandbox.GameServer.GameObjects
                     OnSync(userId, team);
                 }
             }
-            else if (forceSpawn || visible || !SpawnShouldBeHidden)
+            else if (visible || !SpawnShouldBeHidden)
             {
                 OnSpawn(userId, team, visible);
                 SetVisibleForPlayer(userId, visible);
@@ -307,7 +308,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         {
             if(IsSpawnedForPlayer(userId))
             {
-                OnSpawn(userId, team, IsVisibleForPlayer(userId));
+                Sync(userId, team, IsVisibleForPlayer(userId), true);
             }
         }
 
@@ -393,10 +394,10 @@ namespace LeagueSandbox.GameServer.GameObjects
         public virtual void TeleportTo(float x, float y)
         {
             var position = _game.Map.NavigationGrid.GetClosestTerrainExit(new Vector2(x, y), PathfindingRadius + 1.0f);
-            
+
             SetPosition(position);
 
-            // TODO: Find a suitable function for this. Maybe modify NotifyWaypointGroup to accept simple objects. 
+            // TODO: Find a suitable function for this. Maybe modify NotifyWaypointGroup to accept simple objects.
             _game.PacketNotifier.NotifyEnterVisibilityClient(this);
             _movementUpdated = false;
         }

--- a/GameServerLib/GameObjects/MonsterCamp.cs
+++ b/GameServerLib/GameObjects/MonsterCamp.cs
@@ -6,14 +6,13 @@ using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.GameObjects;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Timers;
 
 namespace GameServerLib.GameObjects
 {
-    public class MonsterCamp : IMonsterCamp
+    public class MonsterCamp : GameObject, IMonsterCamp
     {
         public byte CampIndex { get; set; }
-        public Vector3 Position { get; set; }
+        public new Vector3 Position { get; set; }
         public byte SideTeamId { get; set; }
         public string MinimapIcon { get; set; }
         public byte RevealEvent { get; set; }
@@ -25,37 +24,96 @@ namespace GameServerLib.GameObjects
         public float RespawnTimer { get; set; }
         public List<IMonster> Monsters { get; set; } = new List<IMonster>();
 
-        private Game _game;
-        public MonsterCamp(Game game, Vector3 position, byte groupNumber, TeamId teamSideOfTheMap, string campTypeIcon, float respawnTimer, bool doPlayVO = true, byte revealEvent = 74, float spawnDuration = 0.0f)
+        public override bool IsAffectedByFoW => true;
+
+        private TeamId[] _playerTeams = new TeamId[]{ TeamId.TEAM_BLUE, TeamId.TEAM_PURPLE };
+        private Dictionary<TeamId, bool> _teamSawLastDeath = new Dictionary<TeamId, bool>{
+            { TeamId.TEAM_BLUE, true },
+            { TeamId.TEAM_PURPLE, true },
+        };
+        private Dictionary<TeamId, bool> _isAliveForTeam = new Dictionary<TeamId, bool>{
+            { TeamId.TEAM_BLUE, false },
+            { TeamId.TEAM_PURPLE, false },
+        };
+        private Dictionary<int, bool> _isAliveForPlayer = new Dictionary<int, bool>();
+
+        public MonsterCamp(
+            Game game, Vector3 position, byte groupNumber, TeamId teamSideOfTheMap,
+            string campTypeIcon, float respawnTimer, bool doPlayVO = true, byte revealEvent = 74,
+            float spawnDuration = 0
+        ): base(
+            game, new Vector2(position.X, position.Z), 0, 0, 0, team: TeamId.TEAM_NEUTRAL
+        )
         {
-            _game = game;
             Position = position;
             CampIndex = groupNumber;
             RevealEvent = revealEvent;
             MinimapIcon = campTypeIcon;
             RespawnTimer = respawnTimer;
             SideTeamId = (byte)teamSideOfTheMap;
+            SpawnDuration = spawnDuration;
+        }
 
-            if (teamSideOfTheMap == TeamId.TEAM_NEUTRAL)
+        public override void LateUpdate(float diff)
+        {
+            foreach(TeamId team in _playerTeams)
             {
-                SideTeamId = 0;
+                if(IsVisibleByTeam(team))
+                {
+                    _isAliveForTeam[team] = IsAlive;
+                }
+            }
+        }
+
+        public override void Sync(int userId, TeamId team, bool visible, bool forceSpawn = false)
+        {
+            base.Sync(userId, team, visible, forceSpawn);
+
+            bool isAliveForTeam = _isAliveForTeam[team];
+            bool isAliveForPlayer = _isAliveForPlayer.GetValueOrDefault(userId, false);
+            if(
+                (forceSpawn && isAliveForPlayer) // Reconnect
+                || (
+                    isAliveForPlayer != isAliveForTeam
+                    && !_game.PlayerManager.GetPeerInfo(userId).Champion.Status
+                        .HasFlag(StatusFlags.NearSighted)
+                )
+            ) {
+                if(_isAliveForPlayer[userId] = isAliveForTeam)
+                {
+                    _game.PacketNotifier.NotifyS2C_ActivateMinionCamp(this, userId);
+                }
+                else
+                {
+                    _game.PacketNotifier.NotifyS2C_Neutral_Camp_Empty(this, userId: userId);
+                }
             }
 
-            SpawnDuration = spawnDuration;
+        }
 
-            game.PacketNotifier.NotifyS2C_CreateMinionCamp(this);
+        protected override void OnSpawn(int userId, TeamId team, bool doVision = false)
+        {
+            _game.PacketNotifier.NotifyS2C_CreateMinionCamp(this, userId);
+        }
+
+        protected override void OnEnterVision(int userId, TeamId team)
+        {
+        }
+
+        protected override void OnLeaveVision(int userId, TeamId team)
+        {
         }
 
         public IMonster AddMonster(IMonster monster)
         {
             var aiscript = monster.AIScript.ToString().Remove(0, 10);
             var campMonster = new Monster
-                    (
-                    _game, monster.Name, monster.Model, monster.Position,
-                    monster.Direction, this, monster.Team, 0,
-                    monster.SpawnAnimation, monster.IsTargetable, monster.IgnoresCollision, aiscript,
-                    monster.DamageBonus, monster.HealthBonus, monster.InitialLevel
-                    );
+            (
+                _game, monster.Name, monster.Model, monster.Position,
+                monster.Direction, this, monster.Team, 0,
+                monster.SpawnAnimation, monster.IsTargetable, monster.IgnoresCollision, aiscript,
+                monster.DamageBonus, monster.HealthBonus, monster.InitialLevel
+            );
             while(campMonster.Stats.Level < monster.InitialLevel)
             {
                 campMonster.Stats.LevelUp();
@@ -63,7 +121,17 @@ namespace GameServerLib.GameObjects
             Monsters.Add(campMonster);
             ApiEventManager.OnDeath.AddListener(campMonster, campMonster, OnMonsterDeath, true);
             _game.ObjectManager.AddObject(campMonster);
-            NotifyCampActivation();
+
+            IsAlive = true;
+            foreach(TeamId team in _playerTeams)
+            {
+                if(_teamSawLastDeath[team])
+                {
+                    _teamSawLastDeath[team] = false;
+                    _isAliveForTeam[team] = true;
+                }
+            }
+
             return campMonster;
         }
 
@@ -73,20 +141,15 @@ namespace GameServerLib.GameObjects
             Monsters.Remove(monster);
             if (Monsters.Count == 0)
             {
-                NotifyCampDeactivation(deathData);
+                IsAlive = false;
+                foreach(TeamId team in _playerTeams)
+                {
+                    if(_teamSawLastDeath[team] = (monster.IsVisibleByTeam(team) || IsVisibleByTeam(team)))
+                    {
+                        _isAliveForTeam[team] = false;
+                    }
+                }
             }
-        }
-
-        public void NotifyCampActivation()
-        {
-            IsAlive = true;
-            _game.PacketNotifier.NotifyS2C_ActivateMinionCamp(this);
-        }
-
-        public void NotifyCampDeactivation(IDeathData deathData = null)
-        {
-            IsAlive = false;
-            _game.PacketNotifier.NotifyS2C_Neutral_Camp_Empty(this, deathData);
         }
     }
 }

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -91,17 +91,14 @@ namespace LeagueSandbox.GameServer
                     RemoveObject(obj);
                 }
             }
-            
+
             foreach (var obj in _objectsToRemove)
             {
                 _objects.Remove(obj.NetId);
             }
             _objectsToRemove.Clear();
 
-            foreach (var obj in _objects.Values)
-            {
-                obj.LateUpdate(diff);
-            }
+            int oldObjectsCount = _objects.Count;
 
             foreach (var obj in _objectsToAdd)
             {
@@ -110,10 +107,15 @@ namespace LeagueSandbox.GameServer
             _objectsToAdd.Clear();
 
             var players = _game.PlayerManager.GetPlayers(includeBots: false);
-            
+
+            int i = 0;
             foreach (IGameObject obj in _objects.Values)
             {
                 UpdateTeamsVision(obj);
+                if(i++ < oldObjectsCount)
+                {
+                    obj.LateUpdate(diff);
+                }
 
                 foreach (var kv in players)
                 {
@@ -167,10 +169,10 @@ namespace LeagueSandbox.GameServer
         /// </summary>
         void UpdateTeamsVision(IGameObject obj)
         {
-                foreach (var team in Teams)
-                {
-                    obj.SetVisibleByTeam(team, !obj.IsAffectedByFoW || TeamHasVisionOn(team, obj));
-                }
+            foreach (var team in Teams)
+            {
+                obj.SetVisibleByTeam(team, !obj.IsAffectedByFoW || TeamHasVisionOn(team, obj));
+            }
         }
 
         /// <summary>
@@ -181,14 +183,14 @@ namespace LeagueSandbox.GameServer
             int pid = (int)clientInfo.PlayerId;
             TeamId team = clientInfo.Team;
             IChampion champion = clientInfo.Champion;
-            
+
             bool nearSighted = champion.Status.HasFlag(StatusFlags.NearSighted);
             bool shouldBeVisibleForPlayer = !obj.IsAffectedByFoW || (
                 nearSighted ?
                     UnitHasVisionOn(champion, obj) :
                     obj.IsVisibleByTeam(champion.Team)
             );
-            
+
             obj.Sync(pid, team, shouldBeVisibleForPlayer, forceSpawn);
         }
 

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -2462,7 +2462,7 @@ namespace PacketDefinitions420
             _packetHandlerManager.SendPacket((int)player.PlayerId, resume.GetBytes(), Channel.CHL_S2C);
         }
 
-        public void NotifyS2C_ActivateMinionCamp(IMonsterCamp monsterCamp)
+        public void NotifyS2C_ActivateMinionCamp(IMonsterCamp monsterCamp, int userId = 0)
         {
             var packet = new S2C_ActivateMinionCamp
             {
@@ -2471,7 +2471,14 @@ namespace PacketDefinitions420
                 SpawnDuration = monsterCamp.SpawnDuration,
                 TimerType = monsterCamp.TimerType
             };
-            _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
+            if (userId <= 0)
+            {
+                _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
+            }
+            else
+            {
+                _packetHandlerManager.SendPacket(userId, packet.GetBytes(), Channel.CHL_S2C);
+            }
         }
 
         public void NotifyS2C_AmmoUpdate(ISpell spell)
@@ -2600,7 +2607,7 @@ namespace PacketDefinitions420
             }
         }
 
-        public void NotifyS2C_CreateMinionCamp(IMonsterCamp monsterCamp)
+        public void NotifyS2C_CreateMinionCamp(IMonsterCamp monsterCamp, int userId = 0)
         {
             var packet = new S2C_CreateMinionCamp
             {
@@ -2612,7 +2619,14 @@ namespace PacketDefinitions420
                 Expire = monsterCamp.Expire,
                 TimerType = monsterCamp.TimerType
             };
-            _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
+            if (userId <= 0)
+            {
+                _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
+            }
+            else
+            {
+                _packetHandlerManager.SendPacket(userId, packet.GetBytes(), Channel.CHL_S2C);
+            }
         }
 
         public void NotifyS2C_CreateNeutral(IMonster monster, float time)
@@ -2810,7 +2824,7 @@ namespace PacketDefinitions420
 
             _packetHandlerManager.SendPacket((int)player.Item2.PlayerId, cam.GetBytes(), Channel.CHL_S2C);
         }
-        public void NotifyS2C_Neutral_Camp_Empty(IMonsterCamp monsterCamp, IDeathData deathData = null)
+        public void NotifyS2C_Neutral_Camp_Empty(IMonsterCamp monsterCamp, IDeathData deathData = null, int userId = 0)
         {
             var packet = new S2C_Neutral_Camp_Empty
             {
@@ -2826,7 +2840,14 @@ namespace PacketDefinitions420
             {
                 packet.KillerNetID = deathData.Killer.NetId;
             }
-            _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
+            if (userId <= 0)
+            {
+                _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
+            }
+            else
+            {
+                _packetHandlerManager.SendPacket(userId, packet.GetBytes(), Channel.CHL_S2C);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
- `UNKNOWN`, `MAX` and `ALL` keys have been added to `TeamId` `enum`.
https://discord.com/channels/472169314913353730/472169315479846914/966008616995938364
In some places they have replaced zero.
- Camps are now `GameObjects` and subject to vision.
    - As long as the camp is in sight, the player and his team know if it is empty or not.
    - If the player sees the death of the monster (or the camp at the time of the death of the monster, see previous point),
the player and his team will know when it respawns.
- Also, camps are now correctly displayed on the minimap when reconnecting.
- `GameObject.OnReconnect` now calls `Sync` by default.