### PR TITLE
Movement Speed³

### DIFF
--- a/Content/LeagueSandbox-Scripts/Maps/Map1/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map1/LevelScriptObjects.cs
@@ -293,8 +293,12 @@ namespace MapScripts.Map1
             {
                 var teamId = nexusObj.GetTeamID();
                 var position = new Vector2(nexusObj.CentralPoint.X, nexusObj.CentralPoint.Z);
+                var nexusStats = new Stats();
+                nexusStats.HealthPoints.BaseValue = 5500.0f;
+                nexusStats.CurrentHealth = nexusStats.HealthPoints.BaseValue;
 
-                var nexus = CreateNexus(nexusObj.Name, NexusModels[teamId], position, teamId, 353, 1700);
+                var nexus = CreateNexus(nexusObj.Name, NexusModels[teamId], position, teamId, 353, 1700, nexusStats);
+
                 ApiEventManager.OnDeath.AddListener(nexus, nexus, OnNexusDeath, true);
                 NexusList.Add(nexus);
                 AddObject(nexus);
@@ -305,12 +309,13 @@ namespace MapScripts.Map1
                 var teamId = inhibitorObj.GetTeamID();
                 var lane = inhibitorObj.GetLaneID();
                 var position = new Vector2(inhibitorObj.CentralPoint.X, inhibitorObj.CentralPoint.Z);
+                var inhibitorStats = new Stats();
+                inhibitorStats.HealthPoints.BaseValue = 4000.0f;
+                inhibitorStats.CurrentHealth = inhibitorStats.HealthPoints.BaseValue;
 
-                var inhibitor = CreateInhibitor(inhibitorObj.Name, InhibitorModels[teamId], position, teamId, lane, 214, 0);
+                var inhibitor = CreateInhibitor(inhibitorObj.Name, InhibitorModels[teamId], position, teamId, lane, 214, 0, inhibitorStats);
                 ApiEventManager.OnDeath.AddListener(inhibitor, inhibitor, OnInhibitorDeath, false);
                 inhibitor.RespawnTime = 240.0f;
-                inhibitor.Stats.CurrentHealth = 4000.0f;
-                inhibitor.Stats.HealthPoints.BaseValue = 4000.0f;
                 InhibitorList[teamId][lane] = inhibitor;
                 AddObject(inhibitor);
             }

--- a/Content/LeagueSandbox-Scripts/Maps/Map10/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map10/LevelScriptObjects.cs
@@ -275,8 +275,11 @@ namespace MapScripts.Map10
             {
                 var teamId = nexusObj.GetTeamID();
                 var position = new Vector2(nexusObj.CentralPoint.X, nexusObj.CentralPoint.Z);
+                var nexusStats = new Stats();
+                nexusStats.HealthPoints.BaseValue = 5500.0f;
+                nexusStats.CurrentHealth = nexusStats.HealthPoints.BaseValue;
 
-                var nexus = CreateNexus(nexusObj.Name, NexusModels[teamId], position, teamId, 353, 1700);
+                var nexus = CreateNexus(nexusObj.Name, NexusModels[teamId], position, teamId, 353, 1700, nexusStats);
                 ApiEventManager.OnDeath.AddListener(nexus, nexus, OnNexusDeath, true);
                 NexusList.Add(nexus);
                 AddObject(nexus);
@@ -287,12 +290,13 @@ namespace MapScripts.Map10
                 var teamId = inhibitorObj.GetTeamID();
                 var lane = inhibitorObj.GetLaneID();
                 var position = new Vector2(inhibitorObj.CentralPoint.X, inhibitorObj.CentralPoint.Z);
+                var inhibitorStats = new Stats();
+                inhibitorStats.HealthPoints.BaseValue = 4000.0f;
+                inhibitorStats.CurrentHealth = inhibitorStats.HealthPoints.BaseValue;
 
-                var inhibitor = CreateInhibitor(inhibitorObj.Name, InhibitorModels[teamId], position, teamId, lane, 214, 0);
+                var inhibitor = CreateInhibitor(inhibitorObj.Name, InhibitorModels[teamId], position, teamId, lane, 214, 0, inhibitorStats);
                 ApiEventManager.OnDeath.AddListener(inhibitor, inhibitor, OnInhibitorDeath, false);
                 inhibitor.RespawnTime = 240.0f;
-                inhibitor.Stats.CurrentHealth = 4000.0f;
-                inhibitor.Stats.HealthPoints.BaseValue = 4000.0f;
                 InhibitorList[teamId][lane] = inhibitor;
                 AddObject(inhibitor);
             }

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScriptObjects.cs
@@ -327,13 +327,9 @@ namespace MapScripts.Map11
             CreateInhib("Barracks_T2_C1", "SRUAP_ChaosInhibitor", new Vector2(11598.124f, 11667.8125f), TeamId.TEAM_PURPLE, LaneID.MIDDLE);
             CreateInhib("Barracks_T2_R1", "SRUAP_ChaosInhibitor", new Vector2(13604.601f, 11316.011f), TeamId.TEAM_PURPLE, LaneID.BOTTOM);
 
