### PR TITLE
Resolve #1385 -- Flags overridden by buffs are now reset when they are removed

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/AscWarp/AscWarp.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/AscWarp/AscWarp.cs
@@ -20,14 +20,13 @@ namespace Buffs
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            SetStatus(unit, StatusFlags.Stunned, true);
+            buff.SetStatusEffect(StatusFlags.Stunned, true);
             unit.IconInfo.SwapBorder("Teleport", true, "AscWarp");
             AddParticleTarget(unit, unit, "Global_Asc_teleport", unit, buff.Duration);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            SetStatus(unit, StatusFlags.Stunned, false);
             unit.IconInfo.SwapBorder("", true);
             if (unit is IObjAiBase obj)
             {

--- a/Content/LeagueSandbox-Scripts/Buffs/Ascension/AscBuffTransfer.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Ascension/AscBuffTransfer.cs
@@ -44,18 +44,13 @@ namespace Buffs
             AddParticle(unit, unit, "AscTransferGlow", unit.Position, buff.Duration, flags: (FXFlags)32);
             AddParticle(unit, unit, "AscTurnToStone", unit.Position, buff.Duration, flags: (FXFlags)32);
 
-            //Using SetStatus temporarily due to: https://github.com/LeagueSandbox/GameServer/issues/1385
-            SetStatus(unit, StatusFlags.Targetable, false);
-            SetStatus(unit, StatusFlags.Stunned, true);
-            SetStatus(unit, StatusFlags.Invulnerable, true);
+            buff.SetStatusEffect(StatusFlags.Targetable, false);
+            buff.SetStatusEffect(StatusFlags.Stunned, true);
+            buff.SetStatusEffect(StatusFlags.Invulnerable, true);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            SetStatus(unit, StatusFlags.Targetable, true);
-            SetStatus(unit, StatusFlags.Stunned, false);
-            SetStatus(unit, StatusFlags.Invulnerable, false);
-
             unit.PauseAnimation(false);
 
             AddParticleTarget(unit, unit, "CassPetrifyMiss_tar", unit, size: 3.0f);

--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
@@ -27,8 +27,6 @@ namespace Buffs
         // TODO: Use OnMoveEnd event and call this manually.
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            SetStatus(unit, StatusFlags.CanAttack | StatusFlags.CanMove | StatusFlags.CanCast, true);
-
             if (buff.SourceUnit is IObjAiBase ai && unit is IChampion ch)
             {
                 ai.SetTargetUnit(ch, true);

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/ExpirationTimer.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/ExpirationTimer.cs
@@ -27,8 +27,6 @@ namespace Buffs
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            SetStatus(unit, StatusFlags.Targetable, true);
-
             unit.Die(CreateDeathData(false, 0, unit, unit, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_INTERNALRAW, 0));
         }
 

--- a/Content/LeagueSandbox-Scripts/Buffs/Global/Stun.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Global/Stun.cs
@@ -21,14 +21,12 @@ namespace Buffs
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            //Change this back to buff.SetStatusEffect when it's removal get's fixed
-            SetStatus(unit, StatusFlags.Stunned, true);
+            buff.SetStatusEffect(StatusFlags.Stunned, true);
             stun = AddParticleTarget(ownerSpell.CastInfo.Owner, unit, "LOC_Stun", unit, buff.Duration, bone: "head");
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            SetStatus(unit, StatusFlags.Stunned, false);
             RemoveParticle(stun);
         }
 

--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQTwoDash.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQTwoDash.cs
@@ -43,7 +43,8 @@ namespace Buffs
             // Flags: Blend false, Lock true, Loop true
             PlayAnimation(owner, "Spell1b", 0f, flags: AnimationFlags.Lock);
             toRemove = false;
-            SetStatus(owner, StatusFlags.Ghosted, true);
+
+            buff.SetStatusEffect(StatusFlags.Ghosted, true);
         }
 
         public void OnMoveEnd(IAttackableUnit unit)
@@ -84,7 +85,6 @@ namespace Buffs
             RemoveParticle(selfParticle);
             // Flags: Blend true
             // UnlockAnimation(true, unit);
-            SetStatus(owner, StatusFlags.Ghosted, false);
         }
 
         public void OnUpdate(float diff)

--- a/GameServerCore/Domain/GameObjects/IBuff.cs
+++ b/GameServerCore/Domain/GameObjects/IBuff.cs
@@ -52,9 +52,13 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         IBuffGameScript BuffScript { get; }
         /// <summary>
-        /// All status effects applied by this buff.
+        /// All status effects enabled by this buff.
         /// </summary>
-        Dictionary<StatusFlags, bool> StatusEffects { get; }
+        StatusFlags StatusEffectsToEnable { get; }
+        /// <summary>
+        /// All status effects disabled by this buff.
+        /// </summary>
+        StatusFlags StatusEffectsToDisable { get; }
         /// <summary>
         /// Used to update player buff tool tip values.
         /// </summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -1056,8 +1056,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             base.Update(diff);
 
-            UpdateBuffs(diff);
-
             CharScript.OnUpdate(diff);
             if (!_aiPaused)
             {
@@ -1087,21 +1085,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 SetPet(null);
             }
         }
