### PR TITLE
Introducing IconInfo and a few fixes

### DIFF
--- a/Content/LeagueSandbox-Scripts/AiScripts/BasicJungleMonsterAi.cs
+++ b/Content/LeagueSandbox-Scripts/AiScripts/BasicJungleMonsterAi.cs
@@ -51,6 +51,8 @@ namespace AIScripts
                 {
                     if (monster.Position != initialPosition)
                     {
+                        //This causes EXTREME lag when monsters spawn
+                        //TODO: Find a better way to do this
                         ResetCamp();
                     }
                     else if (monster.Direction != initialFacingDirection)

--- a/Content/LeagueSandbox-Scripts/Buffs/AscRelic/AscRelicBombBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/AscRelic/AscRelicBombBuff.cs
@@ -27,7 +27,7 @@ namespace Buffs
             AddUnitPerceptionBubble(unit, 800.0f, 25000.0f, TeamId.TEAM_PURPLE, false, null, 38.08f, collisionOwner: unit);
             p1 = AddParticleTarget(unit, unit, "Asc_RelicPrism_Sand", unit, -1.0f, 1.0f ,direction: new Vector3(0.0f, 0.0f, -1.0f), flags: (FXFlags)304);
             AddParticleTarget(unit, unit, "Asc_relic_Sand_buf", unit, -1.0f, flags: (FXFlags)32);
-            SetMinimapIcon(unit, "Relic", true);
+            unit.IconInfo.SwapIcon("Relic", true);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Buffs/AscWarp/AscWarp.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/AscWarp/AscWarp.cs
@@ -21,15 +21,15 @@ namespace Buffs
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             SetStatus(unit, StatusFlags.Stunned, true);
-            SetMinimapIcon(unit, changeBorder: true, borderCategory: "Teleport", borderScriptName: "AscWarp");
+            unit.IconInfo.SwapBorder("Teleport", true, "AscWarp");
             AddParticleTarget(unit, unit, "Global_Asc_teleport", unit, buff.Duration);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             SetStatus(unit, StatusFlags.Stunned, false);
-            SetMinimapIcon(unit, changeBorder: true);
-            if(unit is IObjAiBase obj)
+            unit.IconInfo.SwapBorder("", true);
+            if (unit is IObjAiBase obj)
             {
                 AddBuff("AscWarpReappear", 10.0f, 1, null, unit, obj);
             }

--- a/Content/LeagueSandbox-Scripts/Buffs/AscWarp/AscWarpTarget.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/AscWarp/AscWarpTarget.cs
@@ -22,17 +22,17 @@ namespace Buffs
         IParticle p1;
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            SetMinimapIcon(unit, changeBorder: true, borderCategory: "Teleport", borderScriptName: "ascwarptarget");
-            SetMinimapIcon(unit, "NoIcon", true);
+            unit.IconInfo.SwapBorder("Teleport", true, "ascwarptarget");
+            unit.IconInfo.SwapIcon("NoIcon", true);
             p1 = AddParticleTarget(buff.SourceUnit, null, "global_asc_teleport_target", unit, -1);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             RemoveParticle(p1);
-            SetMinimapIcon(unit, changeBorder: true);
+            unit.IconInfo.SwapBorder("", true);
             TeleportTo(buff.SourceUnit, unit.Position.X, unit.Position.Y);
-            if(buff.SourceUnit is IChampion ch)
+            if (buff.SourceUnit is IChampion ch)
             {
                 TeleportCamera(ch, new Vector3(unit.Position.X, unit.GetHeight(), unit.Position.Y));
             }

--- a/Content/LeagueSandbox-Scripts/Buffs/OdinCenterRelic/OdinBombBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/OdinCenterRelic/OdinBombBuff.cs
@@ -64,7 +64,7 @@ namespace Buffs
                 iconCategory = "CenterRelicRight";
             }
 