-            //Nexus Stats
-            var nexusStats = new Stats();
-            nexusStats.HealthPoints.BaseValue = 5500.0f;
-            nexusStats.CurrentHealth = nexusStats.HealthPoints.BaseValue;
-
             //Create Nexus
-            NexusList = new List<INexus> { { CreateNexus("HQ_T1", "SRUAP_OrderNexus", new Vector2(1551.3535f, 1659.627f), TeamId.TEAM_BLUE, 353, 1700, nexusStats) }, { CreateNexus("HQ_T2", "SRUAP_ChaosNexus", new Vector2(13142.73f, 12964.941f), TeamId.TEAM_PURPLE, 353, 1700, nexusStats) } };
+            CreateNex("HQ_T1", "SRUAP_OrderNexus", new Vector2(1551.3535f, 1659.627f), TeamId.TEAM_BLUE);
+            CreateNex("HQ_T2", "SRUAP_ChaosNexus", new Vector2(13142.73f, 12964.941f), TeamId.TEAM_PURPLE);
 
             foreach (var team in InhibitorList.Keys)
             {
@@ -386,6 +382,15 @@ namespace MapScripts.Map11
             inhibitorStats.HealthPoints.BaseValue = 4000.0f;
             inhibitorStats.CurrentHealth = inhibitorStats.HealthPoints.BaseValue;
             InhibitorList[team][laneID] = CreateInhibitor(name, model, position, team, laneID, 214, 0, inhibitorStats);
+        }
+
+        public static void CreateNex(string name, string model, Vector2 position, TeamId team)
+        {
+            var nexusStats = new Stats();
+            nexusStats.HealthPoints.BaseValue = 5500.0f;
+            nexusStats.CurrentHealth = nexusStats.HealthPoints.BaseValue;
+
+            NexusList.Add(CreateNexus(name, model, position, team, 353, 1700, nexusStats));
         }
 
         static void LoadProtection()

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScriptObjects.cs
@@ -20,7 +20,7 @@ namespace MapScripts.Map11
         public static Dictionary<LaneID, List<Vector2>> MinionPaths = new Dictionary<LaneID, List<Vector2>> { { LaneID.TOP, new List<Vector2>() }, { LaneID.BOTTOM, new List<Vector2>() } };
         public static Dictionary<TeamId, bool> AllInhibitorsAreDead = new Dictionary<TeamId, bool> { { TeamId.TEAM_BLUE, false }, { TeamId.TEAM_PURPLE, false } };
         static Dictionary<TeamId, Dictionary<IInhibitor, float>> DeadInhibitors = new Dictionary<TeamId, Dictionary<IInhibitor, float>> { { TeamId.TEAM_BLUE, new Dictionary<IInhibitor, float>() }, { TeamId.TEAM_PURPLE, new Dictionary<IInhibitor, float>() } };
-        static List<INexus> NexusList = new List<INexus>();
+        static List<INexus> NexusList;
         static string LaneTurretAI = "TurretAI";
 
         static Dictionary<TeamId, Dictionary<LaneID, List<ILaneTurret>>> TurretList = new Dictionary<TeamId, Dictionary<LaneID, List<ILaneTurret>>>
@@ -314,19 +314,29 @@ namespace MapScripts.Map11
             var redTopInhibtorTurret = CreateLaneTurret("Turret_T2_L_01_A", "SRUAP_Turret_Chaos3", new Vector2(10481.091f, 13650.535f), TeamId.TEAM_PURPLE, TurretType.INHIBITOR_TURRET, LaneID.TOP, LaneTurretAI);
             TurretList[TeamId.TEAM_PURPLE][LaneID.TOP].AddRange(new List<ILaneTurret> { { redTopOuterTurret }, { redTopInnerTurret }, { redTopInhibtorTurret } });
 
+            //Inhibitor Stats
+            var inhibitorStats = new Stats();
+            inhibitorStats.HealthPoints.BaseValue = 4000.0f;
+            inhibitorStats.CurrentHealth = inhibitorStats.HealthPoints.BaseValue;
+
             //Blue Team Inhibitors
