### PR TITLE
Resolve #1460, Resolve #1442 -- Dash fixes

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
@@ -19,7 +19,7 @@ namespace Buffs
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            //buff.SetStatusEffect(StatusFlags.CanAttack | StatusFlags.CanMove | StatusFlags.CanCast, false);
+            buff.SetStatusEffect(StatusFlags.CanAttack | StatusFlags.CanMove | StatusFlags.CanCast, false);
             //ForceMovement(unit, "RUN", buff.SourceUnit.Position, 1800f, 0, 5.0f, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
             ForceMovement(unit as IObjAiBase, buff.SourceUnit, "RUN", 1800f, 0, 5.0f, 0, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
         }

--- a/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Blitzcrank/RocketGrab2.cs
@@ -19,9 +19,9 @@ namespace Buffs
 
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            buff.SetStatusEffect(StatusFlags.CanAttack | StatusFlags.CanMove | StatusFlags.CanCast, false);
-
-            ForceMovement(unit, "RUN", buff.SourceUnit.Position, 1800f, 0, 5.0f, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
+            //buff.SetStatusEffect(StatusFlags.CanAttack | StatusFlags.CanMove | StatusFlags.CanCast, false);
+            //ForceMovement(unit, "RUN", buff.SourceUnit.Position, 1800f, 0, 5.0f, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
+            ForceMovement(unit as IObjAiBase, buff.SourceUnit, "RUN", 1800f, 0, 5.0f, 0, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
         }
 
         // TODO: Use OnMoveEnd event and call this manually.

--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQTwoDash.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQTwoDash.cs
@@ -37,7 +37,7 @@ namespace Buffs
 
             var dashSpeed = 1350f + owner.GetTrueMoveSpeed();
 
-            ForceMovement(owner, target, "", dashSpeed, 2000f, 0, 150, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
+            ForceMovement(owner, target, "", dashSpeed, 2000f, 0, 0, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
 
             selfParticle = AddParticleTarget(owner, owner, "blindMonk_Q_resonatingStrike_mis", owner, flags: 0);
             // Flags: Blend false, Lock true, Loop true

--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQTwoDash.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQTwoDash.cs
@@ -37,7 +37,7 @@ namespace Buffs
 
             var dashSpeed = 1350f + owner.GetTrueMoveSpeed();
 
-            ForceMovement(owner, target, "", dashSpeed, 0f, Vector2.Distance(target.Position, owner.Position), 0f, -1f, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
+            ForceMovement(owner, target, "", dashSpeed, 2000f, 0, 150, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
 
             selfParticle = AddParticleTarget(owner, owner, "blindMonk_Q_resonatingStrike_mis", owner, flags: 0);
             // Flags: Blend false, Lock true, Loop true

--- a/Content/LeagueSandbox-Scripts/Characters/Diana/CharScriptDiana.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Diana/CharScriptDiana.cs
@@ -30,7 +30,7 @@ namespace CharScripts
             if (diana != null)
             {
                 // Not moving
-                if (diana.CurrentWaypoint.Value == diana.Position && !beginStance)
+                if (diana.CurrentWaypoint == diana.Position && !beginStance)
                 {
                     PlayAnimation(diana, "Attack1", 5f);
                     beginStance = true;

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -35,7 +35,8 @@ namespace GameServerCore.Domain.GameObjects
         /// <summary>
         /// Index of the waypoint in the list of waypoints that the object is currently on.
         /// </summary>
-        KeyValuePair<int, Vector2> CurrentWaypoint { get; }
+        Vector2 CurrentWaypoint { get; }
+        int CurrentWaypointKey { get; }
         /// <summary>
         /// Status effects enabled on this unit. Refer to StatusFlags enum.
         /// </summary>
@@ -241,10 +242,6 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="y">Y coordinate to teleport to.</param>
         /// <param name="repath">Whether or not to repath from the new position.</param>
         void TeleportTo(float x, float y, bool repath = false);
-        /// <summary>
-        /// Returns the next waypoint. If all waypoints have been reached then this returns a -inf Vector2
-        /// </summary>
-        Vector2 GetNextWaypoint();
         /// <summary>
         /// Returns whether this unit has reached the last waypoint in its path of waypoints.
         /// </summary>

--- a/GameServerCore/Domain/GameObjects/IForceMovementParameters.cs
+++ b/GameServerCore/Domain/GameObjects/IForceMovementParameters.cs
@@ -9,7 +9,11 @@ namespace GameServerCore.Domain.GameObjects
         /// <summary>
         /// Amount of time passed since the unit started dashing.
         /// </summary>
-        float ElapsedTime { get; }
+        float ElapsedTime { get; set; }
+        /// <summary>
+        /// The distance traveled from the beginning of the dash.
+        /// </summary>
+        float PassedDistance { get; set; }
         /// <summary>
         /// Speed to use for the movement.
         /// </summary>
@@ -42,7 +46,5 @@ namespace GameServerCore.Domain.GameObjects
         /// Maximum amount of time to follow the FollowNetID.
         /// </summary>
         float FollowTravelTime { get; }
-
-        void SetTimeElapsed(float time);
     }
 }

--- a/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
+++ b/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
@@ -191,7 +191,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                     }
                 }
 
-                for (int waypoint = u.CurrentWaypoint.Key; waypoint < u.Waypoints.Count; waypoint++)
+                for (int waypoint = u.CurrentWaypointKey; waypoint < u.Waypoints.Count; waypoint++)
                 {
                     var current = u.Waypoints[waypoint - 1];
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -496,7 +496,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         {
             // False because we don't want this to be networked as a normal movement.
             SetWaypoints(new List<Vector2> { Position, target.Position }, false);
-            
+
             SetTargetUnit(target, true);
 
             // TODO: Take into account the rest of the arguments
@@ -514,22 +514,18 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 FollowTravelTime = travelTime
             };
 
-            ///*
             if (consideredCC)
             {
                 MovementParameters.SetStatus = StatusFlags.CanAttack | StatusFlags.CanCast | StatusFlags.CanMove;
             }
-            //*/
 
             SetDashingState(true);
 
-            ///*
             if (animation != null && animation != "")
             {
                 var animPairs = new Dictionary<string, string> { { "RUN", animation } };
                 SetAnimStates(animPairs);
             }
-            //*/
 
             // Movement is networked this way instead.
             // TODO: Verify if we want to use NotifyWaypointListWithSpeed instead as it does not require conversions.

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -277,25 +277,33 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
         public override bool CanMove()
         {
-            return (!IsDead
-                && MovementParameters != null)
-                || (Status.HasFlag(StatusFlags.CanMove) && Status.HasFlag(StatusFlags.CanMoveEver)
+            return !IsDead && (
+                Status.HasFlag(StatusFlags.CanMove) && Status.HasFlag(StatusFlags.CanMoveEver)
                 && (MoveOrder != OrderType.CastSpell && _castingSpell == null)
                 && (ChannelSpell == null || (ChannelSpell != null && ChannelSpell.SpellData.CanMoveWhileChanneling))
                 && (!IsAttacking || !AutoAttackSpell.SpellData.CantCancelWhileWindingUp)
-                && !(Status.HasFlag(StatusFlags.Netted)
-                || Status.HasFlag(StatusFlags.Rooted)
-                || Status.HasFlag(StatusFlags.Sleep)
-                || Status.HasFlag(StatusFlags.Stunned)
-                || Status.HasFlag(StatusFlags.Suppressed)));
+                && !(
+                    Status.HasFlag(StatusFlags.Netted)
+                    || Status.HasFlag(StatusFlags.Rooted)
+                    || Status.HasFlag(StatusFlags.Sleep)
+                    || Status.HasFlag(StatusFlags.Stunned)
+                    || Status.HasFlag(StatusFlags.Suppressed)
+                )
+            );
         }
 
         public override bool CanChangeWaypoints()
         {
             return !IsDead
-                && (MovementParameters == null || (MovementParameters != null && MovementParameters.FollowNetID != 0))
-                && _castingSpell == null
-                && (ChannelSpell == null || (ChannelSpell != null && !ChannelSpell.SpellData.CantCancelWhileChanneling));
+            && MovementParameters == null
+            && _castingSpell == null
+            && (
+                ChannelSpell == null
+                || (
+                    ChannelSpell != null
+                    && !ChannelSpell.SpellData.CantCancelWhileChanneling
+                )
+            );
         }
 
         /// <summary>
@@ -486,8 +494,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             bool consideredCC = true
         )
         {
+            // False because we don't want this to be networked as a normal movement.
             SetWaypoints(new List<Vector2> { Position, target.Position }, false);
-
+            
             SetTargetUnit(target, true);
 
             // TODO: Take into account the rest of the arguments
@@ -505,22 +514,28 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 FollowTravelTime = travelTime
             };
 
+            ///*
             if (consideredCC)
             {
                 MovementParameters.SetStatus = StatusFlags.CanAttack | StatusFlags.CanCast | StatusFlags.CanMove;
             }
-
-            _game.PacketNotifier.NotifyWaypointGroupWithSpeed(this);
+            //*/
 
             SetDashingState(true);
 
+            ///*
             if (animation != null && animation != "")
             {
                 var animPairs = new Dictionary<string, string> { { "RUN", animation } };
                 SetAnimStates(animPairs);
             }
+            //*/
 
+            // Movement is networked this way instead.
             // TODO: Verify if we want to use NotifyWaypointListWithSpeed instead as it does not require conversions.
+            //_game.PacketNotifier.NotifyWaypointListWithSpeed(this, dashSpeed, leapGravity, keepFacingLastDirection, target, followTargetMaxDistance, backDistance, travelTime);
+            _game.PacketNotifier.NotifyWaypointGroupWithSpeed(this);
+            _movementUpdated = false;
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -353,13 +353,13 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
             if (IsMovementUpdated())
             {
-                if(MovementParameters != null)
+                if(MovementParameters == null)
                 {
-                //    _game.PacketNotifier.HoldMovementDataUntilWaypointGroupNotification(this, userId, false);
+                    _game.PacketNotifier.HoldMovementDataUntilWaypointGroupNotification(this, userId, false);
                 }
                 else
                 {
-                    _game.PacketNotifier.HoldMovementDataUntilWaypointGroupNotification(this, userId, false);
+                //    _game.PacketNotifier.HoldMovementDataWithSpeedUntilWaypointGroupNotification(this, userId, false);
                 }
             }
         }
@@ -1728,7 +1728,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 
             if (consideredCC)
             {
-            //    MovementParameters.SetStatus = StatusFlags.CanAttack | StatusFlags.CanCast | StatusFlags.CanMove;
+                MovementParameters.SetStatus = StatusFlags.CanAttack | StatusFlags.CanCast | StatusFlags.CanMove;
             }
 
             SetDashingState(true);
@@ -1766,10 +1766,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 MovementParameters = null;
                 ResetWaypoints();
 
-                ///*
                 var animPairs = new Dictionary<string, string> { { "RUN", "" } };
                 SetAnimStates(animPairs);
-                //*/
 
                 ApiEventManager.OnMoveEnd.Publish(this);
 

--- a/GameServerLib/GameObjects/AttackableUnits/ForceMovementParameters.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/ForceMovementParameters.cs
@@ -13,7 +13,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// <summary>
         /// Amount of time passed since the unit started dashing.
         /// </summary>
-        public float ElapsedTime { get; set; }
+        public float ElapsedTime { get; set; } = 0;
+        public float PassedDistance { get; set; } = 0;
+        public bool FlewOverUnit { get; set; } = false;
+        public Vector2 Direction { get; set; }
+        public float OverpassedDistance { get; set; } = 0;
         /// <summary>
         /// Speed to use for the movement.
         /// </summary>
@@ -51,6 +55,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public void SetTimeElapsed(float time)
         {
             ElapsedTime = time;
+        }
+
+        public void SetDistancePassed(float dist)
+        {
+            PassedDistance = dist;
         }
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/ForceMovementParameters.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/ForceMovementParameters.cs
@@ -15,9 +15,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// </summary>
         public float ElapsedTime { get; set; } = 0;
         public float PassedDistance { get; set; } = 0;
-        public bool FlewOverUnit { get; set; } = false;
-        public Vector2 Direction { get; set; }
-        public float OverpassedDistance { get; set; } = 0;
         /// <summary>
         /// Speed to use for the movement.
         /// </summary>
@@ -51,15 +48,5 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// Maximum amount of time to follow the FollowNetID.
         /// </summary>
         public float FollowTravelTime { get; set; }
-
-        public void SetTimeElapsed(float time)
-        {
-            ElapsedTime = time;
-        }
-
-        public void SetDistancePassed(float dist)
-        {
-            PassedDistance = dist;
-        }
     }
 }