-            SetMinimapIcon(unit, iconCategory, true);
+            unit.IconInfo.SwapIcon(iconCategory, true);
         }
         public void OnDeath(IDeathData deathData)
         {

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScriptObjects.cs
@@ -64,7 +64,7 @@ namespace MapScripts.Map8
         {
             foreach (var shop in _mapObjects[GameObjectTypes.ObjBuilding_Shop])
             {
-                NotifySpawnBroadcast(CreateShop(shop.Name, new Vector2(shop.CentralPoint.X, shop.CentralPoint.Z), shop.GetTeamID()));
+                CreateShop(shop.Name, new Vector2(shop.CentralPoint.X, shop.CentralPoint.Z), shop.GetTeamID());
             }
         }
 

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScriptObjectsAscension.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScriptObjectsAscension.cs
@@ -81,8 +81,8 @@ namespace MapScripts.Map8
             foreach (var infoPoint in _mapObjects[GameObjectTypes.InfoPoint])
             {
                 var position = new Vector2(infoPoint.CentralPoint.X, infoPoint.CentralPoint.Z);
-                NotifySpawnBroadcast(AddPosPerceptionBubble(position, 500.0f, 25000.0f, TeamId.TEAM_BLUE, false));
-                NotifySpawnBroadcast(AddPosPerceptionBubble(position, 500.0f, 25000.0f, TeamId.TEAM_PURPLE, false));
+                AddPosPerceptionBubble(position, 500.0f, 25000.0f, TeamId.TEAM_BLUE, false);
+                AddPosPerceptionBubble(position, 500.0f, 25000.0f, TeamId.TEAM_PURPLE, false);
 
                 if (infoPoint.Name == "Info_PointA" || infoPoint.Name == "Info_PointB")
                 {
@@ -103,7 +103,7 @@ namespace MapScripts.Map8
         public static void CreateTeleportPoint(Vector2 position, TeamId team, string mapIcon)
         {
             var point = CreateMinion("AscWarpIcon", "AscWarpIcon", position, team: team, ignoreCollision: false, isTargetable: false);
-            SetMinimapIcon(point, mapIcon, true);
+            point.IconInfo.SwapIcon(mapIcon, true);
             TeleportPlates.Add(point);
             point.PauseAi(true);
         }

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/NeutralMinionSpawnAscension.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/NeutralMinionSpawnAscension.cs
@@ -134,7 +134,7 @@ public class AscXerath
     public void SpawnXerath()
     {
         var ascXerath = Camp.AddMonster(Xerath);
-        SetMinimapIcon(ascXerath, "Dragon", true);
+        ascXerath.IconInfo.SwapIcon("Dragon", true);
         ApiEventManager.OnDeath.AddListener(ascXerath, ascXerath, OnXerathDeath, true);
         RespawnTimer = 30.0f * 1000;
     }
@@ -171,9 +171,8 @@ public class AscensionCrystal
     public void SpawnCrystal()
     {
         var crystal = CreateMinion("AscRelic", "AscRelic", Position, ignoreCollision: true, isTargetable: false);
-        NotifySpawnBroadcast(crystal);
         ApiEventManager.OnDeath.AddListener(crystal, crystal, OnDeath, true);
-        SetMinimapIcon(crystal, "Relic", true);
+        crystal.IconInfo.SwapIcon("Relic", true);
         IsDead = false;
         RespawnTimer = 20.0f * 1000f;
 

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -58,6 +58,10 @@ namespace GameServerCore.Domain.GameObjects
         /// Resets when reaching byte.MaxValue (255).
         /// </summary>
         byte TeleportID { get; set; }
+        /// <summary>
+        /// Information about this object's icon on the minimap.
+        /// </summary>
+        /// TODO: Move this to GameObject.
         IIconInfo IconInfo { get; }
         /// <summary>
         /// Gets the HashString for this unit's model. Used for packets so clients know what data to load.

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -11,6 +11,11 @@ namespace GameServerCore.Domain.GameObjects
     public interface IAttackableUnit : IGameObject
     {
         /// <summary>
+        /// Variable containing all data about the AI's current character such as base health, base mana, whether or not they are melee, base movespeed, per level stats, etc.
+        /// </summary>
+        /// TODO: Move to AttackableUnit as it relates to stats..
+        ICharData CharData { get; }
+        /// <summary>
         /// Whether or not this Unit is dead. Refer to TakeDamage() and Die().
         /// </summary>
         bool IsDead { get; }

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -11,9 +11,8 @@ namespace GameServerCore.Domain.GameObjects
     public interface IAttackableUnit : IGameObject
     {
         /// <summary>
-        /// Variable containing all data about the AI's current character such as base health, base mana, whether or not they are melee, base movespeed, per level stats, etc.
+        /// Variable containing all data about this unit's current character such as base health, base mana, whether or not they are melee, base movespeed, per level stats, etc.
         /// </summary>
-        /// TODO: Move to AttackableUnit as it relates to stats..
         ICharData CharData { get; }
         /// <summary>
         /// Whether or not this Unit is dead. Refer to TakeDamage() and Die().

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -54,7 +54,7 @@ namespace GameServerCore.Domain.GameObjects
         /// Resets when reaching byte.MaxValue (255).
         /// </summary>
         byte TeleportID { get; set; }
-
+        IIconInfo IconInfo { get; }
         /// <summary>
         /// Gets the HashString for this unit's model. Used for packets so clients know what data to load.
         /// </summary>
@@ -282,5 +282,6 @@ namespace GameServerCore.Domain.GameObjects
         /// First string is the animation to override, second string is the animation to play in place of the first.
         /// <param name="animPairs">Dictionary of animations to set.</param>
         void SetAnimStates(Dictionary<string, string> animPairs);
+        void UpdateIcon();
     }
 }

--- a/GameServerCore/Domain/GameObjects/IGameObject.cs
+++ b/GameServerCore/Domain/GameObjects/IGameObject.cs
@@ -161,6 +161,7 @@ namespace GameServerCore.Domain.GameObjects
         /// Gets a list of all teams that have vision of this object.
         /// </summary>
         List<TeamId> TeamsWithVision();
+        
         /// <summary>
         /// Whether or not the object is visible for the specified player.
         /// <summary>

--- a/GameServerCore/Domain/GameObjects/IGameObject.cs
+++ b/GameServerCore/Domain/GameObjects/IGameObject.cs
@@ -156,7 +156,11 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="team">A team which could have vision of this object.</param>
         /// <param name="visible">New value.</param>
         void SetVisibleByTeam(TeamId team, bool visible = true);
-                
+        /// <summary>
+        /// List of all teams that has vision of this object
+        /// </summary>
+        /// <returns></returns>
+        List<TeamId> TeamsWithVision();
         /// <summary>
         /// Whether or not the object is visible for the specified player.
         /// <summary>

--- a/GameServerCore/Domain/GameObjects/IGameObject.cs
+++ b/GameServerCore/Domain/GameObjects/IGameObject.cs
@@ -156,10 +156,10 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="team">A team which could have vision of this object.</param>
         /// <param name="visible">New value.</param>
         void SetVisibleByTeam(TeamId team, bool visible = true);
+        
         /// <summary>
-        /// List of all teams that has vision of this object
+        /// Gets a list of all teams that have vision of this object.
         /// </summary>
-        /// <returns></returns>
         List<TeamId> TeamsWithVision();
         /// <summary>
         /// Whether or not the object is visible for the specified player.

--- a/GameServerCore/Domain/GameObjects/IObjAiBase.cs
+++ b/GameServerCore/Domain/GameObjects/IObjAiBase.cs
@@ -21,11 +21,6 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         ISpell ChannelSpell { get; }
         /// <summary>
-        /// Variable containing all data about the AI's current character such as base health, base mana, whether or not they are melee, base movespeed, per level stats, etc.
-        /// </summary>
-        /// TODO: Move to AttackableUnit as it relates to stats..
-        ICharData CharData { get; }
-        /// <summary>
         /// An unit's A.I Script
         /// </summary>
         IAIScript AIScript { get; }

--- a/GameServerCore/Domain/IIconInfo.cs
+++ b/GameServerCore/Domain/IIconInfo.cs
@@ -1,0 +1,19 @@
+﻿using GameServerCore.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace GameServerCore.Domain
+{
+    public interface IIconInfo
+    {
+        string IconCategory { get; }
+        bool ChangeIcon { get; }
+        string BorderCategory { get; }
+        bool ChangeBorder { get; }
+        string BorderScriptName { get; }
+        List<TeamId> TeamsNotified { get; }
+        void SwapIcon(string iconCategory, bool changeIcon);
+        void SwapBorder(string borderCategory, bool changeBorder, string borderScriptName = "");
+        void AddNotifiedTeam(TeamId team);
+    }
+}

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -742,7 +742,8 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="attacked">Unit that is being attacked.</param>
         /// <param name="attackType">AttackType that the attacker is using to attack.</param>
         void NotifyS2C_UnitSetLookAt(IAttackableUnit attacker, IAttackableUnit attacked, AttackType attackType);
-        void NotifyS2C_UnitSetMinimapIcon(IAttackableUnit unit, string iconCategory = "", bool changeIcon = false, string borderCategory = "", bool changeBorder = false, string borderScriptName = "");
+        void NotifyS2C_UnitSetMinimapIcon(IAttackableUnit unit, TeamId team);
+        void NotifyS2C_UnitSetMinimapIcon(IAttackableUnit unit);
         void NotifyS2C_UpdateAscended(IObjAiBase ascendant = null);
         /// <summary>
         /// Sends a packet to all players detailing the attack speed cap overrides for this game.

--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -8,6 +8,7 @@ using GameServerLib.GameObjects.AttackableUnits;
 using LeaguePackets.Game.Common;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.AnimatedBuildings;
 using LeagueSandbox.GameServer.Handlers;
 using LeagueSandbox.GameServer.Logging;
@@ -175,7 +176,7 @@ namespace LeagueSandbox.GameServer.API
             string name, string model, Vector2 position, uint netId = 0,
             TeamId team = TeamId.TEAM_NEUTRAL, int skinId = 0, bool ignoreCollision = false,
             bool isTargetable = false, bool isWard = false, string aiScript = "", int damageBonus = 0,
-            int healthBonus = 0, int initialLevel = 1, bool instantNotifyBroadcast = false)
+            int healthBonus = 0, int initialLevel = 1)
         {
             return new Minion(_game, null, position, model, name, netId, team, skinId, ignoreCollision, isTargetable, isWard, null, aiScript, damageBonus, healthBonus, initialLevel);
         }
@@ -234,19 +235,6 @@ namespace LeagueSandbox.GameServer.API
         )
         {
             return new Monster(_game, name, model, position, faceDirection, monsterCamp, team, netId, spawnAnimation, isTargetable, ignoresCollision, aiScript, damageBonus, healthBonus, initialLevel);
-        }
-
-        /// <summary>
-        /// Set an unit's icon on minimap
-        /// </summary>
-        /// <param name="unit"></param>
-        /// <param name="iconCategory"></param>
-        /// <param name="changeIcon"></param>
-        /// <param name="borderCategory"></param>
-        /// <param name="changeBorder"></param>
-        public static void SetMinimapIcon(IAttackableUnit unit, string iconCategory = "", bool changeIcon = false, string borderCategory = "", bool changeBorder = false, string borderScriptName = "")
-        {
-            _game.PacketNotifier.NotifyS2C_UnitSetMinimapIcon(unit, iconCategory, changeIcon, borderCategory, changeBorder, borderScriptName);
         }
 
         /// <summary>

--- a/GameServerLib/API/ApiEventManager.cs
+++ b/GameServerLib/API/ApiEventManager.cs
@@ -236,7 +236,7 @@ namespace LeagueSandbox.GameServer.API
 
                         if (listener.Item4)
                         {
-                            _listeners.RemoveAt(i);
+                            _listeners.Remove(listener);
                         }
                     }
                 }