-            InhibitorList[TeamId.TEAM_BLUE][LaneID.TOP] = CreateInhibitor("Barracks_T1_L1", "SRUAP_OrderInhibitor", new Vector2(1171.8285f, 3571.784f), TeamId.TEAM_BLUE, LaneID.TOP, 214, 0);
-            InhibitorList[TeamId.TEAM_BLUE][LaneID.MIDDLE] = CreateInhibitor("Barracks_T1_C1", "SRUAP_OrderInhibitor", new Vector2(3203.0286f, 3208.784f), TeamId.TEAM_BLUE, LaneID.MIDDLE, 214, 0);
-            InhibitorList[TeamId.TEAM_BLUE][LaneID.BOTTOM] = CreateInhibitor("Barracks_T1_R1", "SRUAP_OrderInhibitor", new Vector2(3452.5286f, 1236.884f), TeamId.TEAM_BLUE, LaneID.BOTTOM, 214, 0);
+            InhibitorList[TeamId.TEAM_BLUE][LaneID.TOP] = CreateInhibitor("Barracks_T1_L1", "SRUAP_OrderInhibitor", new Vector2(1171.8285f, 3571.784f), TeamId.TEAM_BLUE, LaneID.TOP, 214, 0, inhibitorStats);
+            InhibitorList[TeamId.TEAM_BLUE][LaneID.MIDDLE] = CreateInhibitor("Barracks_T1_C1", "SRUAP_OrderInhibitor", new Vector2(3203.0286f, 3208.784f), TeamId.TEAM_BLUE, LaneID.MIDDLE, 214, 0, inhibitorStats);
+            InhibitorList[TeamId.TEAM_BLUE][LaneID.BOTTOM] = CreateInhibitor("Barracks_T1_R1", "SRUAP_OrderInhibitor", new Vector2(3452.5286f, 1236.884f), TeamId.TEAM_BLUE, LaneID.BOTTOM, 214, 0, inhibitorStats);
 
 
             //Red Team Inhibitors
-            InhibitorList[TeamId.TEAM_PURPLE][LaneID.TOP] = CreateInhibitor("Barracks_T2_L1", "SRUAP_ChaosInhibitor", new Vector2(11261.665f, 13676.563f), TeamId.TEAM_PURPLE, LaneID.TOP, 214, 0);
-            InhibitorList[TeamId.TEAM_PURPLE][LaneID.MIDDLE] = CreateInhibitor("Barracks_T2_C1", "SRUAP_ChaosInhibitor", new Vector2(11598.124f, 11667.8125f), TeamId.TEAM_PURPLE, LaneID.MIDDLE, 214, 0);
-            InhibitorList[TeamId.TEAM_PURPLE][LaneID.BOTTOM] = CreateInhibitor("Barracks_T2_R1", "SRUAP_ChaosInhibitor", new Vector2(13604.601f, 11316.011f), TeamId.TEAM_PURPLE, LaneID.BOTTOM, 214, 0);
+            InhibitorList[TeamId.TEAM_PURPLE][LaneID.TOP] = CreateInhibitor("Barracks_T2_L1", "SRUAP_ChaosInhibitor", new Vector2(11261.665f, 13676.563f), TeamId.TEAM_PURPLE, LaneID.TOP, 214, 0, inhibitorStats);
+            InhibitorList[TeamId.TEAM_PURPLE][LaneID.MIDDLE] = CreateInhibitor("Barracks_T2_C1", "SRUAP_ChaosInhibitor", new Vector2(11598.124f, 11667.8125f), TeamId.TEAM_PURPLE, LaneID.MIDDLE, 214, 0, inhibitorStats);
+            InhibitorList[TeamId.TEAM_PURPLE][LaneID.BOTTOM] = CreateInhibitor("Barracks_T2_R1", "SRUAP_ChaosInhibitor", new Vector2(13604.601f, 11316.011f), TeamId.TEAM_PURPLE, LaneID.BOTTOM, 214, 0, inhibitorStats);
+
+            //Nexus Stats
+            var nexusStats = new Stats();
+            nexusStats.HealthPoints.BaseValue = 5500.0f;
+            nexusStats.CurrentHealth = nexusStats.HealthPoints.BaseValue;
 
             //Create Nexus
-            NexusList.AddRange(new List<INexus> { { CreateNexus("HQ_T1", "SRUAP_OrderNexus", new Vector2(1551.3535f, 1659.627f), TeamId.TEAM_BLUE, 353, 1700) }, { CreateNexus("HQ_T2", "SRUAP_ChaosNexus", new Vector2(13142.73f, 12964.941f), TeamId.TEAM_PURPLE, 353, 1700) } });
+            NexusList = new List<INexus> { { CreateNexus("HQ_T1", "SRUAP_OrderNexus", new Vector2(1551.3535f, 1659.627f), TeamId.TEAM_BLUE, 353, 1700, nexusStats) }, { CreateNexus("HQ_T2", "SRUAP_ChaosNexus", new Vector2(13142.73f, 12964.941f), TeamId.TEAM_PURPLE, 353, 1700, nexusStats) } };
 
             foreach (var team in InhibitorList.Keys)
             {
@@ -334,8 +344,6 @@ namespace MapScripts.Map11
                 {
                     ApiEventManager.OnDeath.AddListener(inhibitor, inhibitor, OnInhibitorDeath, false);
                     inhibitor.RespawnTime = 300.0f;
-                    inhibitor.Stats.CurrentHealth = 4000.0f;
-                    inhibitor.Stats.HealthPoints.BaseValue = 4000.0f;
                 }
             }
             foreach (var nexus in NexusList)