-        void UpdateBuffs(float diff)
-        {
-            var tempBuffs = new List<IBuff>(GetBuffs());
-            for (int i = tempBuffs.Count - 1; i >= 0; i--)
-            {
-                if (tempBuffs[i].Elapsed())
-                {
-                    RemoveBuff(tempBuffs[i]);
-                }
-                else
-                {
-                    tempBuffs[i].Update(diff);
-                }
-            }
-        }
+        
         public override void LateUpdate(float diff)
         {
             // Stop targeting an untargetable unit.

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -67,18 +67,15 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// Array of buff slots which contains all parent buffs (oldest buff of a given name) applied to this AI.
         /// Maximum of 256 slots, hard limit due to packets.
         /// </summary>
-        /// TODO: Move to AttackableUnit.
         private IBuff[] BuffSlots { get; }
         /// <summary>
         /// Dictionary containing all parent buffs (oldest buff of a given name). Used for packets and assigning stacks if a buff of the same name is added.
         /// </summary>
-        /// TODO: Move to AttackableUnit.
         private Dictionary<string, IBuff> ParentBuffs { get; }
         /// <summary>
         /// List of all buffs applied to this AI. Used for easier indexing of buffs.
         /// </summary>
         /// TODO: Verify if we can remove this in favor of BuffSlots while keeping the functions which allow for easy accessing of individual buff instances.
-        /// TODO: Move to AttackableUnit.
         private List<IBuff> BuffList { get; }
         /// <summary>
         /// List of all slows applied to this unit
@@ -96,10 +93,15 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// Index of the waypoint in the list of waypoints that the object is currently on.
         /// </summary>
         public KeyValuePair<int, Vector2> CurrentWaypoint { get; protected set; }
+        
         /// <summary>
         /// Status effects enabled on this unit. Refer to StatusFlags enum.
         /// </summary>
         public StatusFlags Status { get; protected set; }
+        StatusFlags _statusBeforeApplyingBuffEfects = 0;
+        StatusFlags _buffEffectsToEnable = 0;
+        StatusFlags _buffEffectsToDisable = 0;
+
         /// <summary>
         /// Parameters of any forced movements (dashes) this unit is performing.
         /// </summary>
@@ -256,7 +258,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 _death = null;
             }
 
-            UpdateStatus();
+            ApplyBuffEffects();
         }
 
         /// <summary>
@@ -897,6 +899,20 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// <param name="enabled">Whether or not to enable the flag.</param>
         public void SetStatus(StatusFlags status, bool enabled)
         {
+            if (enabled)
+            {
+                _statusBeforeApplyingBuffEfects |= status;
+            }
+            else
+            {
+                _statusBeforeApplyingBuffEfects &= ~status;
+            }
+            Status = (Status & ~_buffEffectsToDisable) | _buffEffectsToEnable;
+            UpdateActionState(status, enabled);
+        }
+    
+        void UpdateActionState(StatusFlags status, bool enabled)
+        {
             // Loop over all possible status flags and set them individually.
             for (int i = 0; i < Enum.GetNames(typeof(StatusFlags)).Length - 1; i++)
             {
@@ -904,15 +920,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 
                 if (status.HasFlag(currentFlag))
                 {
-                    if (enabled)
-                    {
-                        Status |= currentFlag;
-                    }
-                    else
-                    {
-                        Status &= ~currentFlag;
-                    }
-
                     switch (currentFlag)
                     {
                         // CallForHelpSuppressor
@@ -1048,39 +1055,23 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 Stats.SetActionState(ActionState.CAN_NOT_ATTACK, false);
             }
         }
-
-        public void UpdateStatus()
+        
+        void ApplyBuffEffects()
         {
             // Combine the status effects of all the buffs
-            Dictionary<StatusFlags, bool> finalEffects = new Dictionary<StatusFlags, bool>();
+            _buffEffectsToEnable = 0;
+            _buffEffectsToDisable = 0;
             foreach (IBuff buff in GetBuffs())
             {
-                foreach (KeyValuePair<StatusFlags, bool> effect in buff.StatusEffects)
-                {
-                    if (finalEffects.ContainsKey(effect.Key))
-                    {
-                        // If the effect should be enabled, it overrides disable.
-                        if (finalEffects[effect.Key])
-                        {
-                            continue;
-                        }
-                        else
-                        {
-                            finalEffects[effect.Key] = effect.Value;
-                        }
-                    }
-                    else
-                    {
-                        finalEffects.Add(effect.Key, effect.Value);
-                    }
-                }
+                _buffEffectsToEnable |= buff.StatusEffectsToEnable;
+                _buffEffectsToDisable |= buff.StatusEffectsToDisable;
             }
 
+            // If the effect should be enabled, it overrides disable.
+            _buffEffectsToDisable &= ~_buffEffectsToEnable;
+
             // Set the status effects of this unit.
-            foreach (KeyValuePair<StatusFlags, bool> effect in finalEffects)
-            {
-                SetStatus(effect.Key, effect.Value);
-            }
+            SetStatus(StatusFlags.None, true);
         }
 
         /// <summary>


### PR DESCRIPTION
- Instead of loops and dictionaries, bitwise operations are now used where possible.
- The `UpdateBuffs` function has been moved from `ObjAIBase` to `AttackableUnit` and merged with `UpdateStatus`.