### PR TITLE
Movement Speed² 

### DIFF
--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -224,7 +224,17 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         /// <returns>Float units/sec.</returns>
         float GetMoveSpeed();
+        /// <summary>
+        /// Returns the true movespeed of an unit
+        /// </summary>
+        /// <returns></returns>
         float GetTrueMoveSpeed();
+        /// <summary>
+        /// Manual call to calculate an unit's true speed
+        /// Ideally it won't be used much, just when manually setting base stats of an unit on-spawn.
+        /// Lane Minions would probably use this as they seem to have a lot of manually-set stats.
+        /// </summary>
+        void CalculateTrueMoveSpeed();
         /// <summary>
         /// Teleports this unit to the given position, and optionally repaths from the new position.
         /// </summary>

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -225,16 +225,15 @@ namespace GameServerCore.Domain.GameObjects
         /// <returns>Float units/sec.</returns>
         float GetMoveSpeed();
         /// <summary>
+        /// Processes the unit's move speed
+        /// </summary>
+        void CalculateTrueMoveSpeed();
+        /// <summary>
         /// Returns the true movespeed of an unit
         /// </summary>
         /// <returns></returns>
         float GetTrueMoveSpeed();
-        /// <summary>
-        /// Manual call to calculate an unit's true speed
-        /// Ideally it won't be used much, just when manually setting base stats of an unit on-spawn.
-        /// Lane Minions would probably use this as they seem to have a lot of manually-set stats.
-        /// </summary>
-        void CalculateTrueMoveSpeed();
+        void ClearSlows();
         /// <summary>
         /// Teleports this unit to the given position, and optionally repaths from the new position.
         /// </summary>

--- a/GameServerLib/Chatbox/Commands/ClearSlowsCommand.cs
+++ b/GameServerLib/Chatbox/Commands/ClearSlowsCommand.cs
@@ -1,0 +1,24 @@
+﻿using GameServerCore;
+
+namespace LeagueSandbox.GameServer.Chatbox.Commands
+{
+    public class ClearSlowCommand : ChatCommandBase
+    {
+        private readonly IPlayerManager _playerManager;
+
+        public override string Command => "clearslows";
+        public override string Syntax => $"{Command}";
+
+        public ClearSlowCommand(ChatCommandManager chatCommandManager, Game game)
+            : base(chatCommandManager, game)
+        {
+            _playerManager = game.PlayerManager;
+        }
+
+        public override void Execute(int userId, bool hasReceivedArguments, string arguments = "")
+        {
+            _playerManager.GetPeerInfo(userId).Champion.ClearSlows();
+            ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "Your slows have been cleared!");
+        }
+    }
+}

--- a/GameServerLib/Chatbox/Commands/SpeedCommand.cs
+++ b/GameServerLib/Chatbox/Commands/SpeedCommand.cs
@@ -9,7 +9,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         private readonly IPlayerManager _playerManager;
 
         public override string Command => "speed";
-        public override string Syntax => $"{Command} speed";
+        public override string Syntax => $"{Command} parameter [p (percent), f (flat)] speed";
 
         public SpeedCommand(ChatCommandManager chatCommandManager, Game game)
             : base(chatCommandManager, game)
@@ -26,13 +26,26 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                 ShowSyntax();
             }
 
-            if (float.TryParse(split[1], out var speed))
+            try
             {
                 IStatsModifier stat = new StatsModifier();
-                stat.MoveSpeed.FlatBonus = speed;
+
+                switch (split[1])
+                {
+                    case "p":
+                        stat.MoveSpeed.PercentBonus = float.Parse(split[2]) / 100;
+                        break;
+                    case "f":
+                        stat.MoveSpeed.FlatBonus = float.Parse(split[2]);
+                        break;
+                    default:
+                        ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.ERROR, "Incorrect parameter");
+                        break;
+                }
+
                 _playerManager.GetPeerInfo(userId).Champion.AddStatModifier(stat);
             }
-            else
+            catch
             {
                 ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.ERROR, "Incorrect parameter");
             }

--- a/GameServerLib/Chatbox/Commands/SpeedCommand.cs
+++ b/GameServerLib/Chatbox/Commands/SpeedCommand.cs
@@ -1,4 +1,6 @@
 ﻿using GameServerCore;
