### PR TITLE
Progress #1410 -- Region changes

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/AscRelic/AscRelicBombBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/AscRelic/AscRelicBombBuff.cs
@@ -23,8 +23,8 @@ namespace Buffs
         IParticle p1;
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            AddUnitPerceptionBubble(unit, 800.0f, 25000.0f, TeamId.TEAM_BLUE, false, null, 38.08f, collisionOwner: unit);
-            AddUnitPerceptionBubble(unit, 800.0f, 25000.0f, TeamId.TEAM_PURPLE, false, null, 38.08f, collisionOwner: unit);
+            AddUnitPerceptionBubble(unit, 800.0f, 25000.0f, TeamId.TEAM_BLUE, false, null, 38.08f);
+            AddUnitPerceptionBubble(unit, 800.0f, 25000.0f, TeamId.TEAM_PURPLE, false, null, 38.08f);
             p1 = AddParticleTarget(unit, unit, "Asc_RelicPrism_Sand", unit, -1.0f, 1.0f ,direction: new Vector3(0.0f, 0.0f, -1.0f), flags: (FXFlags)304);
             AddParticleTarget(unit, unit, "Asc_relic_Sand_buf", unit, -1.0f, flags: (FXFlags)32);
             unit.IconInfo.SwapIcon("Relic", true);

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/OdinChannelVision.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/OdinChannelVision.cs
@@ -23,11 +23,11 @@ namespace Buffs
         IRegion r4;
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            r1 = AddUnitPerceptionBubble(unit, 400.0f, buff.Duration, TeamId.TEAM_BLUE, false, collisionArea: 35.0f, collisionOwner: unit, regionType: RegionType.Unknown2);
-            r2 = AddUnitPerceptionBubble(unit, 50.0f, buff.Duration, TeamId.TEAM_BLUE, true, collisionArea: 35.0f, collisionOwner: unit, regionType: RegionType.Unknown2);
+            r1 = AddUnitPerceptionBubble(unit, 400.0f, buff.Duration, TeamId.TEAM_BLUE, false, collisionArea: 35.0f, regionType: RegionType.Unknown2);
+            r2 = AddUnitPerceptionBubble(unit, 50.0f, buff.Duration, TeamId.TEAM_BLUE, true, collisionArea: 35.0f, regionType: RegionType.Unknown2);
 
