### PR TITLE
Build DateTime and tips fix

### DIFF
--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -583,7 +583,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="playerNetId">NetID to send the packet to.</param>
         /// <param name="targetNetId">NetID of the target referenced by the tip.</param>
         /// TODO: tipCommand should be a lib/core enum that gets translated into a league version specific packet enum as it may change over time.
-        void NotifyS2C_HandleTipUpdatep(int userId, string title, string text, string imagePath, byte tipCommand, uint playerNetId, uint targetNetId);
+        void NotifyS2C_HandleTipUpdate(int userId, string title, string text, string imagePath, byte tipCommand, uint playerNetId, uint targetNetId);
         /// <summary>
         /// Sends a packet to all players detailing the stats (CS, kills, deaths, etc) of the player who owns the specified Champion.
         /// </summary>

--- a/GameServerLib/GameServerLib.csproj
+++ b/GameServerLib/GameServerLib.csproj
@@ -21,4 +21,10 @@
     <ProjectReference Include="..\QuadTree\QuadTree.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+      <AssemblyAttribute Include="LeagueSandbox.GameServer.BuildDateTimeAttribute">
+          <_Parameter1>$([System.String]::Concat($([System.DateTime]::UtcNow.ToString("G")), " UTC"))</_Parameter1>
+      </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/GameServerLib/Packets/PacketHandlers/HandleBlueTipClicked.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleBlueTipClicked.cs
@@ -22,7 +22,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
         {
             // TODO: can we use player net id from request?
             var playerNetId = _playerManager.GetPeerInfo(userId).Champion.NetId;
-            _game.PacketNotifier.NotifyS2C_HandleTipUpdatep(userId, "", "", "", 0, playerNetId, req.TipID);
+            _game.PacketNotifier.NotifyS2C_HandleTipUpdate(userId, "", "", "", 0, playerNetId, req.TipID);
 
             var msg = $"Clicked blue tip with netid: {req.TipID}";
             _chatCommandManager.SendDebugMsgFormatted(DebugMsgType.NORMAL, msg);

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -68,13 +68,13 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                         }
 
                         // TODO: send this in one place only
-                        _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int)player.Item2.PlayerId, "Welcome to League Sandbox!",
+                        _game.PacketNotifier.NotifyS2C_HandleTipUpdate((int)player.Item2.PlayerId, "Welcome to League Sandbox!",
                             "This is a WIP project.", "", 0, player.Item2.Champion.NetId,
                             _game.NetworkIdManager.GetNewNetId());
-                        _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int)player.Item2.PlayerId, "Server Build Date",
+                        _game.PacketNotifier.NotifyS2C_HandleTipUpdate((int)player.Item2.PlayerId, "Server Build Date",
                             ServerContext.BuildDateString, "", 0, player.Item2.Champion.NetId,
                             _game.NetworkIdManager.GetNewNetId());
-                        _game.PacketNotifier.NotifyS2C_HandleTipUpdatep((int)player.Item2.PlayerId, "Your Champion:",
+                        _game.PacketNotifier.NotifyS2C_HandleTipUpdate((int)player.Item2.PlayerId, "Your Champion:",
                             player.Item2.Champion.Model, "", 0, player.Item2.Champion.NetId,
                             _game.NetworkIdManager.GetNewNetId());
 

--- a/GameServerLib/ServerContext.cs
+++ b/GameServerLib/ServerContext.cs
@@ -11,57 +11,25 @@ namespace LeagueSandbox.GameServer
     /// </summary>
     public static class ServerContext
     {
-        public static string ExecutingDirectory { get; } = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        public static string ExecutingDirectory => Path.GetDirectoryName(
+            Assembly.GetExecutingAssembly().Location
+        );
 
-        public static string BuildDateString =>
-            BuildDate.GetBuildDateTime().ToString("G", CultureInfo.InvariantCulture) + " UTC";
+        public static string BuildDateString => (
+            Attribute.GetCustomAttribute(
+                Assembly.GetExecutingAssembly(),
+                typeof(BuildDateTimeAttribute)
+            ) as BuildDateTimeAttribute
+        ).Date;
     }
 
-    public static class BuildDate
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public class BuildDateTimeAttribute : Attribute
     {
-        private struct ImageFileHeader
+        public string Date { get; private set; }
+        public BuildDateTimeAttribute(string date)
         {
-            #pragma warning disable 0649
-            public ushort Machine;
-            public ushort NumberOfSections;
-            public uint TimeDateStamp;
-            public uint PointerToSymbolTable;
-            public uint NumberOfSymbols;
-            public ushort SizeOfOptionalHeader;
-            public ushort Characteristics;
-        }
-
-        public static DateTime GetBuildDateTime()
-        {
-            var path = Path.Combine(ServerContext.ExecutingDirectory, "GameServerLib.dll");
-            if (File.Exists(path))
-            {
-                var buffer = new byte[Math.Max(Marshal.SizeOf(typeof(ImageFileHeader)), 4)];
-                using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read))
-                {
-                    fs.Position = 0x3C;
-                    fs.Read(buffer, 0, 4);
-                    fs.Position = BitConverter.ToUInt32(buffer, 0); // COFF header offset
-                    fs.Read(buffer, 0, 4); // "PE\0\0"
-                    fs.Read(buffer, 0, buffer.Length);
-                }
-
-                var pinnedBuffer = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-
-                try
-                {
-                    var coffHeader = (ImageFileHeader)Marshal.PtrToStructure(pinnedBuffer.AddrOfPinnedObject(),
-                        typeof(ImageFileHeader));
-
-                    return new DateTime(1970, 1, 1).AddSeconds(coffHeader.TimeDateStamp);
-                }
-                finally
-                {
-                    pinnedBuffer.Free();
-                }
-            }
-
-            return new DateTime(2014, 11, 20);
+            Date = date;
         }
     }
 }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -2723,15 +2723,15 @@ namespace PacketDefinitions420
         /// <param name="playerNetId">NetID to send the packet to.</param>
         /// <param name="targetNetId">NetID of the target referenced by the tip.</param>
         /// TODO: tipCommand should be a lib/core enum that gets translated into a league version specific packet enum as it may change over time.
-        public void NotifyS2C_HandleTipUpdatep(int userId, string title, string text, string imagePath, byte tipCommand, uint playerNetId, uint targetNetId)
+        public void NotifyS2C_HandleTipUpdate(int userId, string title, string text, string imagePath, byte tipCommand, uint playerNetId, uint targetNetId)
         {
             var packet = new S2C_HandleTipUpdate
             {
                 SenderNetID = playerNetId,
                 TipCommand = tipCommand,
                 TipImagePath = imagePath,
-                TipName = title,
-                TipOther = text,
+                TipName = text,
+                TipOther = title,
                 TipID = targetNetId
             };
             _packetHandlerManager.SendPacket(userId, packet.GetBytes(), Channel.CHL_S2C);


### PR DESCRIPTION
- The title and text of the tips have been swapped.
- The correct build date and time is now displayed at the start of the game.
- Fixed typo in function name.