--- a/GameServerLib/Handlers/PathingHandler.cs
+++ b/GameServerLib/Handlers/PathingHandler.cs
@@ -75,7 +75,7 @@ namespace LeagueSandbox.GameServer.Handlers
             }
 
             var lastWaypoint = path[path.Count - 1];
-            if (obj.CurrentWaypoint.Value.Equals(lastWaypoint) && lastWaypoint.Equals(obj.Position))
+            if (obj.CurrentWaypoint.Equals(lastWaypoint) && lastWaypoint.Equals(obj.Position))
             {
                 return;
             }

--- a/PacketDefinitions420/PacketExtensions.cs
+++ b/PacketDefinitions420/PacketExtensions.cs
@@ -129,14 +129,13 @@ namespace PacketDefinitions420
             var currentWaypoints = new List<Vector2>(unit.Waypoints);
             currentWaypoints[0] = unit.Position;
 
-            int count = 2 + ((currentWaypoints.Count - 1) - unit.CurrentWaypoint.Key);
+            int count = 2 + ((currentWaypoints.Count - 1) - unit.CurrentWaypointKey);
             if (count >= 2)
             {
                 currentWaypoints.RemoveRange(1, currentWaypoints.Count - count);
             }
 
             return currentWaypoints.ConvertAll(v => Vector2ToWaypoint(TranslateToCenteredCoordinates(v, grid)));