@@ -263,7 +263,7 @@ namespace LeagueSandbox.GameServer.API
 
                         if (listener.Item4)
                         {
-                            _listeners.RemoveAt(i);
+                            _listeners.Remove(listener);
                         }
                     }
                 }

--- a/GameServerLib/Content/IconInfo.cs
+++ b/GameServerLib/Content/IconInfo.cs
@@ -1,0 +1,49 @@
+﻿using GameServerCore.Domain;
+using GameServerCore.Domain.GameObjects;
+using GameServerCore.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace GameServerLib.Content
+{
+    public class IconInfo : IIconInfo
+    {
+        public string IconCategory { get; private set; } = string.Empty;
+        public bool ChangeIcon { get; private set; } = false;
+        public string BorderCategory { get; private set; } = string.Empty;
+        public bool ChangeBorder { get; private set; } = false;
+        public string BorderScriptName { get; private set; } = string.Empty;
+        public List<TeamId> TeamsNotified { get; private set; } = new List<TeamId>((TeamId[])Enum.GetValues(typeof(TeamId)));
+        
+        private IAttackableUnit _owner;
+        public IconInfo(IAttackableUnit owner)
+        {
+            _owner = owner;
+        }
+
+        public void SwapIcon(string iconCategory, bool changeIcon)
+        {
+            IconCategory = iconCategory;
+            ChangeIcon = changeIcon;
+
+            _owner.UpdateIcon();
+        }
+
+        public void SwapBorder(string borderCategory, bool changeBorder, string borderScriptName = "")
+        {
+            BorderCategory = borderCategory;
+            ChangeBorder = changeBorder;
+            BorderScriptName = borderScriptName;
+
+            _owner.UpdateIcon();
+        }
+
+        public void AddNotifiedTeam(TeamId team)
+        {
+            if (!TeamsNotified.Contains(team))
+            {
+                TeamsNotified.Add(team);
+            }
+        }
+    }
+}