-            r3 = AddUnitPerceptionBubble(unit, 400.0f, buff.Duration, TeamId.TEAM_PURPLE, false, collisionArea: 35.0f, collisionOwner: unit, regionType: RegionType.Unknown2);
-            r4 = AddUnitPerceptionBubble(unit, 50.0f, buff.Duration, TeamId.TEAM_PURPLE, true, collisionArea: 35.0f, collisionOwner: unit, regionType: RegionType.Unknown2);
+            r3 = AddUnitPerceptionBubble(unit, 400.0f, buff.Duration, TeamId.TEAM_PURPLE, false, collisionArea: 35.0f, regionType: RegionType.Unknown2);
+            r4 = AddUnitPerceptionBubble(unit, 50.0f, buff.Duration, TeamId.TEAM_PURPLE, true, collisionArea: 35.0f, regionType: RegionType.Unknown2);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScriptObjects.cs
@@ -83,7 +83,7 @@ namespace MapScripts.Map8
             foreach (var infoPoint in _mapObjects[GameObjectTypes.InfoPoint])
             {
                 var point = CreateMinion("OdinNeutralGuardian", "OdinNeutralGuardian", new Vector2(infoPoint.CentralPoint.X, infoPoint.CentralPoint.Z), ignoreCollision: true);
-                AddUnitPerceptionBubble(point, 800.0f, 25000.0f, TeamId.TEAM_BLUE, true, collisionArea: 120.0f, collisionOwner: point);
+                AddUnitPerceptionBubble(point, 800.0f, 25000.0f, TeamId.TEAM_BLUE, true, collisionArea: 120.0f);
                 point.PauseAi(true);
                 InfoPoints.Add(pointIndex, point);
                 pointIndex++;

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/NeutralMinionSpawn.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/NeutralMinionSpawn.cs
@@ -140,8 +140,8 @@ namespace MapScripts.Map8
         {
             var crystal = CreateMinion("OdinCenterRelic", "OdinCenterRelic", Position, team: Team);
 
-            Regions.Add(AddUnitPerceptionBubble(crystal, 350.0f, 25000.0f, TeamId.TEAM_BLUE, collisionArea: 38.08f, collisionOwner: crystal));
-            Regions.Add(AddUnitPerceptionBubble(crystal, 350.0f, 25000.0f, TeamId.TEAM_PURPLE, collisionArea: 38.08f, collisionOwner: crystal));
+            Regions.Add(AddUnitPerceptionBubble(crystal, 350.0f, 25000.0f, TeamId.TEAM_BLUE, collisionArea: 38.08f));
+            Regions.Add(AddUnitPerceptionBubble(crystal, 350.0f, 25000.0f, TeamId.TEAM_PURPLE, collisionArea: 38.08f));
 
             ApiEventManager.OnDeath.AddListener(crystal, crystal, OnCrystalDeath, true);
             IsDead = false;

--- a/GameServerCore/Domain/GameObjects/IRegion.cs
+++ b/GameServerCore/Domain/GameObjects/IRegion.cs
@@ -10,9 +10,8 @@ namespace GameServerCore.Domain.GameObjects
     {
         int Type { get; }
         IGameObject CollisionUnit { get; }
+        IGameObject VisionTarget { get; }
         int OwnerClientID { get; }
-        uint VisionNetID { get; }
-        uint VisionBindNetID { get; }
         /// <summary>
         /// Total game-time that this region should exist for
         /// </summary>

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -447,7 +447,7 @@ namespace LeagueSandbox.GameServer.API
             int skinId = 0,
             bool ignoreCollision = false,
             bool targetable = true,
-             bool isWard = false,
+            bool isWard = false,
             SpellDataFlags targetingFlags = 0,
             IObjAiBase visibilityOwner = null,
             bool isVisible = true,
@@ -475,27 +475,29 @@ namespace LeagueSandbox.GameServer.API
         /// <param name="revealStealthed">Whether or not the perception bubble should reveal stealthed units while they are in range.</param>
         /// <param name="revealSpecificUnitOnly">Specific unit to reveal. Perception bubble will not reveal any other units when used. *NOTE* Currently does nothing.</param>
         /// <param name="collisionArea">Area around the perception bubble where units are not allowed to move into.</param>
+        ///
         /// <returns>New Region instance.</returns>
         public static IRegion AddPosPerceptionBubble
         (
             Vector2 position,
             float radius,
-            float duration = -1f,
+            float duration,
             TeamId team = TeamId.TEAM_NEUTRAL,
             bool revealStealthed = false,
             IAttackableUnit revealSpecificUnitOnly = null,
             float collisionArea = 0f,
-            IGameObject collisionOwner = null
+            RegionType regionType = RegionType.Default
         )
         {
-            var useCollision = false;
-            if (collisionArea > 0)
-            {
-                useCollision = true;
-            }
-
-            // TODO: Implement revealSpecificUnitOnly
-            return new Region(_game, team, position, collisionUnit: collisionOwner, giveVision: true, visionRadius: radius, revealStealth: revealStealthed, hasCollision: useCollision, collisionRadius: collisionArea, lifetime: duration);
+            return new Region
+            (
+                _game, team, position, regionType,
+                visionTarget: revealSpecificUnitOnly,
+                visionRadius: radius,
+                revealStealth: revealStealthed,
+                collisionRadius: collisionArea,
+                lifetime: duration
+            );
         }
 
         /// <summary>
@@ -514,23 +516,24 @@ namespace LeagueSandbox.GameServer.API
         (
             IAttackableUnit target,
             float radius,
-            float duration = -1f,
+            float duration,
             TeamId team = TeamId.TEAM_NEUTRAL,
             bool revealStealthed = false,
             IAttackableUnit revealSpecificUnitOnly = null,
             float collisionArea = 0f,
-            IGameObject collisionOwner = null,
             RegionType regionType = RegionType.Default
         )
         {
-            var useCollision = false;
-            if (collisionArea > 0)
-            {
-                useCollision = true;
-            }
-
-            // TODO: Implement revealSpecificUnitOnly
-            return new Region(_game, team, target.Position, regionType, collisionOwner, revealSpecificUnitOnly, true, radius, revealStealthed, useCollision, collisionArea, duration);
+            return new Region
+            (
+                _game, team, target.Position, regionType,
+                collisionUnit: target,
+                visionTarget: revealSpecificUnitOnly,
+                visionRadius: radius,
+                revealStealth: revealStealthed,
+                collisionRadius: collisionArea,
+                lifetime: duration
+            );
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
@@ -91,7 +91,17 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             _game.ObjectManager.AddTurret(this);
 
             // TODO: Handle this via map script for LaneTurret and via CharScript for AzirTurret.
-            BubbleRegion = new Region(_game, Team, Position, RegionType.Default, this, this, true, 800f, true, true, PathfindingRadius, lifetime: 25000.0f);
+            BubbleRegion = new Region
+            (
+                _game, Team, Position,
+                RegionType.Unknown2,
+                collisionUnit: this,
+                visionTarget: null,
+                visionRadius: 800f,
+                revealStealth: true,
+                collisionRadius: PathfindingRadius,
+                lifetime: 25000.0f
+            );
         }
 
         public override void OnCollision(IGameObject collider, bool isTerrain = false)

--- a/GameServerLib/GameObjects/Region.cs
+++ b/GameServerLib/GameObjects/Region.cs
@@ -17,9 +17,8 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         public int Type { get; }
         public IGameObject CollisionUnit { get; }
+        public IGameObject VisionTarget { get; }
         public int OwnerClientID { get; }
-        public uint VisionNetID { get; }
-        public uint VisionBindNetID { get; }
         /// <summary>
         /// Total game-time that this region should exist for
         /// </summary>
@@ -62,10 +61,8 @@ namespace LeagueSandbox.GameServer.GameObjects
             RegionType type = RegionType.Default,
             IGameObject collisionUnit = null,
             IGameObject visionTarget = null,
-            bool giveVision = false,
             float visionRadius = 0,
             bool revealStealth = false,
-            bool hasCollision = false,
             float collisionRadius = 0,
             float grassRadius = 0,
             float scale = 1.0f,
@@ -76,24 +73,13 @@ namespace LeagueSandbox.GameServer.GameObjects
         {
             Type = (int)type;
             CollisionUnit = collisionUnit;
+            VisionTarget = visionTarget;
             OwnerClientID = clientId;
-            VisionNetID = _game.NetworkIdManager.GetNewNetId();
-            if (visionTarget != null)
-            {
-                VisionBindNetID = visionTarget.NetId;
-            }
 
             Lifetime = lifetime;
             GrassRadius = grassRadius;
             Scale = scale;
             AdditionalSize = addedSize;
-            HasCollision = hasCollision;
-            GrantVision = giveVision;
-
-            if (!GrantVision)
-            {
-                VisionRadius = 0;
-            }
 
             if (Scale > 0)
             {
@@ -106,6 +92,9 @@ namespace LeagueSandbox.GameServer.GameObjects
                 PathfindingRadius += AdditionalSize;
                 VisionRadius += AdditionalSize;
             }
+
+            HasCollision = PathfindingRadius > 0;
+            GrantVision = VisionRadius > 0;
 
             RevealsStealth = revealStealth;
 
@@ -174,15 +163,17 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// <param name="diff">Number of milliseconds since this tick occurred.</param>
         public override void Update(float diff)
         {
-            if (Lifetime == -1f)
+            if (CollisionUnit != null)
             {
-                return;
+                Position = CollisionUnit.Position;
             }
-
-            _currentTime += diff / 1000.0f;
-            if (_currentTime >= Lifetime)
+            if (Lifetime > 0)
             {
-                SetToRemove();
+                _currentTime += diff / 1000.0f;
+                if (_currentTime >= Lifetime)
+                {
+                    SetToRemove();
+                }
             }
         }
 

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -310,7 +310,14 @@ namespace LeagueSandbox.GameServer
                 return true;
             }
 
-            if(tested is IParticle particle)
+            if(observer is IRegion region)
+            {
+                if(region.VisionTarget != null && region.VisionTarget != tested)
+                {
+                    return false;
+                }
+            }
+            else if(tested is IParticle particle)
             {
                 // Default behaviour
                 if(particle.SpecificTeam == TeamId.TEAM_NEUTRAL)

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -61,8 +61,8 @@ namespace PacketDefinitions420
                 // TODO: Verify (usually 0 for vision only?)
                 UnitNetID = 0,
                 // TODO: Verify (is usually different from UnitNetID in packets, may also be a remnant or for internal use)
-                BubbleNetID = region.VisionNetID,
-                VisionTargetNetID = region.VisionBindNetID,
+                BubbleNetID = region.NetId,
+                VisionTargetNetID = 0,
                 Position = region.Position,
                 // For turrets, usually 25000.0 is used
                 TimeToLive = region.Lifetime,
@@ -83,6 +83,11 @@ namespace PacketDefinitions420
             if (region.CollisionUnit != null)
             {
                 regionPacket.UnitNetID = region.CollisionUnit.NetId;
+            }
+
+            if(region.VisionTarget != null)
+            {
+                regionPacket.VisionTargetNetID = region.VisionTarget.NetId;
             }
 
             return regionPacket;


### PR DESCRIPTION
- `Region`s now attach to and sync position with `CollisionUnit`
- When creating a region using functions, it is now mandatory to specify the time.
Negative values disable the timer, but are not used in packets (it seems that for some reason the game is not designed to be played for more than 7 hours, i.e. 25000 seconds).
- `HasCollision` and `GrantVision` are now determined by `collisionRadius` (`PathfindingRadius`) and `VisionRadius` respectively.
- If you set a visionTarget to a region, the region will reveal that and only that unit when it enters the vision radius.
- Turrets now use `RegionType.Unknown2` by default because that's how it is in replays.
- Instead of `VisionNetID`, `NetId` is now simply used, just like it was in `NotifyRemoveRegion`, which should solve problems with removing regions.