-
         }
 
         /// <summary>

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -167,8 +167,6 @@ namespace PacketDefinitions420
                     temp = source;
                 }
 
-                //Console.WriteLine($"<- {(GamePacketID)source[0]}");
-
                 return _peers[playerId].Send((byte)channelNo, new LENet.Packet(temp, flag)) == 0;
             }
             return false;
@@ -191,8 +189,6 @@ namespace PacketDefinitions420
             else
             {
                 var packet = new LENet.Packet(data, flag);
-
-                //Console.WriteLine($"<- {(GamePacketID)data[0]}");
 
                 _server.Broadcast((byte)channelNo, packet);
                 return true;

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -167,6 +167,8 @@ namespace PacketDefinitions420
                     temp = source;
                 }
 
+                //Console.WriteLine($"<- {(GamePacketID)source[0]}");
+
                 return _peers[playerId].Send((byte)channelNo, new LENet.Packet(temp, flag)) == 0;
             }
             return false;
@@ -189,6 +191,9 @@ namespace PacketDefinitions420
             else
             {
                 var packet = new LENet.Packet(data, flag);
+
+                //Console.WriteLine($"<- {(GamePacketID)data[0]}");
+
                 _server.Broadcast((byte)channelNo, packet);
                 return true;
             }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -4169,10 +4169,7 @@ namespace PacketDefinitions420
         /// </summary>
         /// <param name="u">Unit that is dashing.</param>
         /// TODO: Implement ForceMovement class which houses these parameters, then have that as the only parameter to this function (and other Dash-based functions).