--- a/GameServerLib/Content/SpellData.cs
+++ b/GameServerLib/Content/SpellData.cs
@@ -192,7 +192,7 @@ namespace LeagueSandbox.GameServer.Content
         {
 
             bool overrideTargetable = false;
-            if (target is IObjAiBase obj && obj.CharData.IsUseable && Flags.HasFlag(SpellDataFlags.AffectUseable))
+            if (target.CharData.IsUseable && Flags.HasFlag(SpellDataFlags.AffectUseable))
             {
                 //TODO: Verify if we need a check for CharData.UsableByEnemy here too.
                 overrideTargetable = true;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -40,11 +40,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// </summary>
         public ISpell ChannelSpell { get; protected set; }
         /// <summary>
-        /// Variable containing all data about the AI's current character such as base health, base mana, whether or not they are melee, base movespeed, per level stats, etc.
-        /// </summary>
-        /// TODO: Move to AttackableUnit as it relates to stats.
-        public ICharData CharData { get; }
-        /// <summary>
         /// The ID of the skin this unit should use for its model.
         /// </summary>
         public int SkinID { get; set; }
@@ -90,8 +85,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             base(game, model, stats, collisionRadius, position, visionRadius, netId, team)
         {
             _itemManager = game.ItemManager;
-
-            CharData = _game.Config.ContentManager.GetCharData(Model);
 
             SkinID = skinId;
 
@@ -1116,7 +1109,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             // Stop targeting an untargetable unit.
             if (TargetUnit != null && !TargetUnit.Status.HasFlag(StatusFlags.Targetable))
             {
-                if(TargetUnit is IObjAiBase aiTar && aiTar.CharData.IsUseable)
+                if(TargetUnit.CharData.IsUseable)
                 {
                     return;
                 }
@@ -1179,7 +1172,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     CancelAutoAttack(!HasAutoAttacked, true);
                 }
             }
-            else if (TargetUnit.IsDead || (!TargetUnit.Status.HasFlag(StatusFlags.Targetable) && TargetUnit is IObjAiBase obj && !obj.CharData.IsUseable) || !TargetUnit.IsVisibleByTeam(Team))
+            else if (TargetUnit.IsDead || (!TargetUnit.Status.HasFlag(StatusFlags.Targetable) && TargetUnit.CharData.IsUseable) || !TargetUnit.IsVisibleByTeam(Team))
             {
                 if (IsAttacking)
                 {

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -33,9 +33,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         internal const float DETECT_RANGE = 475.0f;
 
         /// <summary>
-        /// Variable containing all data about the AI's current character such as base health, base mana, whether or not they are melee, base movespeed, per level stats, etc.
+        /// Variable containing all data about the this unit's current character such as base health, base mana, whether or not they are melee, base movespeed, per level stats, etc.
         /// </summary>
-        /// TODO: Move to AttackableUnit as it relates to stats.
         public ICharData CharData { get; }
         /// <summary>
         /// Whether or not this Unit is dead. Refer to TakeDamage() and Die().

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -96,6 +96,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// Parameters of any forced movements (dashes) this unit is performing.
         /// </summary>
         public IForceMovementParameters MovementParameters { get; protected set; }
+        /// <summary>
+        /// Information about this object's icon on the minimap.
+        /// </summary>
+        /// TODO: Move this to GameObject.
         public IIconInfo IconInfo { get; }
         public override bool IsAffectedByFoW => true;
         public override bool SpawnShouldBeHidden => true;

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -33,6 +33,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         internal const float DETECT_RANGE = 475.0f;
 
         /// <summary>
+        /// Variable containing all data about the AI's current character such as base health, base mana, whether or not they are melee, base movespeed, per level stats, etc.
+        /// </summary>
+        /// TODO: Move to AttackableUnit as it relates to stats.
+        public ICharData CharData { get; }
+        /// <summary>
         /// Whether or not this Unit is dead. Refer to TakeDamage() and Die().
         /// </summary>
         public bool IsDead { get; protected set; }
@@ -109,8 +114,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 
         {
             Logger = LoggerProvider.GetLogger();
-            Stats = stats;
             Model = model;
+            CharData = _game.Config.ContentManager.GetCharData(Model);
+            Stats = stats;
             Waypoints = new List<Vector2> { Position };
             CurrentWaypoint = new KeyValuePair<int, Vector2>(1, Position);
             Status = StatusFlags.CanAttack | StatusFlags.CanCast | StatusFlags.CanMove | StatusFlags.CanMoveEver | StatusFlags.Targetable;
@@ -914,7 +920,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                         {
                             Stats.IsTargetable = enabled;
                             // TODO: Refactor this.
-                            if (this is IObjAiBase obj && !obj.CharData.IsUseable)
+                            if (CharData.IsUseable)
                             {
                                 Stats.SetActionState(ActionState.TARGETABLE, enabled);
                             }

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -9,6 +9,7 @@ using GameServerCore.Domain.GameObjects;
 using GameServerCore.Domain.GameObjects.Spell.Missile;
 using GameServerCore.Domain.GameObjects.Spell.Sector;
 using GameServerCore.Enums;
+using GameServerLib.Content;
 using GameServerLib.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.Logging;
@@ -91,7 +92,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// Parameters of any forced movements (dashes) this unit is performing.
         /// </summary>
         public IForceMovementParameters MovementParameters { get; protected set; }
-
+        public IIconInfo IconInfo { get; }
         public override bool IsAffectedByFoW => true;
         public override bool SpawnShouldBeHidden => true;
 
@@ -120,6 +121,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             BuffSlots = new IBuff[256];
             ParentBuffs = new Dictionary<string, IBuff>();
             BuffList = new List<IBuff>();
+            IconInfo = new IconInfo(this);
         }
 
         /// <summary>
@@ -273,6 +275,36 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                     exit = _game.Map.NavigationGrid.GetClosestTerrainExit(exit, PathfindingRadius + 1.0f);
                 }
                 SetPosition(exit, false);
+            }
+        }
+
+        protected override void OnSpawn(int userId, TeamId team, bool doVision)
+        {
+            base.OnSpawn(userId, team, doVision);
+            UpdateIconVision(team);
+        }
+        protected override void OnEnterVision(int userId, TeamId team)
+        {
+            base.OnEnterVision(userId, team);
+            UpdateIconVision(team);
+        }
+
+        public void UpdateIconVision(TeamId team)
+        {
+            if (!IconInfo.TeamsNotified.Contains(team))
+            {
+                IconInfo.AddNotifiedTeam(team);
+                _game.PacketNotifier.NotifyS2C_UnitSetMinimapIcon(this, team);
+            }
+        }
+
+        public void UpdateIcon()
+        {
+            IconInfo.TeamsNotified.Clear();
+            _game.PacketNotifier.NotifyS2C_UnitSetMinimapIcon(this);
+            foreach(TeamId team in TeamsWithVision())
+            {
+                IconInfo.TeamsNotified.Add(team);
             }
         }
 

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -348,6 +348,23 @@ namespace LeagueSandbox.GameServer.GameObjects
         }
 
         /// <summary>
+        /// List of all teams that has vision of this object
+        /// </summary>
+        /// <returns></returns>
+        public List<TeamId> TeamsWithVision()
+        {
+            List<TeamId> toReturn = new List<TeamId>();
+            foreach(var team in _visibleByTeam.Keys)
+            {
+                if (_visibleByTeam[team])
+                {
+                    toReturn.Add(team);
+                }
+            }
+            return toReturn;
+        }
+
+        /// <summary>
         /// Whether or not the object is visible for the specified player.
         /// <summary>
         /// <param name="userId">The player in relation to which the value is obtained</param>

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -348,9 +348,8 @@ namespace LeagueSandbox.GameServer.GameObjects
         }
 
         /// <summary>