--- a/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScriptObjects.cs
@@ -314,21 +314,18 @@ namespace MapScripts.Map11
             var redTopInhibtorTurret = CreateLaneTurret("Turret_T2_L_01_A", "SRUAP_Turret_Chaos3", new Vector2(10481.091f, 13650.535f), TeamId.TEAM_PURPLE, TurretType.INHIBITOR_TURRET, LaneID.TOP, LaneTurretAI);
             TurretList[TeamId.TEAM_PURPLE][LaneID.TOP].AddRange(new List<ILaneTurret> { { redTopOuterTurret }, { redTopInnerTurret }, { redTopInhibtorTurret } });
 
-            //Inhibitor Stats
-            var inhibitorStats = new Stats();
-            inhibitorStats.HealthPoints.BaseValue = 4000.0f;
-            inhibitorStats.CurrentHealth = inhibitorStats.HealthPoints.BaseValue;
+
 
             //Blue Team Inhibitors
-            InhibitorList[TeamId.TEAM_BLUE][LaneID.TOP] = CreateInhibitor("Barracks_T1_L1", "SRUAP_OrderInhibitor", new Vector2(1171.8285f, 3571.784f), TeamId.TEAM_BLUE, LaneID.TOP, 214, 0, inhibitorStats);
-            InhibitorList[TeamId.TEAM_BLUE][LaneID.MIDDLE] = CreateInhibitor("Barracks_T1_C1", "SRUAP_OrderInhibitor", new Vector2(3203.0286f, 3208.784f), TeamId.TEAM_BLUE, LaneID.MIDDLE, 214, 0, inhibitorStats);
-            InhibitorList[TeamId.TEAM_BLUE][LaneID.BOTTOM] = CreateInhibitor("Barracks_T1_R1", "SRUAP_OrderInhibitor", new Vector2(3452.5286f, 1236.884f), TeamId.TEAM_BLUE, LaneID.BOTTOM, 214, 0, inhibitorStats);
+            CreateInhib("Barracks_T1_L1", "SRUAP_OrderInhibitor", new Vector2(1171.8285f, 3571.784f), TeamId.TEAM_BLUE, LaneID.TOP);
+            CreateInhib("Barracks_T1_C1", "SRUAP_OrderInhibitor", new Vector2(3203.0286f, 3208.784f), TeamId.TEAM_BLUE, LaneID.MIDDLE);
+            CreateInhib("Barracks_T1_R1", "SRUAP_OrderInhibitor", new Vector2(3452.5286f, 1236.884f), TeamId.TEAM_BLUE, LaneID.BOTTOM);
 
 
             //Red Team Inhibitors
-            InhibitorList[TeamId.TEAM_PURPLE][LaneID.TOP] = CreateInhibitor("Barracks_T2_L1", "SRUAP_ChaosInhibitor", new Vector2(11261.665f, 13676.563f), TeamId.TEAM_PURPLE, LaneID.TOP, 214, 0, inhibitorStats);
-            InhibitorList[TeamId.TEAM_PURPLE][LaneID.MIDDLE] = CreateInhibitor("Barracks_T2_C1", "SRUAP_ChaosInhibitor", new Vector2(11598.124f, 11667.8125f), TeamId.TEAM_PURPLE, LaneID.MIDDLE, 214, 0, inhibitorStats);
-            InhibitorList[TeamId.TEAM_PURPLE][LaneID.BOTTOM] = CreateInhibitor("Barracks_T2_R1", "SRUAP_ChaosInhibitor", new Vector2(13604.601f, 11316.011f), TeamId.TEAM_PURPLE, LaneID.BOTTOM, 214, 0, inhibitorStats);
+            CreateInhib("Barracks_T2_L1", "SRUAP_ChaosInhibitor", new Vector2(11261.665f, 13676.563f), TeamId.TEAM_PURPLE, LaneID.TOP);
+            CreateInhib("Barracks_T2_C1", "SRUAP_ChaosInhibitor", new Vector2(11598.124f, 11667.8125f), TeamId.TEAM_PURPLE, LaneID.MIDDLE);
+            CreateInhib("Barracks_T2_R1", "SRUAP_ChaosInhibitor", new Vector2(13604.601f, 11316.011f), TeamId.TEAM_PURPLE, LaneID.BOTTOM);
 
             //Nexus Stats
             var nexusStats = new Stats();
@@ -381,6 +378,14 @@ namespace MapScripts.Map11
                     AddObject(turret);
                 }
             }
+        }
+
+        public static void CreateInhib(string name, string model, Vector2 position, TeamId team, LaneID laneID)
+        {
+            var inhibitorStats = new Stats();
+            inhibitorStats.HealthPoints.BaseValue = 4000.0f;
+            inhibitorStats.CurrentHealth = inhibitorStats.HealthPoints.BaseValue;
+            InhibitorList[team][laneID] = CreateInhibitor(name, model, position, team, laneID, 214, 0, inhibitorStats);
         }
 
         static void LoadProtection()

