### PR TITLE
Useable Objects fix

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/AscRelic/AscRelicCaptureChannel.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/AscRelic/AscRelicCaptureChannel.cs
@@ -25,7 +25,7 @@ namespace Buffs
         IParticle p1;
         IRegion r1;
         IRegion r2;
-        float windUpTime;
+        float windUpTime = 1500.0f;
         bool castWindUp = false;
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
@@ -33,10 +33,9 @@ namespace Buffs
             Spell = ownerSpell;
             Owner = buff.SourceUnit;
             Target = ownerSpell.CastInfo.Targets[0].Unit;
+            castWindUp = true;
 
             p1 = AddParticleTarget(buff.SourceUnit, buff.SourceUnit, "OdinCaptureBeam", Target, 1.5f, 1, "buffbone_glb_channel_loc", "spine", flags: (FXFlags)32);
-            windUpTime = 1500.0f;
-            castWindUp = true;
             r1 = AddUnitPerceptionBubble(unit, 0.0f, buff.Duration, TeamId.TEAM_BLUE, true, unit);
             r2 = AddUnitPerceptionBubble(unit, 0.0f, buff.Duration, TeamId.TEAM_PURPLE, true, unit);
         }

--- a/Content/LeagueSandbox-Scripts/Buffs/AscRelic/AscRelicSuppression.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/AscRelic/AscRelicSuppression.cs
@@ -20,6 +20,7 @@ namespace Buffs
         public IStatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
         IBuff Buff;
+        float timer = 100.0f;
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             Buff = buff;
@@ -34,10 +35,18 @@ namespace Buffs
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             ApiEventManager.OnDeath.RemoveListener(this);
+            unit.Stats.CurrentMana = unit.Stats.ManaPoints.Total;
         }
 
         public void OnUpdate(float diff)
         {
+            timer -= diff;
+            if(timer <= 0)
+            {
+                //Exact values for both Current Mana reduction and timer are unknow, these are approximations.
+                Buff.TargetUnit.Stats.CurrentMana -= 700;
+                timer = 530;
+            }
         }
     }
 }

--- a/Content/LeagueSandbox-Scripts/Characters/AscRelic/AscRelicCaptureChannel.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/AscRelic/AscRelicCaptureChannel.cs
@@ -7,6 +7,7 @@ using LeagueSandbox.GameServer.API;
 using GameServerCore.Scripting.CSharp;
 using GameServerCore.Enums;
 using GameServerCore.Domain;
+using System.Collections.Generic;
 
 namespace Spells
 {
@@ -82,6 +83,7 @@ namespace Spells
             if (spell.CastInfo.Targets[0].Unit != null)
             {
                 var crystal = spell.CastInfo.Targets[0].Unit;
+                //I Suspect that the condition that actually kills the crystal is it running out of mana, have to investigate further.
                 crystal.Die(CreateDeathData(false, 0, crystal, crystal, DamageType.DAMAGE_TYPE_TRUE, DamageSource.DAMAGE_SOURCE_INTERNALRAW, 0.0f));
 
                 if (spell.CastInfo.Owner is IChampion ch)
@@ -95,31 +97,21 @@ namespace Spells
 
         public void StopChannel()
         {
-            var relicSupression = Target.GetBuffWithName("AscRelicSuppression");
-            var orderSupression = Target.GetBuffWithName("OdinBombSuppressionOrder");
-            var chaosSupression = Target.GetBuffWithName("OdinBombSuppressionChaos");
-            var captureChannel = Spell.CastInfo.Owner.GetBuffWithName("AscRelicCaptureChannel");
-            var odinChannelVision = Spell.CastInfo.Owner.GetBuffWithName("OdinChannelVision");
+            List<IBuff> buffs = new List<IBuff>
+            {
+                Target.GetBuffWithName("AscRelicSuppression"),
+                Target.GetBuffWithName("OdinBombSuppressionOrder"),
+                Target.GetBuffWithName("OdinBombSuppressionChaos"),
+                Spell.CastInfo.Owner.GetBuffWithName("AscRelicCaptureChannel"),
+                Spell.CastInfo.Owner.GetBuffWithName("OdinChannelVision")
+            };
 
-            if (relicSupression != null)
+            foreach(var buff in buffs)
             {
-                relicSupression.DeactivateBuff();
-            }
-            if (orderSupression != null)
-            {
-                orderSupression.DeactivateBuff();
-            }
-            if (chaosSupression != null)
-            {
-                chaosSupression.DeactivateBuff();
-            }
-            if (captureChannel != null)
-            {
-                captureChannel.DeactivateBuff();
-            }
-            if (odinChannelVision != null)
-            {
-                odinChannelVision.DeactivateBuff();
+                if (buff != null)
+                {
+                    buff.DeactivateBuff();
+                }
             }
 
             Owner.StopAnimation("", true, true);

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -865,7 +865,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             bool targetable = Status.HasFlag(StatusFlags.Targetable);
             Stats.IsTargetable = targetable;
             // TODO: Refactor this.
-            if (CharData.IsUseable)
+            if (!CharData.IsUseable)
             {
                 Stats.SetActionState(ActionState.TARGETABLE, targetable);
             }

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -853,10 +853,10 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             {
                 var spellTarget = CastInfo.Targets[0].Unit;
 
-                if (spellTarget != null
-                && (!spellTarget.IsVisibleByTeam(CastInfo.Owner.Team)
-                || (!spellTarget.Status.HasFlag(StatusFlags.Targetable) && spellTarget.CharData.IsUseable)
-                || spellTarget.IsDead))
+                if (spellTarget != null && (!spellTarget.IsVisibleByTeam(CastInfo.Owner.Team) || (!spellTarget.Status.HasFlag(StatusFlags.Targetable) && !spellTarget.CharData.IsUseable) || spellTarget.IsDead))
+
+
+
                 {
                     CastInfo.Owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.LostTarget);
                     return;

--- a/GameServerLib/GameObjects/Stats/Replication/ReplicationMinion.cs
+++ b/GameServerLib/GameObjects/Stats/Replication/ReplicationMinion.cs
@@ -15,8 +15,8 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             // UpdateFloat(Stats.LifeTime, 1, 2); //mLifetime
             // UpdateFloat(Stats.MaxLifeTime, 1, 3); //mMaxLifetime
             // UpdateFloat(Stats.LifeTimeTicks, 1, 4); //mLifetimeTicks
-            // UpdateFloat(Stats.ManaPoints.Total, 1, 5); //mMaxMP
-            // UpdateFloat(Stats.CurrentMana, 1, 6); //mMP
+            UpdateFloat(Stats.ManaPoints.Total, 1, 5); //mMaxMP
+            UpdateFloat(Stats.CurrentMana, 1, 6); //mMP
             UpdateUint((uint)Stats.ActionState, 1, 7); //ActionState
             UpdateBool(Stats.IsMagicImmune, 1, 8); //MagicImmune
             UpdateBool(Stats.IsInvulnerable, 1, 9); //IsInvulnerable


### PR DESCRIPTION
* Some update broke Useable Objects, causing them to not be clickable, while also making all other units clickable even though they're supposed to be untargetable. Simple `If` condition swapping.
* Uncommented `Mana.Total` and `CurrentMana` stats from the Minion's replication, as they seemed to work fine.
* With Minions now having their PAR notified, it was possible to do the whole "shrinking" thing with crystals, as they're particles bound to the owner's PAR (I couldn't find any specific info on the original values regarding the timing and how much mana would get reduced, so i ended up just watching videos and comparing it to be as close as possible).