-        /// List of all teams that has vision of this object
+        /// Gets a list of all teams that have vision of this object.
         /// </summary>
-        /// <returns></returns>
         public List<TeamId> TeamsWithVision()
         {
             List<TeamId> toReturn = new List<TeamId>();

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -849,7 +849,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
 
                 if (spellTarget != null
                 && (!spellTarget.IsVisibleByTeam(CastInfo.Owner.Team)
-                || (!spellTarget.Status.HasFlag(StatusFlags.Targetable) && spellTarget is IObjAiBase obj && !obj.CharData.IsUseable)
+                || (!spellTarget.Status.HasFlag(StatusFlags.Targetable) && spellTarget.CharData.IsUseable)
                 || spellTarget.IsDead))
                 {
                     CastInfo.Owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.LostTarget);

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -514,7 +514,11 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
 
             if (!CastInfo.IsAutoAttack)
             {
-                CurrentAmmo--;
+                if(SpellData.MaxAmmo > 1)
+                {
+                    CurrentAmmo--;
+                }
+
                 _game.PacketNotifier.NotifyNPC_CastSpellAns(this);
             }
 

--- a/GameServerLib/Packets/PacketHandlers/HandleUseObject.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleUseObject.cs
@@ -26,10 +26,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             var champion = _playerManager.GetPeerInfo(userId).Champion;
             var target = _game.ObjectManager.GetObjectById(req.TargetNetID) as IAttackableUnit;
 
-            if (target is IObjAiBase obj)
-            {
-                champion.SetSpell(obj.CharData.HeroUseSpell, (byte)SpellSlotType.UseSpellSlot, true);
-            }
+            champion.SetSpell(target.CharData.HeroUseSpell, (byte)SpellSlotType.UseSpellSlot, true);
 
             var s = champion.GetSpell((byte)SpellSlotType.UseSpellSlot);
             var ownerCastingSpell = champion.GetCastSpell();

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -2176,7 +2176,7 @@ namespace PacketDefinitions420
                 Level = obj.Stats.Level,
             };
 