--- a/Content/LeagueSandbox-Scripts/Maps/Map12/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map12/LevelScriptObjects.cs
@@ -242,6 +242,9 @@ namespace MapScripts.Map12
             {
                 var teamId = nexusObj.GetTeamID();
                 var position = new Vector2(nexusObj.CentralPoint.X, nexusObj.CentralPoint.Z);
+                var nexusStats = new Stats();
+                nexusStats.HealthPoints.BaseValue = 5500.0f;
+                nexusStats.CurrentHealth = nexusStats.HealthPoints.BaseValue;
 
                 var nexus = CreateNexus(nexusObj.Name, NexusModels[teamId], position, teamId, 353, 1700);
                 ApiEventManager.OnDeath.AddListener(nexus, nexus, OnNexusDeath, true);
@@ -254,12 +257,13 @@ namespace MapScripts.Map12
                 var teamId = inhibitorObj.GetTeamID();
                 var lane = inhibitorObj.GetLaneID();
                 var position = new Vector2(inhibitorObj.CentralPoint.X, inhibitorObj.CentralPoint.Z);
+                var inhibitorStats = new Stats();
+                inhibitorStats.HealthPoints.BaseValue = 4000.0f;
+                inhibitorStats.CurrentHealth = inhibitorStats.HealthPoints.BaseValue;
 
                 var inhibitor = CreateInhibitor(inhibitorObj.Name, InhibitorModels[teamId], position, teamId, lane, 214, 0);
                 ApiEventManager.OnDeath.AddListener(inhibitor, inhibitor, OnInhibitorDeath, false);
                 inhibitor.RespawnTime = 300.0f;
-                inhibitor.Stats.CurrentHealth = 4000.0f;
-                inhibitor.Stats.HealthPoints.BaseValue = 4000.0f;
                 InhibitorList.Add(teamId, inhibitor);
                 AddObject(inhibitor);
             }

--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -69,7 +69,7 @@ namespace LeagueSandbox.GameServer.API
         /// <returns></returns>
         public static INexus CreateNexus(string name, string model, Vector2 position, TeamId team, int nexusRadius, int sightRange)
         {
-            return new Nexus(_game, model, team, nexusRadius, position, sightRange, Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000);
+            return new Nexus(_game, model, team, nexusRadius, position, sightRange, null, Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace LeagueSandbox.GameServer.API
         /// <returns></returns>
         public static IInhibitor CreateInhibitor(string name, string model, Vector2 position, TeamId team, LaneID lane, int inhibRadius, int sightRange)
         {
-            return new Inhibitor(_game, model, lane, team, inhibRadius, position, sightRange, Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000);
+            return new Inhibitor(_game, model, lane, team, inhibRadius, position, sightRange, null, Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000);
         }
 
         public static MapObject CreateLaneMinionSpawnPos(string name, Vector3 position)
@@ -109,7 +109,7 @@ namespace LeagueSandbox.GameServer.API
         /// <returns></returns>
         public static ILaneTurret CreateLaneTurret(string name, string model, Vector2 position, TeamId team, TurretType turretType, LaneID lane, string aiScript, MapObject mapObject = default, uint netId = 0)
         {
-            return new LaneTurret(_game, name, model, position, team, turretType, netId, lane, mapObject, aiScript);
+            return new LaneTurret(_game, name, model, position, team, turretType, netId, lane, mapObject, null, aiScript);
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace LeagueSandbox.GameServer.API
                 return;
             }
 
-            var m = new LaneMinion(_game, list[minionNo], position, barracksName, waypoints, _map.MapScript.MinionModels[team][list[minionNo]], 0, team, _map.MapScript.LaneMinionAI);
+            var m = new LaneMinion(_game, list[minionNo], position, barracksName, waypoints, _map.MapScript.MinionModels[team][list[minionNo]], 0, team, null, _map.MapScript.LaneMinionAI);
             _game.ObjectManager.AddObject(m);
         }
 
@@ -164,10 +164,10 @@ namespace LeagueSandbox.GameServer.API
         public static IMinion CreateMinion(
             string name, string model, Vector2 position, IObjAiBase owner = null, uint netId = 0,
             TeamId team = TeamId.TEAM_NEUTRAL, int skinId = 0, bool ignoreCollision = false,
-            bool isTargetable = false, bool isWard = false,string aiScript = "", int damageBonus = 0,
+            bool isTargetable = false, bool isWard = false, string aiScript = "", int damageBonus = 0,
             int healthBonus = 0, int initialLevel = 1)
         {
-            var m = new Minion(_game, owner, position, model, name, netId, team, skinId, ignoreCollision, isTargetable, isWard, null, aiScript, damageBonus, healthBonus, initialLevel);
+            var m = new Minion(_game, owner, position, model, name, netId, team, skinId, ignoreCollision, isTargetable, isWard, null, null, aiScript, damageBonus, healthBonus, initialLevel);
             _game.ObjectManager.AddObject(m);
             return m;
         }
@@ -178,7 +178,7 @@ namespace LeagueSandbox.GameServer.API
             bool isTargetable = false, bool isWard = false, string aiScript = "", int damageBonus = 0,
             int healthBonus = 0, int initialLevel = 1)
         {
-            return new Minion(_game, null, position, model, name, netId, team, skinId, ignoreCollision, isTargetable, isWard, null, aiScript, damageBonus, healthBonus, initialLevel);
+            return new Minion(_game, null, position, model, name, netId, team, skinId, ignoreCollision, isTargetable, isWard, null, null, aiScript, damageBonus, healthBonus, initialLevel);
         }
 
         /// <summary>
