### PR TITLE
`PlayerID` vs `ClientID`

### DIFF
--- a/GameServerConsole/Program.cs
+++ b/GameServerConsole/Program.cs
@@ -55,7 +55,7 @@ namespace LeagueSandbox.GameServerConsole
                     var startInfo = new ProcessStartInfo(leaguePath)
                     {
                         Arguments = String.Format("\"8394\" \"LoLLauncher.exe\" \"\" \"127.0.0.1 {0} {1} 1\"",
-                            parsedArgs.ServerPort, gameServerLauncher.game.Config.Players.First().Value.BlowfishKey),
+                            parsedArgs.ServerPort, gameServerLauncher.game.Config.Players.First().BlowfishKey),
                         WorkingDirectory = Path.GetDirectoryName(leaguePath)
                     };
 

--- a/GameServerCore/Domain/GameObjects/IChampion.cs
+++ b/GameServerCore/Domain/GameObjects/IChampion.cs
@@ -6,6 +6,7 @@ namespace GameServerCore.Domain.GameObjects
 {
     public interface IChampion : IObjAiBase
     {
+        int ClientId { get; }
         IShop Shop { get; }
         float RespawnTimer { get; }
         int DeathSpree { get; set; }
@@ -20,9 +21,7 @@ namespace GameServerCore.Domain.GameObjects
         // basic
         void AddGold(IAttackableUnit source, float gold, bool notify = true);
         void UpdateSkin(int skinNo);
-        uint GetPlayerId();
         void AddExperience(float experience, bool notify = true);
-        bool LevelUp(bool force = false);
         void Recall();
         void Respawn();
         bool OnDisconnect();

--- a/GameServerCore/Domain/IPlayerConfig.cs
+++ b/GameServerCore/Domain/IPlayerConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace GameServerCore.Domain
+﻿using GameServerCore.Enums;
+
+namespace GameServerCore.Domain
 {
     public interface IPlayerConfig
     {
@@ -6,7 +8,7 @@
         string Rank { get; }
         string Name { get; }
         string Champion { get; }
-        string Team { get; }
+        TeamId Team { get; }
         short Skin { get; }
         string Summoner1 { get; }
         string Summoner2 { get; }

--- a/GameServerCore/IPlayerManager.cs
+++ b/GameServerCore/IPlayerManager.cs
@@ -10,8 +10,9 @@ namespace GameServerCore
     {
         void AddPlayer(IPlayerConfig config);
         void AddPlayer(ClientInfo info);
-        ClientInfo GetClientInfoByChampion(IChampion champ);
         ClientInfo GetPeerInfo(int userId);
+        ClientInfo GetClientInfoByPlayerId(long playerId);
+        ClientInfo GetClientInfoByChampion(IChampion champ);
         List<ClientInfo> GetPlayers(bool includeBots = false);
     }
 }

--- a/GameServerCore/IPlayerManager.cs
+++ b/GameServerCore/IPlayerManager.cs
@@ -8,10 +8,10 @@ namespace GameServerCore
 {
     public interface IPlayerManager
     {
-        void AddPlayer(KeyValuePair<string, IPlayerConfig> p);
-        void AddPlayer(Tuple<uint, ClientInfo> p);
+        void AddPlayer(IPlayerConfig config);
+        void AddPlayer(ClientInfo info);
         ClientInfo GetClientInfoByChampion(IChampion champ);
-        ClientInfo GetPeerInfo(long playerId);
-        List<Tuple<uint, ClientInfo>> GetPlayers(bool includeBots = false);
+        ClientInfo GetPeerInfo(int userId);
+        List<ClientInfo> GetPlayers(bool includeBots = false);
     }
 }

--- a/GameServerCore/NetInfo/ClientInfo.cs
+++ b/GameServerCore/NetInfo/ClientInfo.cs
@@ -6,7 +6,7 @@ namespace GameServerCore.NetInfo
     public class ClientInfo
     {
         public long PlayerId { get; private set; }
-        public uint ClientId { get; set; }
+        public int ClientId { get; set; }
         public bool IsMatchingVersion { get; set; }
         public bool IsDisconnected { get; set; }
         public bool IsStartedClient { get; set; }

--- a/GameServerCore/Packets/Handlers/NetworkHandler.cs
+++ b/GameServerCore/Packets/Handlers/NetworkHandler.cs
@@ -23,8 +23,6 @@ namespace GameServerCore.Packets.Handlers
         // every message (bridge->server or server->bridge) pass should pass here
         public bool OnMessage<T>(int userId, T req) where T: MessageType
         {
-            Console.WriteLine($"MESSAGE FROM {userId}");
-
             var handlerList = _handlers[req.GetType()];
             bool success = true;
             foreach (MessageHandler<T> handler in handlerList)

--- a/GameServerCore/Packets/Handlers/NetworkHandler.cs
+++ b/GameServerCore/Packets/Handlers/NetworkHandler.cs
@@ -23,6 +23,8 @@ namespace GameServerCore.Packets.Handlers
         // every message (bridge->server or server->bridge) pass should pass here
         public bool OnMessage<T>(int userId, T req) where T: MessageType
         {
+            Console.WriteLine($"MESSAGE FROM {userId}");
+
             var handlerList = _handlers[req.GetType()];
             bool success = true;
             foreach (MessageHandler<T> handler in handlerList)

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -211,8 +211,8 @@ namespace GameServerCore.Packets.Interfaces
         /// Sends a packet to, optionally, a specified player, all players with vision of the particle, or all players (given the particle is set as globally visible).
         /// </summary>
         /// <param name="particle">Particle to network.</param>
-        /// <param name="playerId">User to send the packet to.</param>
-        void NotifyFXCreateGroup(IParticle particle, int playerId = 0);
+        /// <param name="userId">User to send the packet to.</param>
+        void NotifyFXCreateGroup(IParticle particle, int userId = 0);
         /// <summary>
         /// Sends a packet to the specified team detailing that the specified Particle has become visible.
         /// </summary>
@@ -283,7 +283,7 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// <param name="userId">User to send the packet to.</param>
         /// <param name="players">Client info of all players in the loading screen.</param>
-        void NotifyLoadScreenInfo(int userId, List<Tuple<uint, ClientInfo>> players);
+        void NotifyLoadScreenInfo(int userId, List<ClientInfo> players);
         /// <summary>
         /// Optionally sends a packet to all players who have vision of the specified Minion detailing that it has spawned.
         /// </summary>
@@ -514,13 +514,13 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// <param name="userId">User to send the packet to.</param>
         /// <param name="player">Player information to send.</param>
-        void NotifyRequestRename(int userId, Tuple<uint, ClientInfo> player);
+        void NotifyRequestRename(int userId, ClientInfo player);
         /// <summary>
         /// Sends a packet to the specified player detailing skin information of all specified players on the loading screen.
         /// </summary>
         /// <param name="userId">User to send the packet to.</param>
         /// <param name="player">Player information to send.</param>
-        void NotifyRequestReskin(int userId, Tuple<uint, ClientInfo> player);
+        void NotifyRequestReskin(int userId, ClientInfo player);
         /// <summary>
         /// Sends a packet to all players detailing that the game has been unpaused.
         /// </summary>
@@ -558,7 +558,7 @@ namespace GameServerCore.Packets.Interfaces
         /// Disables the UI for ther end of the game
         /// </summary>
         /// <param name="player">Player for the UI to be disabled</param>
-        void NotifyS2C_DisableHUDForEndOfGame(Tuple<uint, ClientInfo> player);
+        void NotifyS2C_DisableHUDForEndOfGame(ClientInfo player);
         /// <summary>
         /// Sends packets to all players notifying the result of a match (Victory or defeat)
         /// </summary>
@@ -607,7 +607,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="travelTime">The time the camera will have to travel the given distance</param>
         /// <param name="startFromCurretPosition">Wheter or not it starts from current position</param>
         /// <param name="unlockCamera">Whether or not the camera is unlocked</param>
-        void NotifyS2C_MoveCameraToPoint(Tuple<uint, ClientInfo> player, Vector3 startPosition, Vector3 endPosition, float travelTime = 0, bool startFromCurretPosition = true, bool unlockCamera = false);
+        void NotifyS2C_MoveCameraToPoint(ClientInfo player, Vector3 startPosition, Vector3 endPosition, float travelTime = 0, bool startFromCurretPosition = true, bool unlockCamera = false);
         void NotifyS2C_Neutral_Camp_Empty(IMonsterCamp monsterCamp, IDeathData deathData = null, int userId = 0);
         /// <summary>
         /// Sends a packet to all players detailing that the specified unit has been killed by the specified killer.
@@ -849,7 +849,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="version">Version of the player being checked.</param>
         /// <param name="gameMode">String of the internal name of the gamemode being played.</param>
         /// <param name="mapId">ID of the map being played.</param>
-        void NotifySynchVersion(int userId, List<Tuple<uint, ClientInfo>> players, string version, string gameMode, int mapId);
+        void NotifySynchVersion(int userId, List<ClientInfo> players, string version, string gameMode, int mapId);
         /// <summary>
         /// Sends a packet to the specified player detailing the status (results) of a surrender vote that was called for and ended.
         /// </summary>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -137,7 +137,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="currentCd">Amount of time the spell has already been on cooldown (if applicable).</param>
         /// <param name="totalCd">Amount of time that the spell should have be in cooldown before going off cooldown.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
-        void NotifyCHAR_SetCooldown(IObjAiBase c, byte slotId, float currentCd, float totalCd, int userId = 0);
+        void NotifyCHAR_SetCooldown(IObjAiBase c, byte slotId, float currentCd, float totalCd, int userId = -1);
         /// <summary>
         /// Sends a packet to the specified user that highlights the specified GameObject.
         /// </summary>
@@ -170,7 +170,7 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// <param name="floatTextData">Contains all the data from a floating text.</param>
         /// <param name="userId">User to send to. 0 = sends to all in vision.</param>
-        void NotifyDisplayFloatingText(IFloatingTextData floatTextData, TeamId team = 0, int userId = 0);
+        void NotifyDisplayFloatingText(IFloatingTextData floatTextData, TeamId team = 0, int userId = -1);
         /// <summary>
         /// Sends a packet to the specified user detailing that the GameObject that owns the specified netId has finished being initialized into vision.
         /// </summary>
@@ -183,7 +183,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="o">GameObject coming into vision.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="ignoreVision">Optionally ignore vision checks when sending this packet and broadcast it to all players instead.</param>
-        void NotifyEnterLocalVisibilityClient(IGameObject o, int userId = 0, bool ignoreVision = false);
+        void NotifyEnterLocalVisibilityClient(IGameObject o, int userId = -1, bool ignoreVision = false);
         /// <summary>
         /// Sends a packet to either all players with vision of the specified object or the specified user. The packet details the data surrounding the specified GameObject that is required by players when a GameObject enters vision such as items, shields, skin, and movements.
         /// </summary>
@@ -193,7 +193,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="ignoreVision">Optionally ignore vision checks when sending this packet.</param>
         /// <param name="packets">Takes in a list of packets to send alongside this vision packet.</param>
         /// TODO: Incomplete implementation.
-        void NotifyEnterVisibilityClient(IGameObject o, int userId = 0, bool isChampion = false, bool ignoreVision = false, List<GamePacket> packets = null);
+        void NotifyEnterVisibilityClient(IGameObject o, int userId = -1, bool isChampion = false, bool ignoreVision = false, List<GamePacket> packets = null);
         /// <summary>
         /// Sends a packet to all players with vision of the specified unit detailing that the unit has begun facing the specified direction.
         /// </summary>
@@ -212,7 +212,7 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// <param name="particle">Particle to network.</param>
         /// <param name="userId">User to send the packet to.</param>
-        void NotifyFXCreateGroup(IParticle particle, int userId = 0);
+        void NotifyFXCreateGroup(IParticle particle, int userId = -1);
         /// <summary>
         /// Sends a packet to the specified team detailing that the specified Particle has become visible.
         /// </summary>
@@ -235,7 +235,7 @@ namespace GameServerCore.Packets.Interfaces
         /// Sends a packet to all players detailing that the game has started. Sent when all players have finished loading.
         /// </summary>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players.</param>
-        void NotifyGameStart(int userId = 0);
+        void NotifyGameStart(int userId = -1);
         /// <summary>
         /// Sends a packet to all players detailing the state (DEAD/ALIVE) of the specified inhibitor.
         /// </summary>
@@ -264,20 +264,20 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="o">GameObject that left vision.</param>
         /// <param name="team">TeamId to send the packet to; BLUE/PURPLE/NEUTRAL.</param>
         /// <param name="userId">User to send the packet to.</param>
-        void NotifyLeaveLocalVisibilityClient(IGameObject o, TeamId team, int userId = 0);
+        void NotifyLeaveLocalVisibilityClient(IGameObject o, TeamId team, int userId = -1);
         /// <summary>
         /// Sends a packet to either the specified user or team detailing that the specified GameObject has left vision.
         /// </summary>
         /// <param name="o">GameObject that left vision.</param>
         /// <param name="team">TeamId to send the packet to; BLUE/PURPLE/NEUTRAL.</param>
         /// <param name="userId">User to send the packet to (if applicable).</param>
-        void NotifyLeaveVisibilityClient(IGameObject o, TeamId team, int userId = 0);
+        void NotifyLeaveVisibilityClient(IGameObject o, TeamId team, int userId = -1);
         /// <summary>
         /// Sends a packet to either all players or the specified player detailing that the specified GameObject of type LevelProp has spawned.
         /// </summary>
         /// <param name="levelProp">LevelProp that has spawned.</param>
         /// <param name="userId">User to send the packet to.</param>
-        void NotifySpawnLevelPropS2C(ILevelProp levelProp, int userId = 0);
+        void NotifySpawnLevelPropS2C(ILevelProp levelProp, int userId = -1);
         /// <summary>
         /// Sends a packet to the specified player detailing the load screen information.
         /// </summary>
@@ -304,7 +304,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="modelOnly">Wether or not it's only the model that it's being changed(?). I don't really know what's this for</param>
         /// <param name="overrideSpells">Wether or not the user's spells should be overriden, i assume it would be used for things like Nidalee or Elise.</param>
         /// <param name="replaceCharacterPackage">Unknown.</param>
-        void NotifyS2C_ChangeCharacterData(IAttackableUnit obj, int userId = 0, uint skinID = 0, bool modelOnly = true, bool overrideSpells = false, bool replaceCharacterPackage = false);
+        void NotifyS2C_ChangeCharacterData(IAttackableUnit obj, int userId = -1, uint skinID = 0, bool modelOnly = true, bool overrideSpells = false, bool replaceCharacterPackage = false);
         /// <summary>
         /// Sends a packet to the specified player detailing that the specified debug object's radius has changed.
         /// </summary>
@@ -466,7 +466,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="partial">Whether or not the packet should only include stats marked as changed.</param>
         /// TODO: Replace with LeaguePackets and preferably move all uses of this function to a central EventHandler class (if one is fully implemented).
-        void NotifyOnReplication(IAttackableUnit u, int userId = 0, bool partial = true);
+        void NotifyOnReplication(IAttackableUnit u, int userId = -1, bool partial = true);
         /// <summary>
         /// Sends a packet to all players detailing that the game has paused.
         /// </summary>
@@ -527,7 +527,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="unpauser">Unit that unpaused the game.</param>
         /// <param name="showWindow">Whether or not to show a window before unpausing (delay).</param>
         void NotifyResumePacket(IChampion unpauser, ClientInfo player, bool isDelayed);
-        void NotifyS2C_ActivateMinionCamp(IMonsterCamp monsterCamp, int userId = 0);
+        void NotifyS2C_ActivateMinionCamp(IMonsterCamp monsterCamp, int userId = -1);
         void NotifyS2C_AmmoUpdate(ISpell spell);
         /// <summary>
         /// Sends a packet to all players with vision of the given chain missile that it has updated (unit/position).
@@ -546,14 +546,14 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="userId">User to send the packet to. Set to -1 to broadcast.</param>
         /// <param name="doVision">Whether or not to package the packets into a vision packet.</param>
         void NotifyS2C_CreateHero(ClientInfo clientInfo, int userId = -1, bool doVision = false);
-        void NotifyS2C_CreateMinionCamp(IMonsterCamp monsterCamp, int userId = 0);
+        void NotifyS2C_CreateMinionCamp(IMonsterCamp monsterCamp, int userId = -1);
         void NotifyS2C_CreateNeutral(IMonster monster, float time);
         /// <summary>
         /// Sends a packet to either all players or the specified player detailing that the specified LaneTurret has spawned.
         /// </summary>
         /// <param name="turret">LaneTurret that spawned.</param>
         /// <param name="userId">User to send the packet to.</param>
-        void NotifyS2C_CreateTurret(ILaneTurret turret, int userId = 0);
+        void NotifyS2C_CreateTurret(ILaneTurret turret, int userId = -1);
         /// <summary>
         /// Disables the UI for ther end of the game
         /// </summary>
@@ -608,7 +608,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="startFromCurretPosition">Wheter or not it starts from current position</param>
         /// <param name="unlockCamera">Whether or not the camera is unlocked</param>
         void NotifyS2C_MoveCameraToPoint(ClientInfo player, Vector3 startPosition, Vector3 endPosition, float travelTime = 0, bool startFromCurretPosition = true, bool unlockCamera = false);
-        void NotifyS2C_Neutral_Camp_Empty(IMonsterCamp monsterCamp, IDeathData deathData = null, int userId = 0);
+        void NotifyS2C_Neutral_Camp_Empty(IMonsterCamp monsterCamp, IDeathData deathData = null, int userId = -1);
         /// <summary>
         /// Sends a packet to all players detailing that the specified unit has been killed by the specified killer.
         /// </summary>
@@ -620,7 +620,7 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// <param name="o">GameObject coming into vision.</param>
         /// <param name="userId">User to send the packet to.</param>
-        void NotifyS2C_OnEnterTeamVisibility(IGameObject o, TeamId team, int userId = 0);
+        void NotifyS2C_OnEnterTeamVisibility(IGameObject o, TeamId team, int userId = -1);
         void NotifyOnEvent(IEvent gameEvent, IAttackableUnit sender = null);
         /// <summary>
         /// Sends a packet to all players that announces a specified message (ex: "Minions have spawned.")
@@ -634,7 +634,7 @@ namespace GameServerCore.Packets.Interfaces
         /// </summary>
         /// <param name="o">GameObject going out of vision.</param>
         /// <param name="userId">User to send the packet to.</param>
-        void NotifyS2C_OnLeaveTeamVisibility(IGameObject o, TeamId team, int userId = 0);
+        void NotifyS2C_OnLeaveTeamVisibility(IGameObject o, TeamId team, int userId = -1);
         /// <summary>
         /// Sends a packet to all players detailing that the specified object's current animations have been paused/unpaused.
         /// </summary>
@@ -935,7 +935,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="team">Team which is affected by this visibility change.</param>
         /// <param name="becameVisible">Whether or not the change was an entry into vision.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to the team.</param>
-        void NotifyVisibilityChange(IGameObject obj, TeamId team, bool becameVisible, int userId = 0);
+        void NotifyVisibilityChange(IGameObject obj, TeamId team, bool becameVisible, int userId = -1);
         /// <summary>
         /// Creates a package and puts it in the queue that will be emptied with the NotifyWaypointGroup call.
         /// </summary>
@@ -964,7 +964,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="u">AttackableUnit that is moving.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="useTeleportID">Whether or not to teleport the unit to its current position in its path.</param>
-        void NotifyWaypointGroup(IAttackableUnit u, int userId = 0, bool useTeleportID = false);
+        void NotifyWaypointGroup(IAttackableUnit u, int userId = -1, bool useTeleportID = false);
         /// <summary>
         /// Sends a packet to all players that have vision of the specified unit.
         /// The packet details a group of waypoints with speed parameters which determine what kind of movement will be done to reach the waypoints, or optionally a GameObject.

--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -386,8 +386,8 @@ namespace LeagueSandbox.GameServer.API
         public static void NotifySpawnBroadcast(IGameObject obj)
         {
             //Just a workaround for our current vision problem.
-            _game.PacketNotifier.NotifySpawn(obj, TeamId.TEAM_PURPLE, 0, _game.GameTime, true);
-            _game.PacketNotifier.NotifySpawn(obj, TeamId.TEAM_BLUE, 0, _game.GameTime, true);
+            _game.PacketNotifier.NotifySpawn(obj, TeamId.TEAM_PURPLE, -1, _game.GameTime, true);
+            _game.PacketNotifier.NotifySpawn(obj, TeamId.TEAM_BLUE, -1, _game.GameTime, true);
         }
 
         public static void AddObject(IGameObject obj)

--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -405,7 +405,7 @@ namespace LeagueSandbox.GameServer.API
             var players = _game.PlayerManager.GetPlayers(true);
             foreach (var player in players)
             {
-                average += player.Item2.Champion.Stats.Level / players.Count;
+                average += player.Champion.Stats.Level / players.Count;
             }
             return (int)average;
         }

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -681,7 +681,7 @@ namespace LeagueSandbox.GameServer.API
             var toreturn = new List<IChampion>();
             foreach (var player in _game.PlayerManager.GetPlayers(true))
             {
-                toreturn.Add(player.Item2.Champion);
+                toreturn.Add(player.Champion);
             }
             return toreturn;
         }
@@ -931,7 +931,7 @@ namespace LeagueSandbox.GameServer.API
             {
                 _game.PacketNotifier.NotifyChangeSlotSpellData
                 (
-                    (int)_game.PlayerManager.GetClientInfoByChampion(champion).PlayerId,
+                    _game.PlayerManager.GetClientInfoByChampion(champion).ClientId,
                     target,
                     (byte)slot,
                     ChangeSlotSpellDataType.TargetingType,

--- a/GameServerLib/Chatbox/Commands/ChCommand.cs
+++ b/GameServerLib/Chatbox/Commands/ChCommand.cs
@@ -32,8 +32,6 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             var c = new Champion(
                 Game,
                 split[1],
-                (uint)_playerManager.GetPeerInfo(userId).PlayerId,
-                0, // Doesnt matter at this point
                 currentChampion.RuneList,
                 currentChampion.TalentInventory,
                 _playerManager.GetClientInfoByChampion(currentChampion),

--- a/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
+++ b/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
@@ -157,7 +157,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             DrawAttackableUnit(_userChampion, userId);
         }
 
-        void DrawAttackableUnit(IAttackableUnit u, int userId = 0)
+        void DrawAttackableUnit(IAttackableUnit u, int userId = -1)
         {
             // Arbitrary ratio is required for the DebugCircle particle to look accurate
             var circlesize = _debugCircleScale * u.PathfindingRadius;

--- a/GameServerLib/Chatbox/Commands/SpawnCommand.cs
+++ b/GameServerLib/Chatbox/Commands/SpawnCommand.cs
@@ -150,16 +150,12 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             var runesTemp = new RuneCollection();
             var talents = new TalentInventory();
             var clientInfoTemp = new ClientInfo("", team, 0, 0, 0, model, new string[] { "SummonerHeal", "SummonerFlash" }, -1);
-            uint num = (uint)_playerManager.GetPlayers(true).Count + 1;
-            var playerTemp = new Tuple<uint, ClientInfo>(num, clientInfoTemp);
 
-            _playerManager.AddPlayer(playerTemp);
+            _playerManager.AddPlayer(clientInfoTemp);
 
             var c = new Champion(
                 Game,
                 model,
-                0,
-                0, // Doesnt matter at this point
                 runesTemp,
                 talents,
                 clientInfoTemp,

--- a/GameServerLib/Config.cs
+++ b/GameServerLib/Config.cs
@@ -22,7 +22,7 @@ namespace LeagueSandbox.GameServer
     /// </summary>
     public class Config
     {
-        public Dictionary<string, IPlayerConfig> Players { get; private set; }
+        public List<IPlayerConfig> Players { get; private set; }
         public GameConfig GameConfig { get; private set; }
         public ContentManager ContentManager { get; private set; }
         public FeatureFlags GameFeatures { get; private set; }
@@ -82,14 +82,14 @@ namespace LeagueSandbox.GameServer
             // Load data package
             ContentManager = ContentManager.LoadDataPackage(game, GameConfig.DataPackage, ContentPath);
 
-            Players = new Dictionary<string, IPlayerConfig>();
+            Players = new List<IPlayerConfig>();
 
             // Read the player configuration
             var playerConfigurations = data.SelectToken("players");
             foreach (var player in playerConfigurations)
             {
                 var playerConfig = new PlayerConfig(player, game);
-                Players.Add($"player{playerConfig.PlayerID}", playerConfig);
+                Players.Add(playerConfig);
             }
         }
 
@@ -235,7 +235,7 @@ public class PlayerConfig : IPlayerConfig
     public string Rank { get; private set; }
     public string Name { get; private set; }
     public string Champion { get; private set; }
-    public string Team { get; private set; }
+    public TeamId Team { get; private set; }
     public short Skin { get; private set; }
     public string Summoner1 { get; private set; }
     public string Summoner2 { get; private set; }
@@ -253,7 +253,13 @@ public class PlayerConfig : IPlayerConfig
         Rank = (string)playerData.SelectToken("rank");
         Name = (string)playerData.SelectToken("name");
         Champion = (string)playerData.SelectToken("champion");
-        Team = (string)playerData.SelectToken("team");
+
+        Team = TeamId.TEAM_PURPLE;
+        if (((string)playerData.SelectToken("team")).ToLower().Equals("blue"))
+        {
+            Team = TeamId.TEAM_BLUE;
+        }
+        
         Skin = (short)playerData.SelectToken("skin");
         Summoner1 = (string)playerData.SelectToken("summoner1");
         Summoner2 = (string)playerData.SelectToken("summoner2");

--- a/GameServerLib/Game.cs
+++ b/GameServerLib/Game.cs
@@ -176,7 +176,7 @@ namespace LeagueSandbox.GameServer
             _logger.Info("Add players");
             foreach (var p in Config.Players)
             {
-                _logger.Info("Player " + p.Value.Name + " Added: " + p.Value.Champion);
+                _logger.Info("Player " + p.Name + " Added: " + p.Champion);
                 ((PlayerManager)PlayerManager).AddPlayer(p);
             }
 
@@ -330,10 +330,10 @@ namespace LeagueSandbox.GameServer
 
                             // Pure water framing
                             var players = PlayerManager.GetPlayers();
-                            var unpauser = players[0].Item2.Champion;
+                            var unpauser = players[0].Champion;
                             foreach (var player in players)
                             {
-                                PacketNotifier.NotifyResumePacket(unpauser, player.Item2, false);
+                                PacketNotifier.NotifyResumePacket(unpauser, player, false);
                             }
                             Unpause();
                         }
@@ -439,7 +439,7 @@ namespace LeagueSandbox.GameServer
             IsPaused = true;
             foreach (var player in PlayerManager.GetPlayers())
             {
-                PacketNotifier.NotifyPausePacket(player.Item2, (int)PauseTimeLeft, true);
+                PacketNotifier.NotifyPausePacket(player, (int)PauseTimeLeft, true);
             }
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
@@ -59,8 +59,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
                 foreach (var player in _game.PlayerManager.GetPlayers())
                 {
-                    var champion = player.Item2.Champion;
-                    if (player.Item2.Team != Team)
+                    var champion = player.Champion;
+                    if (player.Team != Team)
                     {
                         if (!championsInRange.Contains(champion))
                         {
@@ -72,10 +72,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
             else
             {
-                foreach (var player in _game.PlayerManager.GetPlayers().FindAll(x => x.Item2.Team != Team))
+                foreach (var player in _game.PlayerManager.GetPlayers())
                 {
-                    var champion = player.Item2.Champion;
-                    if (player.Item2.Team != Team)
+                    var champion = player.Champion;
+                    if (player.Team != Team)
                     {
                         {
                             champion.AddGold(champion, globalGold);

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -858,7 +858,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             if (this is IChampion champion)
             {
-                int userId = (int)_game.PlayerManager.GetClientInfoByChampion(champion).PlayerId;
+                int userId = _game.PlayerManager.GetClientInfoByChampion(champion).ClientId;
                 // TODO: Verify if this is all that is needed.
                 _game.PacketNotifier.NotifyChangeSlotSpellData(userId, champion, slot, ChangeSlotSpellDataType.SpellName, slot == 4 || slot == 5, newName: name);
                 if (networkOld)
@@ -1008,8 +1008,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             if (this is IChampion champion)
             {
-                _game.PacketNotifier.NotifyS2C_SetSpellData((int)_game.PlayerManager.GetClientInfoByChampion(champion).PlayerId, NetId, slot2Name, slot1);
-                _game.PacketNotifier.NotifyS2C_SetSpellData((int)_game.PlayerManager.GetClientInfoByChampion(champion).PlayerId, NetId, slot1Name, slot2);
+                int clientId = _game.PlayerManager.GetClientInfoByChampion(champion).ClientId;
+                _game.PacketNotifier.NotifyS2C_SetSpellData(clientId, NetId, slot2Name, slot1);
+                _game.PacketNotifier.NotifyS2C_SetSpellData(clientId, NetId, slot1Name, slot2);
             }
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -644,17 +644,17 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             // todo: check if damage dealt by disconnected players cause anything bad
             if (attacker is IChampion attackerChamp)
             {
-                attackerId = (int)_game.PlayerManager.GetClientInfoByChampion(attackerChamp).PlayerId;
+                attackerId = _game.PlayerManager.GetClientInfoByChampion(attackerChamp).ClientId;
             }
 
             if (this is IChampion targetChamp)
             {
-                targetId = (int)_game.PlayerManager.GetClientInfoByChampion(targetChamp).PlayerId;
+                targetId = _game.PlayerManager.GetClientInfoByChampion(targetChamp).ClientId;
             }
             // Show damage text for owner of pet
             if (attacker is IPet attackerPet && attackerPet.Owner is IChampion)
             {
-                attackerId = (int)_game.PlayerManager.GetClientInfoByChampion((IChampion)attackerPet.Owner).PlayerId;
+                attackerId = _game.PlayerManager.GetClientInfoByChampion((IChampion)attackerPet.Owner).ClientId;
             }
 
             if (attacker.Team != Team)

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -1454,7 +1454,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             {
                 _game.PacketNotifier.NotifyChangeSlotSpellData
                 (
-                    (int)_game.PlayerManager.GetClientInfoByChampion(champion).PlayerId,
+                    _game.PlayerManager.GetClientInfoByChampion(champion).ClientId,
                     champion,
                     (byte)CastInfo.SpellSlot,
                     ChangeSlotSpellDataType.Range,
@@ -1507,7 +1507,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
 
             if (CastInfo.Owner is IChampion champion)
             {
-                _game.PacketNotifier.NotifyS2C_SetSpellLevel((int)_game.PlayerManager.GetClientInfoByChampion(champion).PlayerId, champion.NetId, CastInfo.SpellSlot, toLevel);
+                _game.PacketNotifier.NotifyS2C_SetSpellLevel(_game.PlayerManager.GetClientInfoByChampion(champion).ClientId, champion.NetId, CastInfo.SpellSlot, toLevel);
             }
         }
 
@@ -1524,7 +1524,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             if (CastInfo.Owner is IChampion ch)
             {
                 var clientInfo = _game.PlayerManager.GetClientInfoByChampion(ch);
-                _game.PacketNotifier.NotifyS2C_UpdateSpellToggle((int)clientInfo.PlayerId, this);
+                _game.PacketNotifier.NotifyS2C_UpdateSpellToggle(clientInfo.ClientId, this);
             }
         }
 

--- a/GameServerLib/Handlers/SurrenderHandler.cs
+++ b/GameServerLib/Handlers/SurrenderHandler.cs
@@ -82,7 +82,7 @@ namespace LeagueSandbox.GameServer.Handlers
                 IsSurrenderActive = false;
                 foreach (var p in _game.PlayerManager.GetPlayers(true))
                 {
-                    _game.PacketNotifier.NotifyTeamSurrenderStatus((int)p.Item1, Team, SurrenderReason.SurrenderAgreed, (byte)voteCounts.Item1, (byte)voteCounts.Item2); // TOOD: fix id casting
+                    _game.PacketNotifier.NotifyTeamSurrenderStatus(p.ClientId, Team, SurrenderReason.SurrenderAgreed, (byte)voteCounts.Item1, (byte)voteCounts.Item2); // TOOD: fix id casting
                 }
 
                 toEnd = true;
@@ -95,8 +95,8 @@ namespace LeagueSandbox.GameServer.Handlers
             {
                 IsSurrenderActive = false;
                 Tuple<int, int> count = GetVoteCounts();
-                foreach (var p in _game.PlayerManager.GetPlayers().Where(kv => kv.Item2.Team == Team))
-                    _game.PacketNotifier.NotifyTeamSurrenderStatus((int)p.Item1, Team, SurrenderReason.VoteWasNoSurrender, (byte)count.Item1, (byte)count.Item2); // TODO: fix id casting
+                foreach (var p in _game.PlayerManager.GetPlayers().Where(kv => kv.Team == Team))
+                    _game.PacketNotifier.NotifyTeamSurrenderStatus(p.ClientId, Team, SurrenderReason.VoteWasNoSurrender, (byte)count.Item1, (byte)count.Item2); // TODO: fix id casting
             }
 
             if (toEnd)

--- a/GameServerLib/Inventory/InventoryManager.cs
+++ b/GameServerLib/Inventory/InventoryManager.cs
@@ -33,7 +33,7 @@ namespace LeagueSandbox.GameServer.Inventory
             if (owner is IChampion champion && item != null)
             {
                 //This packet seems to break when buying more than 3 of one of the 250Gold elixirs
-                _packetNotifier.NotifyBuyItem((int)champion.GetPlayerId(), champion, item);
+                _packetNotifier.NotifyBuyItem(champion.ClientId, champion, item);
             }
             return KeyValuePair.Create(item, true);
         }
@@ -50,7 +50,7 @@ namespace LeagueSandbox.GameServer.Inventory
             if (owner is IChampion champion && item != null)
             {
                 //This packet seems to break when buying more than 3 of one of the 250Gold elixirs
-                _packetNotifier.NotifyBuyItem((int)champion.GetPlayerId(), champion, item);
+                _packetNotifier.NotifyBuyItem(champion.ClientId, champion, item);
             }
 
             return KeyValuePair.Create(item, true);

--- a/GameServerLib/ObjectManager.cs
+++ b/GameServerLib/ObjectManager.cs
@@ -119,7 +119,7 @@ namespace LeagueSandbox.GameServer
 
                 foreach (var kv in players)
                 {
-                    UpdateVisionSpawnAndSync(obj, kv.Item2);
+                    UpdateVisionSpawnAndSync(obj, kv);
                 }
 
                 obj.OnAfterSync();
@@ -142,7 +142,7 @@ namespace LeagueSandbox.GameServer
             var players = _game.PlayerManager.GetPlayers(includeBots: false);
             foreach (var kv in players)
             {
-                UpdateVisionSpawnAndSync(obj, kv.Item2, forceSpawn: true);
+                UpdateVisionSpawnAndSync(obj, kv, forceSpawn: true);
             }
 
             obj.OnAfterSync();
@@ -180,7 +180,7 @@ namespace LeagueSandbox.GameServer
         /// </summary>
         public void UpdateVisionSpawnAndSync(IGameObject obj, ClientInfo clientInfo, bool forceSpawn = false)
         {
-            int pid = (int)clientInfo.PlayerId;
+            int cid = clientInfo.ClientId;
             TeamId team = clientInfo.Team;
             IChampion champion = clientInfo.Champion;
 
@@ -191,7 +191,7 @@ namespace LeagueSandbox.GameServer
                     obj.IsVisibleByTeam(champion.Team)
             );
 
-            obj.Sync(pid, team, shouldBeVisibleForPlayer, forceSpawn);
+            obj.Sync(cid, team, shouldBeVisibleForPlayer, forceSpawn);
         }
 
         /// <summary>

--- a/GameServerLib/Packets/PacketHandlers/HandleJoinTeam.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleJoinTeam.cs
@@ -20,7 +20,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             var players = _playerManager.GetPlayers(true);
             uint version = uint.Parse(Config.VERSION.ToString().Replace(".", string.Empty));
 
-            // Builds team info e.g. first UserId set on Blue has PlayerId 0
+            // Builds team info e.g. first UserId set on Blue has ClientId 0
             // increment by 1 for each added player
             _game.PacketNotifier.NotifyLoadScreenInfo(userId, players);
 
@@ -33,9 +33,9 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 _game.PacketNotifier.NotifyRequestReskin(userId, player);
 
                 // Let other players know we loaded in.
-                if (player.Item1 == userId)
+                if (player.ClientId == userId)
                 {
-                    _game.PacketNotifier.NotifyKeyCheck((int)player.Item2.ClientId, player.Item2.PlayerId, version, broadcast: true);
+                    _game.PacketNotifier.NotifyKeyCheck(player.ClientId, player.PlayerId, version, broadcast: true);
                 }
             }
 

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -55,30 +55,30 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 
                     foreach (var player in _playerManager.GetPlayers())
                     {
-                        if (player.Item2.PlayerId == userId && !player.Item2.IsMatchingVersion)
+                        if (player.ClientId == userId && !player.IsMatchingVersion)
                         {
                             var msg = "Your client version does not match the server. " +
                                     "Check the server log for more information.";
                             _game.PacketNotifier.NotifyS2C_SystemMessage(userId, msg);
                         }
 
-                        while (player.Item2.Champion.Stats.Level < _game.Map.MapScript.MapScriptMetadata.InitialLevel)
+                        while (player.Champion.Stats.Level < _game.Map.MapScript.MapScriptMetadata.InitialLevel)
                         {
-                            player.Item2.Champion.LevelUp(true);
+                            player.Champion.LevelUp(true);
                         }
 
                         // TODO: send this in one place only
-                        _game.PacketNotifier.NotifyS2C_HandleTipUpdate((int)player.Item2.PlayerId, "Welcome to League Sandbox!",
-                            "This is a WIP project.", "", 0, player.Item2.Champion.NetId,
+                        _game.PacketNotifier.NotifyS2C_HandleTipUpdate(player.ClientId, "Welcome to League Sandbox!",
+                            "This is a WIP project.", "", 0, player.Champion.NetId,
                             _game.NetworkIdManager.GetNewNetId());
-                        _game.PacketNotifier.NotifyS2C_HandleTipUpdate((int)player.Item2.PlayerId, "Server Build Date",
-                            ServerContext.BuildDateString, "", 0, player.Item2.Champion.NetId,
+                        _game.PacketNotifier.NotifyS2C_HandleTipUpdate(player.ClientId, "Server Build Date",
+                            ServerContext.BuildDateString, "", 0, player.Champion.NetId,
                             _game.NetworkIdManager.GetNewNetId());
-                        _game.PacketNotifier.NotifyS2C_HandleTipUpdate((int)player.Item2.PlayerId, "Your Champion:",
-                            player.Item2.Champion.Model, "", 0, player.Item2.Champion.NetId,
+                        _game.PacketNotifier.NotifyS2C_HandleTipUpdate(player.ClientId, "Your Champion:",
+                            player.Champion.Model, "", 0, player.Champion.NetId,
                             _game.NetworkIdManager.GetNewNetId());
 
-                        SyncTime(player.Item2.PlayerId);
+                        SyncTime(player.ClientId);
                     }
                     _game.Start();
                 }
@@ -86,12 +86,12 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             return true;
         }
 
-        void SyncTime(long userId)
+        void SyncTime(int userId)
         {
             // Send the initial game time sync packets, then let the map send another
             var gameTime = _game.GameTime;
-            _game.PacketNotifier.NotifySynchSimTimeS2C((int)userId, gameTime);
-            _game.PacketNotifier.NotifySyncMissionStartTimeS2C((int)userId, gameTime);
+            _game.PacketNotifier.NotifySynchSimTimeS2C(userId, gameTime);
+            _game.PacketNotifier.NotifySyncMissionStartTimeS2C(userId, gameTime);
         }
     }
 }

--- a/GameServerLib/Packets/PacketHandlers/HandleSync.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSync.cs
@@ -39,14 +39,8 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                 _logger.Debug("Accepted client version (" + req.Version + ") from client = " + req.ClientID + " & PlayerID = " + userId);
             }
 
-            foreach (var player in _playerManager.GetPlayers())
-            {
-                if (player.Item1 == userId)
-                {
-                    player.Item2.IsMatchingVersion = versionMatch;
-                    break;
-                }
-            }
+            var info = _playerManager.GetPeerInfo(userId);
+            info.IsMatchingVersion = versionMatch;
 
             _game.PacketNotifier.NotifySynchVersion(userId, _playerManager.GetPlayers(), Config.VERSION_STRING, _game.Config.GameConfig.GameMode,
                mapId);

--- a/GameServerLib/Packets/PacketHandlers/HandleSyncSimTime.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSyncSimTime.cs
@@ -26,7 +26,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             if (req.TimeLastClient > req.TimeLastServer)
             {
                 var peerInfo = _playerManager.GetPeerInfo(userId);
-                var msg = $"Player {peerInfo.PlayerId} sent an invalid heartbeat - Timestamp error (diff: {diff})";
+                var msg = $"Client {peerInfo.ClientId} sent an invalid heartbeat - Timestamp error (diff: {diff})";
                 _logger.Warn(msg);
             }
 

--- a/GameServerLib/Packets/PacketHandlers/HandleUnpauseReq.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleUnpauseReq.cs
@@ -29,7 +29,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             unpauser = _playerManager.GetPeerInfo(userId).Champion;
             foreach (var player in _playerManager.GetPlayers())
             {
-                _game.PacketNotifier.NotifyResumePacket(unpauser, player.Item2, true);
+                _game.PacketNotifier.NotifyResumePacket(unpauser, player, true);
             }
             var timer = new Timer
             {
@@ -41,7 +41,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             {
                 foreach (var player in _playerManager.GetPlayers())
                 {
-                    _game.PacketNotifier.NotifyResumePacket(unpauser, player.Item2, false);
+                    _game.PacketNotifier.NotifyResumePacket(unpauser, player, false);
                 }
                 _game.Unpause();
             };

--- a/GameServerLib/Players/PlayerManager.cs
+++ b/GameServerLib/Players/PlayerManager.cs
@@ -87,6 +87,11 @@ namespace LeagueSandbox.GameServer.Players
             return null;
         }
 
+        public ClientInfo GetClientInfoByPlayerId(long playerId)
+        {
+            return _players.Find(c => c.PlayerId == playerId);
+        }
+
         public ClientInfo GetClientInfoByChampion(IChampion champ)
         {
             return _players.Find(c => c.Champion == champ);

--- a/GameServerLib/Players/PlayerManager.cs
+++ b/GameServerLib/Players/PlayerManager.cs
@@ -15,8 +15,8 @@ namespace LeagueSandbox.GameServer.Players
         private NetworkIdManager _networkIdManager;
         private Game _game;
 
-        private List<Tuple<uint, ClientInfo>> _players = new List<Tuple<uint, ClientInfo>>();
-        private Dictionary<TeamId, uint> _userIdsPerTeam = new Dictionary<TeamId, uint>
+        private List<ClientInfo> _players = new List<ClientInfo>();
+        private Dictionary<TeamId, int> _userIdsPerTeam = new Dictionary<TeamId, int>
         {
             { TeamId.TEAM_BLUE, 0 },
             { TeamId.TEAM_PURPLE, 0 }
@@ -28,80 +28,75 @@ namespace LeagueSandbox.GameServer.Players
             _networkIdManager = game.NetworkIdManager;
         }
 
-        private TeamId GetTeamIdFromConfig(IPlayerConfig p)
-        {
-            if (p.Team.ToLower().Equals("blue"))
-            {
-                return TeamId.TEAM_BLUE;
-            }
-
-            return TeamId.TEAM_PURPLE;
-        }
-
-        public void AddPlayer(KeyValuePair<string, IPlayerConfig> p)
+        public void AddPlayer(IPlayerConfig config)
         {
             var summonerSkills = new[]
             {
-                p.Value.Summoner1,
-                p.Value.Summoner2
+                config.Summoner1,
+                config.Summoner2
             };
-            var teamId = GetTeamIdFromConfig(p.Value);
-            var player = new ClientInfo(
-                p.Value.Rank,
+            var teamId = config.Team;
+            var info = new ClientInfo(
+                config.Rank,
                 teamId,
-                p.Value.Ribbon,
-                p.Value.Icon,
-                p.Value.Skin,
-                p.Value.Name,
+                config.Ribbon,
+                config.Icon,
+                config.Skin,
+                config.Name,
                 summonerSkills,
-                p.Value.PlayerID // same as StartClient.bat
+                config.PlayerID
             );
             
-            player.ClientId = (uint)_players.Count;
+            info.ClientId = _players.Count;
+            _userIdsPerTeam[teamId]++;
 
-            var c = new Champion(_game, p.Value.Champion, (uint)player.PlayerId, _userIdsPerTeam[teamId]++, p.Value.Runes, p.Value.Talents, player, 0, teamId);
+            var c = new Champion(
+                _game,
+                config.Champion,
+                config.Runes,
+                config.Talents,
+                info,
+                0,
+                teamId
+            );
 
-            var pos = c.GetSpawnPosition((int)_userIdsPerTeam[teamId]);
+            var pos = c.GetSpawnPosition(_userIdsPerTeam[teamId]);
             c.SetPosition(pos, false);
             c.StopMovement();
             c.UpdateMoveOrder(OrderType.Stop);
 
             _game.ObjectManager.AddObject(c);
 
-            player.Champion = c;
-            var pair = new Tuple<uint, ClientInfo> ((uint)player.PlayerId, player);
-            _players.Add(pair);
+            info.Champion = c;
+            _players.Add(info);
         }
 
-        public void AddPlayer(Tuple<uint, ClientInfo> p)
+        public void AddPlayer(ClientInfo info)
         {
-            _players.Add(p);
+            info.ClientId = _players.Count;
+            _players.Add(info);
         }
 
         // GetPlayerFromPeer
-        public ClientInfo GetPeerInfo(long playerId)
+        public ClientInfo GetPeerInfo(int clientId)
         {
-            foreach (var player in _players)
+            if (0 <= clientId && clientId < _players.Count)
             {
-                if (player.Item2.PlayerId == playerId)
-                {
-                    return player.Item2;
-                }
+                return _players[clientId];
             }
-
             return null;
         }
 
         public ClientInfo GetClientInfoByChampion(IChampion champ)
         {
-            return GetPlayers(true).Find(c => c.Item2.Champion == champ).Item2;
+            return _players.Find(c => c.Champion == champ);
         }
 
-        public List<Tuple<uint, ClientInfo>> GetPlayers(bool includeBots = true)
+        public List<ClientInfo> GetPlayers(bool includeBots = true)
         {
             if (!includeBots)
             {
-                return _players.FindAll(c => !c.Item2.Champion.IsBot);
+                return _players.FindAll(c => !c.Champion.IsBot);
             }
 
             return _players;

--- a/GameServerLib/Server.cs
+++ b/GameServerLib/Server.cs
@@ -14,7 +14,7 @@ namespace LeagueSandbox.GameServer
     /// </summary>
     internal class Server : IDisposable
     {
-        private Dictionary<long, string> _blowfishKeys;
+        private string[] _blowfishKeys;
         private string _serverVersion = "0.2.0";
         private readonly ILog _logger;
         private Game _game;
@@ -31,9 +31,11 @@ namespace LeagueSandbox.GameServer
             _serverPort = port;
             _config = Config.LoadFromJson(game, configJson);
 
-            _blowfishKeys = new Dictionary<long, string>();
-            foreach (var player in _config.Players)
-                _blowfishKeys.Add(player.Value.PlayerID, player.Value.BlowfishKey);
+            _blowfishKeys = new string[_config.Players.Count];
+            for(int i = 0; i < _config.Players.Count; i++)
+            {
+                _blowfishKeys[i] = _config.Players[i].BlowfishKey;
+            }
         }
 
         /// <summary>

--- a/PacketDefinitions420/IPacketHandlerManager.cs
+++ b/PacketDefinitions420/IPacketHandlerManager.cs
@@ -15,7 +15,7 @@ namespace PacketDefinitions420
         bool BroadcastPacketVision(IGameObject o, byte[] data, Channel channelNo, PacketFlags flag = PacketFlags.RELIABLE);
         bool HandlePacket(Peer peer, byte[] data, Channel channelId);
         bool HandlePacket(Peer peer, Packet packet, Channel channelId);
-        bool SendPacket(int playerId, byte[] source, Channel channelNo, PacketFlags flag = PacketFlags.RELIABLE);
+        bool SendPacket(int userId, byte[] source, Channel channelNo, PacketFlags flag = PacketFlags.RELIABLE);
         bool HandleDisconnect(Peer peer);
     }
 }

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -25,23 +25,21 @@ namespace PacketDefinitions420
         private readonly Dictionary<Tuple<GamePacketID, Channel>, RequestConvertor> _gameConvertorTable;
         private readonly Dictionary<LoadScreenPacketID, RequestConvertor> _loadScreenConvertorTable;
         // should be one-to-one, no two users for the same Peer
-        private readonly Dictionary<long, Peer> _peers;
-        private readonly List<TeamId> _teamsEnumerator;
+        private readonly Peer[] _peers;
         private readonly IPlayerManager _playerManager;
-        private readonly Dictionary<long, BlowFish> _blowfishes;
+        private readonly BlowFish[] _blowfishes;
         private readonly Host _server;
         private readonly IGame _game;
 
         private readonly NetworkHandler<ICoreRequest> _netReq;
         private readonly NetworkHandler<ICoreRequest> _netResp;
 
-        public PacketHandlerManager(Dictionary<long, BlowFish> blowfishes, Host server, IGame game, NetworkHandler<ICoreRequest> netReq, NetworkHandler<ICoreRequest> netResp)
+        public PacketHandlerManager(BlowFish[] blowfishes, Host server, IGame game, NetworkHandler<ICoreRequest> netReq, NetworkHandler<ICoreRequest> netResp)
         {
             _blowfishes = blowfishes;
             _server = server;
             _game = game;
-            _peers = new Dictionary<long, Peer>();
-            _teamsEnumerator = Enum.GetValues(typeof(TeamId)).Cast<TeamId>().ToList();
+            _peers = new Peer[blowfishes.Length];
             _playerManager = _game.PlayerManager;
             _netReq = netReq;
             _netResp = netResp;
@@ -148,25 +146,22 @@ namespace PacketDefinitions420
             Debug.WriteLine("--------");
         }
 
-        public bool SendPacket(int playerId, byte[] source, Channel channelNo, PacketFlags flag = PacketFlags.RELIABLE)
+        public bool SendPacket(int userId, byte[] source, Channel channelNo, PacketFlags flag = PacketFlags.RELIABLE)
         {
             // Sometimes we try to send packets to a user that doesn't exist (like in broadcast when not all players are connected).
-            // TODO: fix casting
-            if (_peers.ContainsKey(playerId))
+            if (0 <= userId && userId < _peers.Length)
             {
                 byte[] temp;
                 if (source.Length >= 8)
                 {
-                    if (_blowfishes.ContainsKey(playerId))
-                        temp = _blowfishes[playerId].Encrypt(source);
-                    else
-                        temp = source;
+                    // _peers.Length == _blowfishes.Length
+                    temp = _blowfishes[userId].Encrypt(source);
                 }
                 else
                 {
                     temp = source;
                 }
-                return _peers[playerId].Send((byte)channelNo, new LENet.Packet(temp, flag)) == 0;
+                return _peers[userId].Send((byte)channelNo, new LENet.Packet(temp, flag)) == 0;
             }
             return false;
         }
@@ -176,11 +171,18 @@ namespace PacketDefinitions420
             if (data.Length >= 8)
             {
                 // send packet to all peers and save failed ones
-                List<KeyValuePair<long, Peer>> failedPeers = _peers.Where(x => x.Value.Send((byte)channelNo, new LENet.Packet(_blowfishes[x.Key].Encrypt(data), flag)) < 0).ToList();
-
-                if (failedPeers.Count() > 0)
+                int failedPeers = 0;
+                for(int i = 0; i < _peers.Length; i++)
                 {
-                    Debug.WriteLine($"Broadcasting packet failed for {failedPeers.Count()} peers.");
+                    if(_peers[i].Send((byte)channelNo, new LENet.Packet(_blowfishes[i].Encrypt(data), flag)) < 0)
+                    {
+                        failedPeers++;
+                    }
+                }
+
+                if (failedPeers > 0)
+                {
+                    Debug.WriteLine($"Broadcasting packet failed for {failedPeers} peers.");
                     return false;
                 }
                 return true;
@@ -199,9 +201,9 @@ namespace PacketDefinitions420
         {
             foreach (var ci in _playerManager.GetPlayers(true))
             {
-                if (ci.Item2 != null && ci.Item2.Team == team)
+                if (ci.Team == team)
                 {
-                    SendPacket((int)ci.Item2.PlayerId, data, channelNo, flag);
+                    SendPacket(ci.ClientId, data, channelNo, flag);
                 }
             }
 
@@ -227,30 +229,22 @@ namespace PacketDefinitions420
             {
                 var loadScreenPacketId = (LoadScreenPacketID)reader.ReadByte();
                 convertor = GetConvertor(loadScreenPacketId);
+                Console.Write($"load -> {loadScreenPacketId}");
             }
             else
             {
                 var gamePacketId = (GamePacketID)reader.ReadByte();
                 convertor = GetConvertor(gamePacketId, channelId);
-
-                switch (gamePacketId)
-                {
-                    case GamePacketID.World_SendCamera_Server:
-                    case GamePacketID.Waypoint_Acc:
-                    case GamePacketID.OnReplication_Acc:
-                        break;
-                }
+                Console.Write($"game -> {gamePacketId}");
             }
 
             reader.Close();
 
             if (convertor != null)
             {
-                //TODO: improve dictionary reverse search
-                long playerId = _peers.First(x => x.Value.Address.Equals(peer.Address)).Key;
+                int clientId = (int)peer.UserData;
                 dynamic req = convertor(data);
-                // TODO: fix all to use ulong
-                _netReq.OnMessage((int)playerId, req);
+                _netReq.OnMessage(clientId, req);
                 return true;
             }
 
@@ -260,24 +254,19 @@ namespace PacketDefinitions420
 
         public bool HandleDisconnect(Peer peer)
         {
-            long playerId = _peers.FirstOrDefault(x => x.Value.Address.Equals(peer.Address)).Key;
-            var player = _game.PlayerManager.GetPlayers().Find(x => x.Item2.PlayerId == playerId)?.Item2;
-            if (player == null)
+            int clientId = (int)peer.UserData;
+            var peerInfo = _game.PlayerManager.GetPeerInfo(clientId);
+            if (peerInfo == null)
             {
-                Debug.WriteLine($"prevented double disconnect of {playerId}");
+                Debug.WriteLine($"prevented double disconnect of {clientId}");
                 return true;
             }
             
-            var peerInfo = _game.PlayerManager.GetPeerInfo(player.PlayerId);
-
-            if (peerInfo != null)
-            {
-                var annoucement = new OnLeave { OtherNetID = peerInfo.Champion.NetId };
-                _game.PacketNotifier.NotifyS2C_OnEventWorld(annoucement, peerInfo.Champion);
-                peerInfo.IsDisconnected = true;
-            }
+            var annoucement = new OnLeave { OtherNetID = peerInfo.Champion.NetId };
+            _game.PacketNotifier.NotifyS2C_OnEventWorld(annoucement, peerInfo.Champion);
+            peerInfo.IsDisconnected = true;
             
-            return player.Champion.OnDisconnect();
+            return peerInfo.Champion.OnDisconnect();
         }
 
         public bool HandlePacket(Peer peer, Packet packet, Channel channelId)
@@ -293,8 +282,8 @@ namespace PacketDefinitions420
             // every packet that is not blowfish go here
             if (data.Length >= 8)
             {
-                long playerId = _peers.First(x => x.Value.Address.Equals(peer.Address)).Key;
-                data = _blowfishes[playerId].Decrypt(data);
+                int clientId = (int)peer.UserData;
+                data = _blowfishes[clientId].Decrypt(data);
             }
 
             return HandlePacket(peer, data, channelId);
@@ -304,50 +293,48 @@ namespace PacketDefinitions420
         {
             var request = PacketReader.ReadKeyCheckRequest(data);
 
-            if (!_blowfishes.ContainsKey(request.PlayerID))
+            if (!(0 <= request.ClientID && request.ClientID < _blowfishes.Length))
             {
-                Debug.WriteLine($"Player ID {request.PlayerID} is invalid.");
+                Debug.WriteLine($"Client ID {request.ClientID} is invalid.");
                 return false;
             }
 
-            long playerID = _blowfishes[request.PlayerID].Decrypt(request.CheckSum);
-
+            long playerID = _blowfishes[request.ClientID].Decrypt(request.CheckSum);
             if(request.PlayerID != playerID)
             {
                 Debug.WriteLine($"Blowfish key is wrong!");
                 return false;
             }
 
-            var peerInfo = _playerManager.GetPeerInfo(request.PlayerID);
-            
-            if(_peers.ContainsKey(request.PlayerID) && !peerInfo.IsDisconnected)
+            var peerInfo = _playerManager.GetPeerInfo(request.ClientID);
+            // The ClientID has already been checked, so the peerInfo should not be null
+            if(!peerInfo.IsDisconnected)
             {
-                Debug.WriteLine($"Player {request.PlayerID} is already connected. Request from {peer.Address.ToString()}.");
+                Debug.WriteLine($"Client {request.ClientID} is already connected. Request from {peer.Address.ToString()}.");
                 return false;
             }
 
             peerInfo.IsStartedClient = true;
 
-            Debug.WriteLine("Connected player No " + request.PlayerID);      
+            Debug.WriteLine("Connected client No " + request.ClientID);      
 
-            _peers[request.PlayerID] = peer;
+            peer.UserData = (int)request.ClientID;
+            _peers[request.ClientID] = peer;
+
+            var response = new KeyCheckPacket
+            {
+                ClientID = request.ClientID,
+                PlayerID = request.PlayerID,
+                VersionNumber = request.VersionNo,
+                Action = 0,
+                CheckSum = request.CheckSum
+            };
 
             bool result = true;
-
             // inform players about their player numbers
             foreach (var player in _playerManager.GetPlayers(false))
             {
-                var response = new KeyCheckPacket
-                {
-                    ClientID = (int)player.Item2.ClientId,
-                    PlayerID = player.Item2.PlayerId,
-                    //TODO: Unhardcode all values bellow
-                    VersionNumber = 42000315,
-                    Action = 0,
-                    CheckSum = 0
-                };
-                // TODO: fix casting
-                result = result && SendPacket((int)request.PlayerID, response.GetBytes(), Channel.CHL_HANDSHAKE);
+                result = result && SendPacket(player.ClientId, response.GetBytes(), Channel.CHL_HANDSHAKE);
             }
 
             // only if all packets were sent successfully return true

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -472,7 +472,7 @@ namespace PacketDefinitions420
             return misPacket;
         }
 
-        SpawnLevelPropS2C ConstructSpawnLevelPropPacket(ILevelProp levelProp, int userId = 0)
+        SpawnLevelPropS2C ConstructSpawnLevelPropPacket(ILevelProp levelProp, int userId = -1)
         {
             return new SpawnLevelPropS2C
             {
@@ -996,7 +996,7 @@ namespace PacketDefinitions420
         /// <param name="currentCd">Amount of time the spell has already been on cooldown (if applicable).</param>
         /// <param name="totalCd">Maximum amount of time the spell's cooldown can be.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
-        public void NotifyCHAR_SetCooldown(IObjAiBase u, byte slotId, float currentCd, float totalCd, int userId = 0)
+        public void NotifyCHAR_SetCooldown(IObjAiBase u, byte slotId, float currentCd, float totalCd, int userId = -1)
         {
             var cdPacket = new CHAR_SetCooldown
             {
@@ -1119,7 +1119,7 @@ namespace PacketDefinitions420
         /// <param name="textType">Type of text to display. Refer to FloatTextType</param>
         /// <param name="userId">User to send to. 0 = sends to all in vision.</param>
         /// <param name="param">Optional parameters for the text. Untested, function unknown.</param>
-        public void NotifyDisplayFloatingText(IFloatingTextData floatTextData, TeamId team = 0, int userId = 0)
+        public void NotifyDisplayFloatingText(IFloatingTextData floatTextData, TeamId team = 0, int userId = -1)
         {
             var textPacket = new DisplayFloatingText
             {
@@ -1183,7 +1183,7 @@ namespace PacketDefinitions420
         /// <param name="o">GameObject coming into vision.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="ignoreVision">Optionally ignore vision checks when sending this packet and broadcast it to all players instead.</param>
-        public void NotifyEnterLocalVisibilityClient(IGameObject o, int userId = 0, bool ignoreVision = false)
+        public void NotifyEnterLocalVisibilityClient(IGameObject o, int userId = -1, bool ignoreVision = false)
         {
             var enterLocalVis = ConstructEnterLocalVisibilityClientPacket(o);
 
@@ -1213,12 +1213,12 @@ namespace PacketDefinitions420
         /// <param name="ignoreVision">Optionally ignore vision checks when sending this packet.</param>
         /// <param name="packets">Takes in a list of packets to send alongside this vision packet.</param>
         /// TODO: Incomplete implementation.
-        public void NotifyEnterVisibilityClient(IGameObject o, int userId = 0, bool isChampion = false, bool ignoreVision = false, List<GamePacket> packets = null)
+        public void NotifyEnterVisibilityClient(IGameObject o, int userId = -1, bool isChampion = false, bool ignoreVision = false, List<GamePacket> packets = null)
         {
 
             var enterVis = ConstructEnterVisibilityClientPacket(o, isChampion, packets);
 
-            if (userId != 0)
+            if (userId != -1)
             {
                 _packetHandlerManager.SendPacket(userId, enterVis.GetBytes(), Channel.CHL_S2C);
                 NotifyEnterLocalVisibilityClient(o, userId, ignoreVision);
@@ -1278,7 +1278,7 @@ namespace PacketDefinitions420
         /// </summary>
         /// <param name="particle">Particle to network.</param>
         /// <param name="userId">User to send the packet to.</param>
-        public void NotifyFXCreateGroup(IParticle particle, int userId = 0)
+        public void NotifyFXCreateGroup(IParticle particle, int userId = -1)
         {
             var fxPacket = ConstructFXCreateGroupPacket(particle);
 
@@ -1365,7 +1365,7 @@ namespace PacketDefinitions420
             NotifyFXLeaveTeamVisibility(particle, team, 0);
         }
 
-        public void NotifyFXLeaveTeamVisibility(IParticle particle, TeamId team, int userId = 0)
+        public void NotifyFXLeaveTeamVisibility(IParticle particle, TeamId team, int userId = -1)
         {
             var fxVisPacket = new S2C_FX_OnLeaveTeamVisibility
             {
@@ -1393,7 +1393,7 @@ namespace PacketDefinitions420
         /// Sends a packet to all players detailing that the game has started. Sent when all players have finished loading.
         /// </summary>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players.</param>
-        public void NotifyGameStart(int userId = 0)
+        public void NotifyGameStart(int userId = -1)
         {
             var start = new S2C_StartGame
             {
@@ -1503,14 +1503,14 @@ namespace PacketDefinitions420
         /// <param name="team">TeamId to send the packet to; BLUE/PURPLE/NEUTRAL.</param>
         /// <param name="userId">User to send the packet to.</param>
         /// TODO: Verify where this should be used.
-        public void NotifyLeaveLocalVisibilityClient(IGameObject o, TeamId team, int userId = 0)
+        public void NotifyLeaveLocalVisibilityClient(IGameObject o, TeamId team, int userId = -1)
         {
             var leaveLocalVis = new OnLeaveLocalVisibilityClient
             {
                 SenderNetID = o.NetId
             };
 
-            if (userId != 0)
+            if (userId != -1)
             {
                 _packetHandlerManager.SendPacket(userId, leaveLocalVis.GetBytes(), Channel.CHL_S2C);
                 return;
@@ -1526,14 +1526,14 @@ namespace PacketDefinitions420
         /// <param name="team">TeamId to send the packet to; BLUE/PURPLE/NEUTRAL.</param>
         /// <param name="userId">User to send the packet to (if applicable).</param>
         /// TODO: Verify where this should be used.
-        public void NotifyLeaveVisibilityClient(IGameObject o, TeamId team, int userId = 0)
+        public void NotifyLeaveVisibilityClient(IGameObject o, TeamId team, int userId = -1)
         {
             var leaveVis = new OnLeaveVisibilityClient
             {
                 SenderNetID = o.NetId
             };
 
-            if (userId != 0)
+            if (userId != -1)
             {
                 _packetHandlerManager.SendPacket(userId, leaveVis.GetBytes(), Channel.CHL_S2C);
             }
@@ -1630,7 +1630,7 @@ namespace PacketDefinitions420
         /// <param name="modelOnly">Wether or not it's only the model that it's being changed(?). I don't really know what's this for</param>
         /// <param name="overrideSpells">Wether or not the user's spells should be overriden, i assume it would be used for things like Nidalee or Elise.</param>
         /// <param name="replaceCharacterPackage">Unknown.</param>
-        public void NotifyS2C_ChangeCharacterData(IAttackableUnit obj, int userId = 0, uint skinID = 0, bool modelOnly = true, bool overrideSpells = false, bool replaceCharacterPackage = false)
+        public void NotifyS2C_ChangeCharacterData(IAttackableUnit obj, int userId = -1, uint skinID = 0, bool modelOnly = true, bool overrideSpells = false, bool replaceCharacterPackage = false)
         {
             var newCharData = new S2C_ChangeCharacterData
             {
@@ -2289,7 +2289,7 @@ namespace PacketDefinitions420
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="partial">Whether or not the packet should only include stats marked as changed.</param>
         /// TODO: Replace with LeaguePackets and preferably move all uses of this function to a central EventHandler class (if one is fully implemented).
-        public void NotifyOnReplication(IAttackableUnit u, int userId = 0, bool partial = true)
+        public void NotifyOnReplication(IAttackableUnit u, int userId = -1, bool partial = true)
         {
             if (u.Replication != null)
             {
@@ -2489,7 +2489,7 @@ namespace PacketDefinitions420
             _packetHandlerManager.SendPacket(player.ClientId, resume.GetBytes(), Channel.CHL_S2C);
         }
 
-        public void NotifyS2C_ActivateMinionCamp(IMonsterCamp monsterCamp, int userId = 0)
+        public void NotifyS2C_ActivateMinionCamp(IMonsterCamp monsterCamp, int userId = -1)
         {
             var packet = new S2C_ActivateMinionCamp
             {
@@ -2634,7 +2634,7 @@ namespace PacketDefinitions420
             }
         }
 
-        public void NotifyS2C_CreateMinionCamp(IMonsterCamp monsterCamp, int userId = 0)
+        public void NotifyS2C_CreateMinionCamp(IMonsterCamp monsterCamp, int userId = -1)
         {
             var packet = new S2C_CreateMinionCamp
             {
@@ -2667,11 +2667,11 @@ namespace PacketDefinitions420
         /// </summary>
         /// <param name="turret">LaneTurret that spawned.</param>
         /// <param name="userId">User to send the packet to.</param>
-        public void NotifyS2C_CreateTurret(ILaneTurret turret, int userId = 0)
+        public void NotifyS2C_CreateTurret(ILaneTurret turret, int userId = -1)
         {
             var createTurret = ConstructCreateTurretPacket(turret);
 
-            if (userId != 0)
+            if (userId != -1)
             {
                 _packetHandlerManager.SendPacket(userId, createTurret.GetBytes(), Channel.CHL_S2C);
                 return;
@@ -2851,7 +2851,7 @@ namespace PacketDefinitions420
 
             _packetHandlerManager.SendPacket(player.ClientId, cam.GetBytes(), Channel.CHL_S2C);
         }
-        public void NotifyS2C_Neutral_Camp_Empty(IMonsterCamp monsterCamp, IDeathData deathData = null, int userId = 0)
+        public void NotifyS2C_Neutral_Camp_Empty(IMonsterCamp monsterCamp, IDeathData deathData = null, int userId = -1)
         {
             var packet = new S2C_Neutral_Camp_Empty
             {
@@ -2921,7 +2921,7 @@ namespace PacketDefinitions420
         /// </summary>
         /// <param name="o">GameObject coming into vision.</param>
         /// <param name="userId">User to send the packet to.</param>
-        public void NotifyS2C_OnEnterTeamVisibility(IGameObject o, TeamId team, int userId = 0)
+        public void NotifyS2C_OnEnterTeamVisibility(IGameObject o, TeamId team, int userId = -1)
         {
             var enterTeamVis = ConstructOnEnterTeamVisibilityPacket(o, team);
 
@@ -2984,7 +2984,7 @@ namespace PacketDefinitions420
         /// </summary>
         /// <param name="o">GameObject going out of vision.</param>
         /// <param name="userId">User to send the packet to.</param>
-        public void NotifyS2C_OnLeaveTeamVisibility(IGameObject o, TeamId team, int userId = 0)
+        public void NotifyS2C_OnLeaveTeamVisibility(IGameObject o, TeamId team, int userId = -1)
         {
             var leaveTeamVis = new S2C_OnLeaveTeamVisibility()
             {
@@ -3198,7 +3198,7 @@ namespace PacketDefinitions420
         /// Sends a packet to the specified player detailing that the game has started the spawning GameObjects that occurs at the start of the game.
         /// </summary>
         /// <param name="userId">User to send the packet to.</param>
-        public void NotifyS2C_StartSpawn(int userId = 0)
+        public void NotifyS2C_StartSpawn(int userId = -1)
         {
             var start = new S2C_StartSpawn
             {
@@ -3591,11 +3591,11 @@ namespace PacketDefinitions420
         /// </summary>
         /// <param name="levelProp">LevelProp that has spawned.</param>
         /// <param name="userId">User to send the packet to.</param>
-        public void NotifySpawnLevelPropS2C(ILevelProp levelProp, int userId = 0)
+        public void NotifySpawnLevelPropS2C(ILevelProp levelProp, int userId = -1)
         {
             var spawnPacket = ConstructSpawnLevelPropPacket(levelProp);
 
-            if (userId != 0)
+            if (userId != -1)
             {
                 _packetHandlerManager.SendPacket(userId, spawnPacket.GetBytes(), Channel.CHL_S2C);
             }
@@ -4003,7 +4003,7 @@ namespace PacketDefinitions420
         /// <param name="team">Team which is affected by this visibility change.</param>
         /// <param name="becameVisible">Whether or not the change was an entry into vision.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to the team.</param>
-        public void NotifyVisibilityChange(IGameObject obj, TeamId team, bool becameVisible = true, int userId = 0)
+        public void NotifyVisibilityChange(IGameObject obj, TeamId team, bool becameVisible = true, int userId = -1)
         {
             if (becameVisible)
             {
@@ -4018,7 +4018,7 @@ namespace PacketDefinitions420
         /// <summary>
         /// Sends a notification that the object has entered the team's scope and fully synchronizes its state.
         /// </summary>
-        void NotifyEnterTeamVision(IGameObject obj, TeamId team, int userId = 0, GamePacket spawnPacket = null)
+        void NotifyEnterTeamVision(IGameObject obj, TeamId team, int userId = -1, GamePacket spawnPacket = null)
         {
             if (obj is IAttackableUnit u)
             {
@@ -4080,7 +4080,7 @@ namespace PacketDefinitions420
             }
         }
 
-        void NotifyLeaveTeamVision(IGameObject obj, TeamId team, int userId = 0)
+        void NotifyLeaveTeamVision(IGameObject obj, TeamId team, int userId = -1)
         {
             if (obj is IParticle p)
             {
@@ -4188,7 +4188,7 @@ namespace PacketDefinitions420
         /// <param name="u">AttackableUnit that is moving.</param>
         /// <param name="userId">UserId to send the packet to. If not specified or zero, the packet is broadcasted to all players that have vision of the specified unit.</param>
         /// <param name="useTeleportID">Whether or not to teleport the unit to its current position in its path.</param>
-        public void NotifyWaypointGroup(IAttackableUnit u, int userId = 0, bool useTeleportID = false)
+        public void NotifyWaypointGroup(IAttackableUnit u, int userId = -1, bool useTeleportID = false)
         {
             var move = PacketExtensions.CreateMovementDataNormal(u, _navGrid, useTeleportID);
 

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -647,7 +647,7 @@ namespace PacketDefinitions420
                 {
                     regionPacket.VisionTargetNetID = clientInfo.Champion.NetId;
                 }
-                regionPacket.ClientID = (int)clientInfo.ClientId;
+                regionPacket.ClientID = clientInfo.ClientId;
             }
 
             if (obj != null)
@@ -1465,7 +1465,7 @@ namespace PacketDefinitions420
             }
             else
             {
-                _packetHandlerManager.SendPacket((int)playerId, keyCheck.GetBytes(), Channel.CHL_HANDSHAKE);
+                _packetHandlerManager.SendPacket(clientID, keyCheck.GetBytes(), Channel.CHL_HANDSHAKE);
             }
         }
 
@@ -1550,7 +1550,7 @@ namespace PacketDefinitions420
         /// </summary>
         /// <param name="userId">User to send the packet to.</param>
         /// <param name="players">Client info of all players in the loading screen.</param>
-        public void NotifyLoadScreenInfo(int userId, List<Tuple<uint, ClientInfo>> players)
+        public void NotifyLoadScreenInfo(int userId, List<ClientInfo> players)
         {
             uint orderSizeCurrent = 0;
             uint chaosSizeCurrent = 0;
@@ -1563,15 +1563,15 @@ namespace PacketDefinitions420
 
             foreach (var player in players)
             {
-                if (player.Item2.Team == TeamId.TEAM_BLUE)
+                if (player.Team == TeamId.TEAM_BLUE)
                 {
-                    teamRoster.OrderMembers[orderSizeCurrent] = player.Item2.PlayerId;
+                    teamRoster.OrderMembers[orderSizeCurrent] = player.PlayerId;
                     orderSizeCurrent++;
                 }
                 // TODO: Verify if it is ok to allow neutral
                 else
                 {
-                    teamRoster.ChaosMembers[chaosSizeCurrent] = player.Item2.PlayerId;
+                    teamRoster.ChaosMembers[chaosSizeCurrent] = player.PlayerId;
                     chaosSizeCurrent++;
                 }
             }
@@ -1619,7 +1619,7 @@ namespace PacketDefinitions420
                 Position = position
             };
 
-            _packetHandlerManager.SendPacket((int)target.GetPlayerId(), packet.GetBytes(), Channel.CHL_S2C);
+            _packetHandlerManager.SendPacket(target.ClientId, packet.GetBytes(), Channel.CHL_S2C);
         }
         /// <summary>
         /// Sends a packet to all players that updates the specified unit's model.
@@ -2157,7 +2157,7 @@ namespace PacketDefinitions420
             history.EventSourceType = 0; //TODO: Confirm that it is always zero
             history.Entries = ch.EventHistory;
             
-            _packetHandlerManager.SendPacket((int)ch.GetPlayerId(), history.GetBytes(), Channel.CHL_S2C);
+            _packetHandlerManager.SendPacket(ch.ClientId, history.GetBytes(), Channel.CHL_S2C);
         }
         /// <summary>
         /// Sends a packet to all players with vision of the specified AttackableUnit detailing that the attacker has abrubtly stopped their attack (can be a spell or auto attack, although internally AAs are also spells).
@@ -2323,12 +2323,12 @@ namespace PacketDefinitions420
             var pg = new PausePacket
             {
                 //Check if SenderNetID should be the person that requested the pause or just 0
-                ClientID = (int)player.ClientId,
+                ClientID = player.ClientId,
                 IsTournament = isTournament,
                 PauseTimeRemaining = seconds
             };
             //I Assumed that, since the packet requires idividual client IDs, that it also sends the packets individually, by useing the SendPacket Channel, double check if that's valid.
-            _packetHandlerManager.SendPacket((int)player.PlayerId, pg.GetBytes(), Channel.CHL_S2C);
+            _packetHandlerManager.SendPacket(player.ClientId, pg.GetBytes(), Channel.CHL_S2C);
         }
 
         /// <summary>
@@ -2438,16 +2438,16 @@ namespace PacketDefinitions420
         /// </summary>
         /// <param name="userId">User to send the packet to.</param>
         /// <param name="player">Player information to send.</param>
-        public void NotifyRequestRename(int userId, Tuple<uint, ClientInfo> player)
+        public void NotifyRequestRename(int userId, ClientInfo player)
         {
             var loadName = new RequestRename
             {
-                PlayerID = player.Item2.PlayerId,
-                PlayerName = player.Item2.Name,
+                PlayerID = player.PlayerId,
+                PlayerName = player.Name,
                 // Most packets show a large default value (in place of what you would expect to be 0)
                 // Seems to be randomized per-game and used for every RequestRename packet during that game.
                 // So, using this SkinNo may be incorrect.
-                SkinID = player.Item2.SkinNo,
+                SkinID = player.SkinNo,
             };
             _packetHandlerManager.SendPacket(userId, loadName.GetBytes(), Channel.CHL_LOADING_SCREEN);
         }
@@ -2457,13 +2457,13 @@ namespace PacketDefinitions420
         /// </summary>
         /// <param name="userId">User to send the packet to.</param>
         /// <param name="player">Player information to send.</param>
-        public void NotifyRequestReskin(int userId, Tuple<uint, ClientInfo> player)
+        public void NotifyRequestReskin(int userId, ClientInfo player)
         {
             var loadChampion = new RequestReskin
             {
-                PlayerID = player.Item2.PlayerId,
-                SkinID = player.Item2.SkinNo,
-                SkinName = player.Item2.Champion.Model
+                PlayerID = player.PlayerId,
+                SkinID = player.SkinNo,
+                SkinName = player.Champion.Model
             };
             _packetHandlerManager.SendPacket(userId, loadChampion.GetBytes(), Channel.CHL_LOADING_SCREEN);
         }
@@ -2479,14 +2479,14 @@ namespace PacketDefinitions420
             {
                 SenderNetID = 0,
                 Delayed = isDelayed,
-                ClientID = (int)player.ClientId
+                ClientID = player.ClientId
             };
             if (unpauser != null)
             {
                 resume.SenderNetID = unpauser.NetId;
             }
 
-            _packetHandlerManager.SendPacket((int)player.PlayerId, resume.GetBytes(), Channel.CHL_S2C);
+            _packetHandlerManager.SendPacket(player.ClientId, resume.GetBytes(), Channel.CHL_S2C);
         }
 
         public void NotifyS2C_ActivateMinionCamp(IMonsterCamp monsterCamp, int userId = 0)
@@ -2528,7 +2528,7 @@ namespace PacketDefinitions420
                     packet.AmmoRechargeTotalTime = spell.GetAmmoRechageTime();
                 }
 
-                _packetHandlerManager.SendPacket((int)ch.GetPlayerId(), packet.GetBytes(), Channel.CHL_S2C);
+                _packetHandlerManager.SendPacket(ch.ClientId, packet.GetBytes(), Channel.CHL_S2C);
             }
         }
 
@@ -2604,7 +2604,7 @@ namespace PacketDefinitions420
             var heroPacket = new S2C_CreateHero()
             {
                 NetID = champion.NetId,
-                ClientID = (int)clientInfo.ClientId,
+                ClientID = clientInfo.ClientId,
                 // NetNodeID,
                 // For bots (0 = Beginner, 1 = Intermediate)
                 SkillLevel = 0,
@@ -2684,10 +2684,10 @@ namespace PacketDefinitions420
         /// Disables the U.I when the game ends
         /// </summary>
         /// <param name="player"></param>
-        public void NotifyS2C_DisableHUDForEndOfGame(Tuple<uint, ClientInfo> player)
+        public void NotifyS2C_DisableHUDForEndOfGame(ClientInfo player)
         {
             var disableHud = new S2C_DisableHUDForEndOfGame();
-            _packetHandlerManager.SendPacket((int)player.Item2.PlayerId, disableHud.GetBytes(), Channel.CHL_S2C);
+            _packetHandlerManager.SendPacket(player.ClientId, disableHud.GetBytes(), Channel.CHL_S2C);
         }
 
         /// <summary>
@@ -2834,11 +2834,11 @@ namespace PacketDefinitions420
         /// <param name="travelTime">The time the camera will have to travel the given distance</param>
         /// <param name="startFromCurretPosition">Wheter or not it starts from current position</param>
         /// <param name="unlockCamera">Whether or not the camera is unlocked</param>
-        public void NotifyS2C_MoveCameraToPoint(Tuple<uint, ClientInfo> player, Vector3 startPosition, Vector3 endPosition, float travelTime = 0, bool startFromCurretPosition = true, bool unlockCamera = false)
+        public void NotifyS2C_MoveCameraToPoint(ClientInfo player, Vector3 startPosition, Vector3 endPosition, float travelTime = 0, bool startFromCurretPosition = true, bool unlockCamera = false)
         {
             var cam = new S2C_MoveCameraToPoint
             {
-                SenderNetID = player.Item2.Champion.NetId,
+                SenderNetID = player.Champion.NetId,
                 StartFromCurrentPosition = startFromCurretPosition,
                 UnlockCamera = unlockCamera,
                 TravelTime = travelTime,
@@ -2849,7 +2849,7 @@ namespace PacketDefinitions420
                 cam.StartPosition = startPosition;
             }
 
-            _packetHandlerManager.SendPacket((int)player.Item2.PlayerId, cam.GetBytes(), Channel.CHL_S2C);
+            _packetHandlerManager.SendPacket(player.ClientId, cam.GetBytes(), Channel.CHL_S2C);
         }
         public void NotifyS2C_Neutral_Camp_Empty(IMonsterCamp monsterCamp, IDeathData deathData = null, int userId = 0)
         {
@@ -3675,7 +3675,7 @@ namespace PacketDefinitions420
         /// <param name="version">Version of the player being checked.</param>
         /// <param name="gameMode">String of the internal name of the gamemode being played.</param>
         /// <param name="mapId">ID of the map being played.</param>
-        public void NotifySynchVersion(int userId, List<Tuple<uint, ClientInfo>> players, string version, string gameMode, int mapId)
+        public void NotifySynchVersion(int userId, List<ClientInfo> players, string version, string gameMode, int mapId)
         {
             var syncVersion = new SynchVersionS2C
             {
@@ -3730,30 +3730,38 @@ namespace PacketDefinitions420
 
             for (int i = 0; i < players.Count; i++)
             {
-                syncVersion.PlayerInfo[i] = new PlayerLoadInfo
+                var info = new PlayerLoadInfo
                 {
-                    PlayerID = players[i].Item2.PlayerId,
+                    PlayerID = players[i].PlayerId,
                     // TODO: Change to players[i].Item2.SummonerLevel
                     SummonorLevel = 30,
-                    SummonorSpell1 = HashString(players[i].Item2.SummonerSkills[0]),
-                    SummonorSpell2 = HashString(players[i].Item2.SummonerSkills[1]),
+                    SummonorSpell1 = HashString(players[i].SummonerSkills[0]),
+                    SummonorSpell2 = HashString(players[i].SummonerSkills[1]),
                     // TODO
                     Bitfield = 0,
-                    TeamId = (uint)players[i].Item2.Team,
-                    // TODO: Change to players[i].Item2.Champion.Model + "Bot" (if players[i].Item2.IsBot)
+                    TeamId = (uint)players[i].Team,
                     BotName = "",
-                    // TODO: Change to players[i].Item2.Champion.Model (if players[i].Item2.IsBot)
                     BotSkinName = "",
-                    EloRanking = players[i].Item2.Rank,
-                    // TODO: Change to players[i].Item2.SkinNo (if players[i].Item2.IsBot)
+                    EloRanking = players[i].Rank,
                     BotSkinID = 0,
-                    // TODO: Change to players[i].Item2.BotDifficulty (if players[i].Item2.IsBot)
                     BotDifficulty = 0,
-                    ProfileIconId = players[i].Item2.Icon,
+                    ProfileIconId = players[i].Icon,
                     // TODO: Unhardcode these two.
                     AllyBadgeID = 0,
                     EnemyBadgeID = 0
                 };
+
+                /*
+                if(players[i].IsBot)
+                {
+                    info.BotName = players[i].Champion.Model + "Bot";
+                    info.BotSkinName = players[i].Champion.Model;
+                    info.BotSkinID = players[i].SkinNo;
+                    info.BotDifficulty = players[i].BotDifficulty;
+                }
+                */
+
+                syncVersion.PlayerInfo[i] = info;
             }
 
             // TODO: syncVersion.Mutators
@@ -3897,7 +3905,7 @@ namespace PacketDefinitions420
                 SourceNetID = died.NetId,
                 GoldAmmount = gold
             };
-            _packetHandlerManager.SendPacket((int)c.GetPlayerId(), ag.GetBytes(), Channel.CHL_S2C);
+            _packetHandlerManager.SendPacket(c.ClientId, ag.GetBytes(), Channel.CHL_S2C);
         }
 
         /// <summary>
@@ -4329,7 +4337,7 @@ namespace PacketDefinitions420
                 SenderNetID = client.Champion.NetId,
                 SyncID = request.SyncID,
             };
-            _packetHandlerManager.SendPacket((int)client.PlayerId, answer.GetBytes(), Channel.CHL_S2C, PacketFlags.NONE);
+            _packetHandlerManager.SendPacket(client.ClientId, answer.GetBytes(), Channel.CHL_S2C, PacketFlags.NONE);
         }
     }
 }

--- a/PacketDefinitions420/PacketServer.cs
+++ b/PacketDefinitions420/PacketServer.cs
@@ -63,8 +63,6 @@ namespace PacketDefinitions420
             var enetEvent = new Event();
             while (_server.HostService(enetEvent, timeout) > 0)
             {
-                Console.WriteLine($"EVENT {enetEvent.Type}");
-
                 switch (enetEvent.Type)
                 {
                     case EventType.CONNECT:

--- a/PacketDefinitions420/PacketServer.cs
+++ b/PacketDefinitions420/PacketServer.cs
@@ -36,24 +36,23 @@ namespace PacketDefinitions420
         /// <param name="game">Game instance.</param>
         /// <param name="netReq">Network request handler instance.</param>
         /// <param name="netResp">Network response handler instance.</param>
-        public void InitServer(ushort port, Dictionary<long, string> blowfishKeys, IGame game, NetworkHandler<ICoreRequest> netReq, NetworkHandler<ICoreRequest> netResp)
+        public void InitServer(ushort port, string[] blowfishKeys, IGame game, NetworkHandler<ICoreRequest> netReq, NetworkHandler<ICoreRequest> netResp)
         {
             _game = game;
             _server = new Host(Version.Patch420, new Address(_serverHost, port), 32, 32, 0, 0);
 
-            Dictionary<long, BlowFish> blowfishes = new Dictionary<long, BlowFish>();
-            foreach(var rawKey in blowfishKeys)
+            BlowFish[] blowfishes = new BlowFish[blowfishKeys.Length];
+            for(int i = 0; i < blowfishKeys.Length; i++)
             {
-                var key = Convert.FromBase64String(rawKey.Value);
+                var key = Convert.FromBase64String(blowfishKeys[i]);
                 if (key.Length <= 0)
                 {
                     throw new Exception($"Invalid blowfish key supplied({ key })");
                 }
-                blowfishes.Add(rawKey.Key, new BlowFish(key));
+                blowfishes[i] = new BlowFish(key);
             }
 
             PacketHandlerManager = new PacketHandlerManager(blowfishes, _server, game, netReq, netResp);
-
         }
 
         /// <summary>
@@ -64,6 +63,8 @@ namespace PacketDefinitions420
             var enetEvent = new Event();
             while (_server.HostService(enetEvent, timeout) > 0)
             {
+                Console.WriteLine($"EVENT {enetEvent.Type}");
+
                 switch (enetEvent.Type)
                 {
                     case EventType.CONNECT:


### PR DESCRIPTION
In its packets, the League uses concepts such as:
`long PlayerID` - identifies the player's account
`int ClientID` (from 0 to n - 1, where n is the number of players) - identifies the player in the current game.
In the Sandbox, instead of `ClientID` (often referred to as `userId`), `PlayerID` is used, which causes confusion and uncontrollable casting from `long` to `int` (and also `ulong` and `uint`) and vice versa, which can create problems in the long run.
On this occasion, TODOs are found in the code, calling to stop this obscurantism.
In addition, things like `List<Tuple<uint, ClientInfo>>` are used. The `ClientInfo` structure already contains the `ClientId`, and the number of players in some places is known in advance - no need to be so perverse.
I was inspired by the `LeagueServer` class. Now the correct terminology and ranges are used everywhere.