-            if(obj is IChampion ch)
+            if (obj is IChampion ch)
             {
                 // TODO: Typo >:(
                 levelUp.AveliablePoints = ch.SkillPoints;
@@ -2483,7 +2483,7 @@ namespace PacketDefinitions420
 
         public void NotifyS2C_AmmoUpdate(ISpell spell)
         {
-            if(spell.CastInfo.Owner is IChampion ch)
+            if (spell.CastInfo.Owner is IChampion ch)
             {
                 var packet = new S2C_AmmoUpdate
                 {
@@ -2501,7 +2501,7 @@ namespace PacketDefinitions420
                     packet.AmmoRechargeTotalTime = spell.GetAmmoRechageTime();
                 }
 
-              _packetHandlerManager.SendPacket((int)ch.GetPlayerId(), packet.GetBytes(), Channel.CHL_S2C);
+                _packetHandlerManager.SendPacket((int)ch.GetPlayerId(), packet.GetBytes(), Channel.CHL_S2C);
             }
         }
 
@@ -3393,18 +3393,34 @@ namespace PacketDefinitions420
             _packetHandlerManager.BroadcastPacketTeam(team, dm.GetBytes(), Channel.CHL_S2C);
         }
 
-        public void NotifyS2C_UnitSetMinimapIcon(IAttackableUnit unit, string iconCategory = "", bool changeIcon = false, string borderCategory = "", bool changeBorder = false, string borderScriptName = "")
+        public void NotifyS2C_UnitSetMinimapIcon(IAttackableUnit unit, TeamId team)
         {
             var packet = new S2C_UnitSetMinimapIcon
             {
                 UnitNetID = unit.NetId,
-                IconCategory = iconCategory,
-                ChangeIcon = changeIcon,
-                BorderCategory = borderCategory,
-                ChangeBorder = changeBorder,
-                BorderScriptName = borderScriptName
+                IconCategory = unit.IconInfo.IconCategory,
+                ChangeIcon = unit.IconInfo.ChangeIcon,
+                BorderCategory = unit.IconInfo.BorderCategory,
+                ChangeBorder = unit.IconInfo.ChangeBorder,
+                BorderScriptName = unit.IconInfo.BorderScriptName
             };
-            _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
+
+            _packetHandlerManager.BroadcastPacketTeam(team, packet.GetBytes(), Channel.CHL_S2C);
+        }
+
+        public void NotifyS2C_UnitSetMinimapIcon(IAttackableUnit unit)
+        {
+            var packet = new S2C_UnitSetMinimapIcon
+            {
+                UnitNetID = unit.NetId,
+                IconCategory = unit.IconInfo.IconCategory,
+                ChangeIcon = unit.IconInfo.ChangeIcon,
+                BorderCategory = unit.IconInfo.BorderCategory,
+                ChangeBorder = unit.IconInfo.ChangeBorder,
+                BorderScriptName = unit.IconInfo.BorderScriptName
+            };
+
+            _packetHandlerManager.BroadcastPacketVision(unit, packet.GetBytes(), Channel.CHL_S2C);
         }
 
         /// <summary>