@@ -234,7 +234,7 @@ namespace LeagueSandbox.GameServer.API
             int damageBonus = 0, int healthBonus = 0, int initialLevel = 1
         )
         {
-            return new Monster(_game, name, model, position, faceDirection, monsterCamp, team, netId, spawnAnimation, isTargetable, ignoresCollision, aiScript, damageBonus, healthBonus, initialLevel);
+            return new Monster(_game, name, model, position, faceDirection, monsterCamp, team, netId, spawnAnimation, isTargetable, ignoresCollision, null, aiScript, damageBonus, healthBonus, initialLevel);
         }
 
         /// <summary>

--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -67,9 +67,9 @@ namespace LeagueSandbox.GameServer.API
         /// <param name="nexusRadius"></param>
         /// <param name="sightRange"></param>
         /// <returns></returns>
-        public static INexus CreateNexus(string name, string model, Vector2 position, TeamId team, int nexusRadius, int sightRange)
+        public static INexus CreateNexus(string name, string model, Vector2 position, TeamId team, int nexusRadius, int sightRange, IStats stats = null)
         {
-            return new Nexus(_game, model, team, nexusRadius, position, sightRange, null, Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000);
+            return new Nexus(_game, model, team, nexusRadius, position, sightRange, stats, Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000);
         }
 
         /// <summary>
@@ -83,9 +83,9 @@ namespace LeagueSandbox.GameServer.API
         /// <param name="inhibRadius"></param>
         /// <param name="sightRange"></param>
         /// <returns></returns>
-        public static IInhibitor CreateInhibitor(string name, string model, Vector2 position, TeamId team, LaneID lane, int inhibRadius, int sightRange)
+        public static IInhibitor CreateInhibitor(string name, string model, Vector2 position, TeamId team, LaneID lane, int inhibRadius, int sightRange, IStats stats = null)
         {
-            return new Inhibitor(_game, model, lane, team, inhibRadius, position, sightRange, null, Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000);
+            return new Inhibitor(_game, model, lane, team, inhibRadius, position, sightRange, stats, Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000);
         }
 
         public static MapObject CreateLaneMinionSpawnPos(string name, Vector3 position)

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -1126,13 +1126,13 @@ namespace LeagueSandbox.GameServer.API
             int skinId = 0,
             bool cloneInventory = true,
             bool showMinimapIfClone = true,
-            bool disallowPlayerControl =false,
+            bool disallowPlayerControl = false,
             bool doFade = false,
             bool isClone = true,
             string aiScript = "Pet"
         )
         {
-            return new Pet(_game, owner, spell, position, name, model, buffName, lifeTime, skinId, cloneInventory, showMinimapIfClone, disallowPlayerControl, doFade, isClone, aiScript);
+            return new Pet(_game, owner, spell, position, name, model, buffName, lifeTime, skinId, null, cloneInventory, showMinimapIfClone, disallowPlayerControl, doFade, isClone, aiScript);
         }
 
         public static float GetPetReturnRadius()

--- a/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
@@ -51,8 +51,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             LaneID lane = LaneID.NONE,
             MapObject mapObject = default,
             int skinId = 0,
+            IStats stats = null,
             string aiScript = ""