-        public void NotifyWaypointGroupWithSpeed
-        (
-            IAttackableUnit u
-        )
+        public void NotifyWaypointGroupWithSpeed(IAttackableUnit u)
         {
             // TODO: Implement Dash class and house a List of these with waypoints.
             var md = PacketExtensions.CreateMovementDataWithSpeed(u, _navGrid);
@@ -4183,13 +4180,6 @@ namespace PacketDefinitions420
                 // TOOD: Implement support for multiple speed-based movements (functionally known as dashes).
                 Movements = new List<MovementDataWithSpeed> { md }
             };
-
-            Console.WriteLine(
-                Newtonsoft.Json.JsonConvert.SerializeObject(
-                    speedWpGroup,
-                    Newtonsoft.Json.Formatting.Indented
-                )
-            );
 
             _packetHandlerManager.BroadcastPacketVision(u, speedWpGroup.GetBytes(), Channel.CHL_S2C);
         }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3776,9 +3776,10 @@ namespace PacketDefinitions420
         /// <param name="position">Position the unit teleported to.</param>
         public void NotifyTeleport(IAttackableUnit unit, Vector2 position)
         {
+            int ticks = Environment.TickCount;
             var md = new MovementDataNormal()
             {
-                SyncID = unit.SyncId,
+                SyncID = ticks,
                 TeleportNetID = unit.NetId,
                 HasTeleportID = true,
                 TeleportID = unit.TeleportID,
@@ -3787,7 +3788,7 @@ namespace PacketDefinitions420
 
             var wpGroup = new WaypointGroup()
             {
-                SyncID = Environment.TickCount,
+                SyncID = ticks,
                 Movements = new List<MovementDataNormal> { md }
             };
 
@@ -4178,10 +4179,17 @@ namespace PacketDefinitions420
 
             var speedWpGroup = new WaypointGroupWithSpeed
             {
-                SyncID = u.SyncId,
+                SyncID = Environment.TickCount,
                 // TOOD: Implement support for multiple speed-based movements (functionally known as dashes).
                 Movements = new List<MovementDataWithSpeed> { md }
             };
+
+            Console.WriteLine(
+                Newtonsoft.Json.JsonConvert.SerializeObject(
+                    speedWpGroup,
+                    Newtonsoft.Json.Formatting.Indented
+                )
+            );
 
             _packetHandlerManager.BroadcastPacketVision(u, speedWpGroup.GetBytes(), Channel.CHL_S2C);
         }
@@ -4194,8 +4202,7 @@ namespace PacketDefinitions420
         {
             var wpList = new WaypointList
             {
-                SenderNetID = unit.NetId,
-                SyncID = unit.SyncId,
+                SyncID = Environment.TickCount,
                 Waypoints = unit.Waypoints
             };
 
@@ -4210,8 +4217,7 @@ namespace PacketDefinitions420
         {
             var wpList = new WaypointList
             {
-                SenderNetID = obj.NetId,
-                SyncID = obj.SyncId,
+                SyncID = Environment.TickCount,
                 Waypoints = waypoints
             };
 
@@ -4265,8 +4271,7 @@ namespace PacketDefinitions420
 
             var speedWpGroup = new WaypointListHeroWithSpeed
             {
-                SenderNetID = u.NetId,
-                SyncID = u.SyncId,
+                SyncID = Environment.TickCount,
                 // TOOD: Implement support for multiple speed-based movements (functionally known as dashes).
                 WaypointSpeedParams = speeds,
                 Waypoints = u.Waypoints
@@ -4286,7 +4291,6 @@ namespace PacketDefinitions420
             var answer = new World_SendCamera_Server_Acknologment
             {
                 //TODO: Check these values
-                SenderNetID = client.Champion.NetId,
                 SyncID = request.SyncID,
             };
             _packetHandlerManager.SendPacket((int)client.PlayerId, answer.GetBytes(), Channel.CHL_S2C, PacketFlags.NONE);


### PR DESCRIPTION
- `KeyValuePair<int, Vector2> CurrentWaypoint` is split into `Vector2 CurrentWaypoint` and `int CurrentWaypointKey` for convenience and integrity.
- Removed unused and not very secure `GetNextWaypoint` function.
- The `Move` function has been rewritten, it is freed from the dependence on `deltaMovement`, so the possibility of "flying" past the waypoint is excluded.
- Added `DashMove` function to control movement while dashing. It follows time and distance constraints, and the remaining frame time can then be given to the `Move` function.
- Calling `SetDashingState(false)` will now reset the waypoints as it is assumed that they were set at the beginning of the jump and that the unit does not then follow them, pushing the target of the dash.
- `WaypointGroupWithSpeed` and similar packets now use `Environment.TickCount` as `SyncID` and `0` as `SenderNetId` because that's how it is in the replays.
- LeeSin limits his jump to `2000` units, as it is in the replays.
- Blitzcrank now pulls the target towards itself instead of towards its position.