@@ -4036,7 +4052,7 @@ namespace PacketDefinitions420
         public void HoldMovementDataUntilWaypointGroupNotification(IAttackableUnit u, int userId, bool useTeleportID = false)
         {
             var data = PacketExtensions.CreateMovementDataNormal(u, _navGrid, useTeleportID);
-            
+
             List<MovementDataNormal> list = null;
             if (!_heldMovementData.TryGetValue(userId, out list))
             {
@@ -4079,7 +4095,7 @@ namespace PacketDefinitions420
         public void HoldReplicationDataUntilOnReplicationNotification(IAttackableUnit u, int userId, bool partial = true)
         {
             var data = u.Replication.GetData(partial);
-            
+
             List<ReplicationData> list = null;
             if (!_heldReplicationData.TryGetValue(userId, out list))
             {


### PR DESCRIPTION
* Introduced IconInfo

* AttackableUnit
    - Moved `CharData` down from `ObjAiBase`.
    - Introduced `IconInfo`.
    - Introduced override functions to `OnSpawn` and `OnEnterVision` in order to properly handle changes to minimap icons

* GameObject
    - Introduced `TeamsWithVision`, which returns all teams that have vision of that unit. This is used to assign all teams that had vision of that unit when it had it's icon updated, in order to prevent repetitive calls every time the unit went in and out of vision.

* Events
    - Fixed an issue where manually removing a triggered listener that has `singleInstance = true` would cause a crash or remove the wrong listener.

* Spells
    - Fixed spells with 1 `MaxAmmo` not getting casted due to `CurrentAmmo` being 0 after the first cast.


* The introduction of IconInfo results in the Unit's icons now being properly updated to the clients when changed before the unit's spawn being notified or or when in the FoW to said clients.