+using GameServerCore.Domain.GameObjects;
+using LeagueSandbox.GameServer.GameObjects.Stats;
 
 namespace LeagueSandbox.GameServer.Chatbox.Commands
 {
@@ -26,7 +28,9 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
             if (float.TryParse(split[1], out var speed))
             {
-                _playerManager.GetPeerInfo(userId).Champion.Stats.MoveSpeed.FlatBonus += speed;
+                IStatsModifier stat = new StatsModifier();
+                stat.MoveSpeed.FlatBonus = speed;
+                _playerManager.GetPeerInfo(userId).Champion.AddStatModifier(stat);
             }
             else
             {

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -85,6 +85,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// </summary>
         private List<float> _slows = new List<float>();
         /// <summary>
+        /// The true movement speed of an unit, after mitigation and softcaps
+        /// </summary>
+        private float _trueMoveSpeed;
+        /// <summary>
         /// Waypoints that make up the path a game object is walking in.
         /// </summary>
         public List<Vector2> Waypoints { get; protected set; }
@@ -135,6 +139,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             ParentBuffs = new Dictionary<string, IBuff>();
             BuffList = new List<IBuff>();
             IconInfo = new IconInfo(this);
+            CalculateTrueMoveSpeed();
         }
 
         /// <summary>
@@ -466,6 +471,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
 
             Stats.AddModifier(statModifier);
+            CalculateTrueMoveSpeed();
         }
 
         /// <summary>
@@ -481,6 +487,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
 
             Stats.RemoveModifier(statModifier);
+            CalculateTrueMoveSpeed();
         }
 
         /// <summary>
@@ -831,20 +838,20 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             return GetTrueMoveSpeed();
         }
 
-        public float GetTrueMoveSpeed()
+        public void CalculateTrueMoveSpeed()
         {
             float speed = Stats.MoveSpeed.Total;
-            if (speed > 490)
+            if (speed > 490.0f)
             {
-                speed = speed * 0.5f + 230;
+                speed = speed * 0.5f + 230.0f;
             }
-            else if (speed >= 415)
+            else if (speed >= 415.0f)
             {
-                speed = speed * 0.8f + 83;
+                speed = speed * 0.8f + 83.0f;
             }
-            else if (speed < 220)
+            else if (speed < 220.0f)
             {
-                speed = speed * 0.5f + 110;
+                speed = speed * 0.5f + 110.0f;
             }
 
             speed = speed * (1 + Stats.MoveSpeed.PercentBonus) * (1 + Stats.MultiplicativeSpeedBonus);
@@ -855,7 +862,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 speed *= 1 - (_slows.Max(z => z) * (1 - Stats.SlowResistPercent));
             }
 
-            return speed;
+            _trueMoveSpeed = speed;
+        }
+
+        public float GetTrueMoveSpeed()
+        {
+            return _trueMoveSpeed;
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -838,9 +838,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             return GetTrueMoveSpeed();
         }
 
+        /// <summary>
+        /// Processes the unit's move speed
+        /// </summary>
         public void CalculateTrueMoveSpeed()
         {
-            float speed = Stats.MoveSpeed.Total;
+            float speed = Stats.MoveSpeed.BaseValue + Stats.MoveSpeed.FlatBonus;
             if (speed > 490.0f)
             {
                 speed = speed * 0.5f + 230.0f;
@@ -859,7 +862,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             if (_slows.Count > 0)
             {
                 //Only takes into account the highest slow
-                speed *= 1 - (_slows.Max(z => z) * (1 - Stats.SlowResistPercent));
+                speed *= 1 + _slows.Max(z => z) * (1 - Stats.SlowResistPercent);
             }
 
             _trueMoveSpeed = speed;
@@ -868,6 +871,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public float GetTrueMoveSpeed()
         {
             return _trueMoveSpeed;
+        }
+
+        public void ClearSlows()
+        {
+            _slows.Clear();
+            CalculateTrueMoveSpeed();
         }
 
         /// <summary>

--- a/GameServerLib/Scripting/CSharp/EmptyMapScript.cs
+++ b/GameServerLib/Scripting/CSharp/EmptyMapScript.cs
@@ -17,54 +17,9 @@ namespace MapScripts
 
         public virtual IGlobalData GlobalData { get; set; } = new GlobalData();
         public bool HasFirstBloodHappened { get; set; } = false;
-        public long NextSpawnTime { get; set; } = 90 * 1000;
         public string LaneMinionAI { get; set; } = "LaneMinionAI";
-        public string LaneTurretAI { get; set; } = "TurretAI";
 
         public Dictionary<TeamId, Dictionary<int, Dictionary<int, Vector2>>> PlayerSpawnPoints { get; }
-
-        //Tower type enumeration might vary slightly from map to map, so we set that up here
-        public TurretType GetTurretType(int trueIndex, LaneID lane, TeamId teamId)
-        {
-            return TurretType.OUTER_TURRET;
-        }
-
-        //Nexus models
-        public Dictionary<TeamId, string> NexusModels { get; set; } = new Dictionary<TeamId, string>
-        {
-            {TeamId.TEAM_BLUE, "OrderNexus" },
-            {TeamId.TEAM_PURPLE, "ChaosNexus" }
-        };
-        //Inhib models
-        public Dictionary<TeamId, string> InhibitorModels { get; set; } = new Dictionary<TeamId, string>
-        {
-            {TeamId.TEAM_BLUE, "OrderInhibitor" },
-            {TeamId.TEAM_PURPLE, "ChaosInhibitor" }
-        };
-        //Tower Models
-        public Dictionary<TeamId, Dictionary<TurretType, string>> TowerModels { get; set; } = new Dictionary<TeamId, Dictionary<TurretType, string>>
-        {
-            {TeamId.TEAM_BLUE, new Dictionary<TurretType, string>
-            {
-                {TurretType.OUTER_TURRET, "OrderTurretNormal" },
-                {TurretType.FOUNTAIN_TURRET, "OrderTurretShrine" }
-
-            } },
-            {TeamId.TEAM_PURPLE, new Dictionary<TurretType, string>
-            {
-                {TurretType.OUTER_TURRET, "ChaosTurretWorm" },
-                {TurretType.FOUNTAIN_TURRET, "ChaosTurretShrine" }
-            } }
-        };
-
-        //Turret Items
-        public Dictionary<TurretType, int[]> TurretItems { get; set; } = new Dictionary<TurretType, int[]>
-        {
-            { TurretType.OUTER_TURRET, new[] { 1500, 1501, 1502, 1503 } },
-        };
-
-        //List of every path minions will take, separated by team and lane
-        public Dictionary<LaneID, List<Vector2>> MinionPaths { get; set; } = new Dictionary<LaneID, List<Vector2>>();
 
         //List of every wave type
         public Dictionary<string, List<MinionSpawnType>> MinionWaveTypes = new Dictionary<string, List<MinionSpawnType>>
@@ -75,15 +30,8 @@ namespace MapScripts
             MinionSpawnType.MINION_TYPE_MELEE,
             MinionSpawnType.MINION_TYPE_CASTER,
             MinionSpawnType.MINION_TYPE_CASTER,
-            MinionSpawnType.MINION_TYPE_CASTER }
-        }
-        };
-
-        //Here you setup the conditions of which wave will be spawned
-        public Tuple<int, List<MinionSpawnType>> MinionWaveToSpawn(float gameTime, int cannonMinionCount, bool isInhibitorDead, bool areAllInhibitorsDead)
-        {
-            return new Tuple<int, List<MinionSpawnType>>(0, MinionWaveTypes["RegularMinionWave"]);
-        }
+            MinionSpawnType.MINION_TYPE_CASTER 
+        }}};
 
         //Minion models for this map
         public Dictionary<TeamId, Dictionary<MinionSpawnType, string>> MinionModels { get; set; } = new Dictionary<TeamId, Dictionary<MinionSpawnType, string>>