-        ) : base(game, model, new Stats.Stats(), position: position, visionRadius: 800, skinId: skinId, netId: netId, team: team, aiScript: aiScript)
+        ) : base(game, model, position: position, visionRadius: 800, skinId: skinId, netId: netId, team: team, stats: stats, aiScript: aiScript)
         {
             ParentNetId = Crc32Algorithm.Compute(Encoding.UTF8.GetBytes(name)) | 0xFF000000;
             Name = name;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -50,8 +50,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                         ITalentInventory talentInventory,
                         ClientInfo clientInfo,
                         uint netId = 0,
-                        TeamId team = TeamId.TEAM_BLUE)
-            : base(game, model, new Stats.Stats(), 30, new Vector2(), 1200, clientInfo.SkinNo, netId, team)
+                        TeamId team = TeamId.TEAM_BLUE,
+                        IStats stats = null)
+            : base(game, model, 30, new Vector2(), 1200, clientInfo.SkinNo, netId, team, stats)
         {
             _playerId = playerId;
             _playerTeamSpecialId = playerTeamSpecialId;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/LaneMinion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/LaneMinion.cs
@@ -30,8 +30,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             string model,
             uint netId = 0,
             TeamId team = TeamId.TEAM_BLUE,
+            IStats stats = null,
             string AiScript = ""
-        ) : base(game, null, new Vector2(), model, model, netId, team, aiScript: AiScript)
+        ) : base(game, null, new Vector2(), model, model, netId, team, stats: stats, aiScript: AiScript)
         {
             IsLaneMinion = true;
             MinionSpawnType = spawnType;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
@@ -20,8 +20,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             uint netId = 0,
             LaneID lane = LaneID.NONE,
             MapObject mapObject = default,
+            IStats stats = null,
             string aiScript = ""
-        ) : base(game, name, model, position, team, netId, lane, mapObject, aiScript: aiScript)
+        ) : base(game, name, model, position, team, netId, lane, mapObject, stats: stats, aiScript: aiScript)
         {
             Type = type;
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Minion.cs
@@ -54,11 +54,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             bool targetable = true,
             bool isWard = false,
             IObjAiBase visibilityOwner = null,
+            IStats stats = null,
             string aiScript = "",
             int damageBonus = 0,
             int healthBonus = 0,
             int initialLevel = 1
-        ) : base(game, model, new Stats.Stats(), 40, position, 1100, skinId, netId, team, aiScript)
+        ) : base(game, model, 40, position, 1100, skinId, netId, team, stats, aiScript)
         {
             Name = name;
             Owner = owner;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Monster.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Monster.cs
@@ -26,6 +26,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             string spawnAnimation = "",
             bool isTargetable = true,
             bool ignoresCollision = false,
+            IStats stats = null,
             string aiScript = "",
             int damageBonus = 0,
             int healthBonus = 0,
@@ -34,7 +35,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             (
                 game, null, position, model, name,
                 netId, team, 0, ignoresCollision, isTargetable,
-                false ,null, aiScript, damageBonus, healthBonus, initialLevel
+                false, null, stats, aiScript, damageBonus, healthBonus, initialLevel
             )
         {
             Camp = monsterCamp;

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -80,15 +80,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public ICharScript CharScript { get; private set; }
         public bool IsBot { get; set; }
         public IAIScript AIScript { get; protected set; }
-        public ObjAiBase(Game game, string model, Stats.Stats stats, int collisionRadius = 0,
-            Vector2 position = new Vector2(), int visionRadius = 0, int skinId = 0, uint netId = 0, TeamId team = TeamId.TEAM_NEUTRAL, string aiScript = "") :
-            base(game, model, stats, collisionRadius, position, visionRadius, netId, team)
+        public ObjAiBase(Game game, string model, int collisionRadius = 0,
+            Vector2 position = new Vector2(), int visionRadius = 0, int skinId = 0, uint netId = 0, TeamId team = TeamId.TEAM_NEUTRAL, IStats stats = null, string aiScript = "") :
+            base(game, model, collisionRadius, position, visionRadius, netId, team, stats)
         {
             _itemManager = game.ItemManager;
 
             SkinID = skinId;
-
-            stats.LoadStats(CharData);
 
             // TODO: Centralize this instead of letting it lay in the initialization.
             if (collisionRadius > 0)
@@ -127,8 +125,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 VisionRadius = 1100;
             }
 
-            Stats.CurrentMana = stats.ManaPoints.Total;
-            Stats.CurrentHealth = stats.HealthPoints.Total;
+            Stats.CurrentMana = Stats.ManaPoints.Total;
+            Stats.CurrentHealth = Stats.HealthPoints.Total;
 
             SpellToCast = null;
 
@@ -1057,9 +1055,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public override void Update(float diff)
         {
             base.Update(diff);
-            
+
             UpdateBuffs(diff);
-            
+
             CharScript.OnUpdate(diff);
             if (!_aiPaused)
             {
@@ -1105,11 +1103,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
         }
         public override void LateUpdate(float diff)
-        {            
+        {
             // Stop targeting an untargetable unit.
             if (TargetUnit != null && !TargetUnit.Status.HasFlag(StatusFlags.Targetable))
             {
-                if(TargetUnit.CharData.IsUseable)
+                if (TargetUnit.CharData.IsUseable)
                 {
                     return;
                 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Pet.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Pet.cs
@@ -26,13 +26,14 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             string buffName,
             float lifeTime,
             int skinId = 0,
+            IStats stats = null,
             bool cloneInventory = true,
             bool showMinimapIfClone = true,
             bool disallowPlayerControl = false,
             bool doFade = false,
             bool isClone = true,
             string aiScript = "Pet"
-            ) : base(game, owner, position, model, name, team: owner.Team, skinId: skinId,aiScript: aiScript)
+            ) : base(game, owner, position, model, name, team: owner.Team, skinId: skinId, stats: stats, aiScript: aiScript)
         {
             _returnRadius = _game.Map.MapScript.MapScriptMetadata.AIVars.DefaultPetReturnRadius;
 

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -115,19 +115,30 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public AttackableUnit(
             Game game,
             string model,
-            IStats stats,
             int collisionRadius = 40,
             Vector2 position = new Vector2(),
             int visionRadius = 0,
             uint netId = 0,
-            TeamId team = TeamId.TEAM_NEUTRAL
+            TeamId team = TeamId.TEAM_NEUTRAL,
+            IStats stats = null
         ) : base(game, position, collisionRadius, collisionRadius, visionRadius, netId, team)
 
         {
             Logger = LoggerProvider.GetLogger();
             Model = model;
+
             CharData = _game.Config.ContentManager.GetCharData(Model);
-            Stats = stats;
+            if (stats == null)
+            {
+                var charStats = new Stats.Stats();
+                charStats.LoadStats(CharData);
+                Stats = charStats;
+            }
+            else
+            {
+                Stats = stats;
+            }
+
             Waypoints = new List<Vector2> { Position };
             CurrentWaypoint = new KeyValuePair<int, Vector2>(1, Position);
             Status = StatusFlags.CanAttack | StatusFlags.CanCast | StatusFlags.CanMove | StatusFlags.CanMoveEver | StatusFlags.Targetable;

--- a/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Inhibitor.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Inhibitor.cs
@@ -24,8 +24,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.Animate
             int collisionRadius = 40,
             Vector2 position = new Vector2(),
             int visionRadius = 0,
+            IStats stats = null,
             uint netId = 0
-        ) : base(game, model, new Stats.Stats(), collisionRadius, position, visionRadius, netId, team)
+        ) : base(game, model, collisionRadius, position, visionRadius, netId, team, stats)
         {
             InhibitorState = InhibitorState.ALIVE;
             Lane = laneId;

--- a/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Nexus.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Nexus.cs
@@ -14,8 +14,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.Animate
             int collisionRadius = 40,
             Vector2 position = new Vector2(),
             int visionRadius = 0,
+            IStats stats = null,
             uint netId = 0
-        ) : base(game, model, new Stats.Stats(), collisionRadius, position, visionRadius, netId, team)
+        ) : base(game, model, collisionRadius, position, visionRadius, netId, team, stats)
         {
             Stats.CurrentHealth = 5500;
             Stats.HealthPoints.BaseValue = 5500;

--- a/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Nexus.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Nexus.cs
@@ -18,13 +18,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.Animate
             uint netId = 0
         ) : base(game, model, collisionRadius, position, visionRadius, netId, team, stats)
         {
-            Stats.CurrentHealth = 5500;
-            Stats.HealthPoints.BaseValue = 5500;
         }
 
         public override void SetToRemove()
         {
-
         }
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/ObjAnimatedBuilding.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/ObjAnimatedBuilding.cs
@@ -8,9 +8,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.Animate
 {
     public class ObjAnimatedBuilding : ObjBuilding, IObjAnimatedBuilding
     {
-        public ObjAnimatedBuilding(Game game, string model, IStats stats, int collisionRadius = 40,
-            Vector2 position = new Vector2(), int visionRadius = 0, uint netId = 0, TeamId team = TeamId.TEAM_BLUE) :
-            base(game, model, stats, collisionRadius, position, visionRadius, netId, team)
+        public ObjAnimatedBuilding(Game game, string model, int collisionRadius = 40,
+            Vector2 position = new Vector2(), int visionRadius = 0, uint netId = 0, TeamId team = TeamId.TEAM_BLUE, IStats stats = null) :
+            base(game, model, collisionRadius, position, visionRadius, netId, team, stats)
         {
             Replication = new ReplicationAnimatedBuilding(this);
         }

--- a/GameServerLib/GameObjects/AttackableUnits/Buildings/ObjBuilding.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/Buildings/ObjBuilding.cs
@@ -8,9 +8,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings
     {
         public override bool IsAffectedByFoW => false;
 
-        public ObjBuilding(Game game, string model, IStats stats, int collisionRadius = 40,
-            Vector2 position = new Vector2(), int visionRadius = 0, uint netId = 0, TeamId team = TeamId.TEAM_BLUE) :
-            base(game, model, stats, collisionRadius, position, visionRadius, netId, team)
+        public ObjBuilding(Game game, string model, int collisionRadius = 40,
+            Vector2 position = new Vector2(), int visionRadius = 0, uint netId = 0, TeamId team = TeamId.TEAM_BLUE, IStats stats = null) :
+            base(game, model, collisionRadius, position, visionRadius, netId, team, stats)
         {
         }
     }

--- a/GameServerLib/GameObjects/MonsterCamp.cs
+++ b/GameServerLib/GameObjects/MonsterCamp.cs
@@ -111,7 +111,7 @@ namespace GameServerLib.GameObjects
             (
                 _game, monster.Name, monster.Model, monster.Position,
                 monster.Direction, this, monster.Team, 0,
-                monster.SpawnAnimation, monster.IsTargetable, monster.IgnoresCollision, aiscript,
+                monster.SpawnAnimation, monster.IsTargetable, monster.IgnoresCollision, null, aiscript,
                 monster.DamageBonus, monster.HealthBonus, monster.InitialLevel
             );
             while(campMonster.Stats.Level < monster.InitialLevel)


### PR DESCRIPTION
* Stats are now loaded in `AttackableUnit` instead of `ObjAiBase`.
* `Stats` arguments are now present in all AttackableUnit-Inherited Class Constructors in order to facilitate initialization of units with hard-coded stats.
* Fixed Unit's movement speed being set to 110 due to their Stats being loaded only after the initial `CalculateTrueMoveSpeed`.
* Updated a few map scripts to make use of the option of hardcoded stats.