@@ -104,17 +52,14 @@ namespace MapScripts
             MapScriptMetadata.MinionSpawnEnabled = IsMinionSpawnEnabled();
             AddSurrender(1200000.0f, 300000.0f, 30.0f);
         }
+
         public void OnMatchStart()
         {
         }
+
         //This function gets executed every server tick
         public void Update(float diff)
         {
-        }
-
-        public float GetGoldFor(IAttackableUnit u)
-        {
-            return 0;
         }
 
         public void SpawnAllCamps()
@@ -124,36 +69,6 @@ namespace MapScripts
         public Vector2 GetFountainPosition(TeamId team)
         {
             return Vector2.Zero;
-        }
-
-        public float GetExperienceFor(IAttackableUnit u)
-        {
-            return 0.0f;
-        }
-
-        public void SetMinionStats(ILaneMinion m)
-        {
-            // Same for all minions
-            m.Stats.MoveSpeed.BaseValue = 325.0f;
-
-            switch (m.MinionSpawnType)
-            {
-                case MinionSpawnType.MINION_TYPE_MELEE:
-                    m.Stats.CurrentHealth = 475.0f;
-                    m.Stats.HealthPoints.BaseValue = 475.0f;
-                    m.Stats.AttackDamage.BaseValue = 12.0f;
-                    m.Stats.Range.BaseValue = 180.0f;
-                    m.Stats.AttackSpeedFlat = 1.250f;
-                    m.IsMelee = true;
-                    break;
-                case MinionSpawnType.MINION_TYPE_CASTER:
-                    m.Stats.CurrentHealth = 279.0f;
-                    m.Stats.HealthPoints.BaseValue = 279.0f; ;
-                    m.Stats.AttackDamage.BaseValue = 23.0f;
-                    m.Stats.Range.BaseValue = 600.0f;
-                    m.Stats.AttackSpeedFlat = 0.670f;
-                    break;
-            }
         }
     }
 }


### PR DESCRIPTION
* Just a Cleanup of my previous PR
* The True Move Speed is no longer calculated every single Replication call, it is now re-calculated only when a `StatsModifier` is applied or removed.
* The Speed command now accepts an extra parameter with the following valid values `[f]lat` and `[p]ercent`, it also now uses `StatsModifiers` instead of direct stat changes.
* Fixed a few wrong values and signs in the move speed calculation process
* Added a command "`clearslows`" to clear all slows applied on you, since they can't be so easily removed when added through commands
* Removed a bunch of deprecated functions from `EmptyMapScript`