### PR TITLE
`userId` and `GetPlayers` microfix

### DIFF
--- a/GameServerLib/API/APIMapFunctionManager.cs
+++ b/GameServerLib/API/APIMapFunctionManager.cs
@@ -340,7 +340,6 @@ namespace LeagueSandbox.GameServer.API
         public static void EndGame(TeamId losingTeam, Vector3 finalCameraPosition, float endGameTimer = 5000.0f, bool moveCamera = true, float cameraTimer = 3.0f, bool disableUI = true, IDeathData deathData = null)
         {
             //TODO: check if mapScripts should handle this directly
-            var players = _game.PlayerManager.GetPlayers();
 
             if (deathData != null)
             {
@@ -352,6 +351,7 @@ namespace LeagueSandbox.GameServer.API
                 _game.PacketNotifier.NotifyS2C_SetGreyscaleEnabledWhenDead(false);
             }
 
+            var players = _game.PlayerManager.GetPlayers(false);
             foreach (var player in players)
             {
                 if (disableUI)

--- a/GameServerLib/Game.cs
+++ b/GameServerLib/Game.cs
@@ -437,7 +437,7 @@ namespace LeagueSandbox.GameServer
                 return;
             }
             IsPaused = true;
-            foreach (var player in PlayerManager.GetPlayers())
+            foreach (var player in PlayerManager.GetPlayers(false))
             {
                 PacketNotifier.NotifyPausePacket(player, (int)PauseTimeLeft, true);
             }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -78,8 +78,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             _tipsChanged = new List<IToolTipData>();
 
-            //TODO: check this
-            if (clientInfo.ClientId == -1)
+            if (clientInfo.PlayerId == -1)
             {
                 IsBot = true;
             }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/LaneTurret.cs
@@ -57,7 +57,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     champion.AddGold(this, globalGold);
                 }
 
-                foreach (var player in _game.PlayerManager.GetPlayers())
+                foreach (var player in _game.PlayerManager.GetPlayers(true))
                 {
                     var champion = player.Champion;
                     if (player.Team != Team)
@@ -72,7 +72,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
             else
             {
-                foreach (var player in _game.PlayerManager.GetPlayers())
+                foreach (var player in _game.PlayerManager.GetPlayers(true))
                 {
                     var champion = player.Champion;
                     if (player.Team != Team)

--- a/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleStartGame.cs
@@ -48,12 +48,14 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                     _game.IncrementReadyPlayers();
                 }
 
+                var players = _playerManager.GetPlayers(false);
+
                 // Only one packet enter here
-                if (_game.PlayersReady == _playerManager.GetPlayers().Count)
+                if (_game.PlayersReady == players.Count)
                 {
                     _game.PacketNotifier.NotifyGameStart();
 
-                    foreach (var player in _playerManager.GetPlayers())
+                    foreach (var player in players)
                     {
                         if (player.ClientId == userId && !player.IsMatchingVersion)
                         {

--- a/GameServerLib/Packets/PacketHandlers/HandleSync.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleSync.cs
@@ -27,23 +27,23 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             var mapId = _game.Config.GameConfig.Map;
             _logger.Debug("Current map: " + mapId);
 
-            var versionMatch = true;
+            var info = _playerManager.GetPeerInfo(userId);
+            var versionMatch = req.Version == Config.VERSION_STRING;
+            info.IsMatchingVersion = versionMatch;
+
             // Version might be an invalid value, currently it trusts the client
-            if (req.Version != Config.VERSION_STRING)
+            if (!versionMatch)
             {
-                versionMatch = false;
                 _logger.Warn($"Client's version ({req.Version}) does not match server's {Config.VERSION}");
             }
             else
             {
-                _logger.Debug("Accepted client version (" + req.Version + ") from client = " + req.ClientID + " & PlayerID = " + userId);
+                _logger.Debug("Accepted client version (" + req.Version + ") from client = " + req.ClientID + " & PlayerID = " + info.PlayerId);
             }
 
-            var info = _playerManager.GetPeerInfo(userId);
-            info.IsMatchingVersion = versionMatch;
-
-            _game.PacketNotifier.NotifySynchVersion(userId, _playerManager.GetPlayers(), Config.VERSION_STRING, _game.Config.GameConfig.GameMode,
-               mapId);
+            _game.PacketNotifier.NotifySynchVersion(
+                userId, _playerManager.GetPlayers(), Config.VERSION_STRING, _game.Config.GameConfig.GameMode, mapId
+            );
 
             return true;
         }

--- a/GameServerLib/Packets/PacketHandlers/HandleUnpauseReq.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleUnpauseReq.cs
@@ -27,7 +27,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             IChampion unpauser = null;
 
             unpauser = _playerManager.GetPeerInfo(userId).Champion;
-            foreach (var player in _playerManager.GetPlayers())
+            foreach (var player in _playerManager.GetPlayers(false))
             {
                 _game.PacketNotifier.NotifyResumePacket(unpauser, player, true);
             }
@@ -39,7 +39,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             };
             timer.Elapsed += (sender, args) =>
             {
-                foreach (var player in _playerManager.GetPlayers())
+                foreach (var player in _playerManager.GetPlayers(false))
                 {
                     _game.PacketNotifier.NotifyResumePacket(unpauser, player, false);
                 }

--- a/PacketDefinitions420/PacketHandlerManager.cs
+++ b/PacketDefinitions420/PacketHandlerManager.cs
@@ -199,7 +199,7 @@ namespace PacketDefinitions420
         public bool BroadcastPacketTeam(TeamId team, byte[] data, Channel channelNo,
             PacketFlags flag = PacketFlags.RELIABLE)
         {
-            foreach (var ci in _playerManager.GetPlayers(true))
+            foreach (var ci in _playerManager.GetPlayers(false))
             {
                 if (ci.Team == team)
                 {
@@ -255,6 +255,11 @@ namespace PacketDefinitions420
 
         public bool HandleDisconnect(Peer peer)
         {
+            if(peer == null)
+            {
+                return true;
+            }
+
             int clientId = ((int)peer.UserData) - 1;
             var peerInfo = _game.PlayerManager.GetPeerInfo(clientId);
             if (peerInfo == null)

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -758,7 +758,7 @@ namespace PacketDefinitions420
                 };
             }
 
-            if (userId <= 0)
+            if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacket(avatar.GetBytes(), Channel.CHL_S2C);
                 return;
@@ -1011,7 +1011,7 @@ namespace PacketDefinitions420
             {
                 cdPacket.IsSummonerSpell = true; // TODO: Verify functionality
             }
-            if (userId <= 0)
+            if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacketVision(u, cdPacket.GetBytes(), Channel.CHL_S2C);
             }
@@ -1129,7 +1129,7 @@ namespace PacketDefinitions420
                 Message = floatTextData.Message
             };
 
-            if (userId <= 0)
+            if (userId < 0)
             {
                 if (team != 0)
                 {
@@ -1187,7 +1187,7 @@ namespace PacketDefinitions420
         {
             var enterLocalVis = ConstructEnterLocalVisibilityClientPacket(o);
 
-            if (userId <= 0)
+            if (userId < 0)
             {
                 if (ignoreVision)
                 {
@@ -1218,7 +1218,7 @@ namespace PacketDefinitions420
 
             var enterVis = ConstructEnterVisibilityClientPacket(o, isChampion, packets);
 
-            if (userId != -1)
+            if (userId >= 0)
             {
                 _packetHandlerManager.SendPacket(userId, enterVis.GetBytes(), Channel.CHL_S2C);
                 NotifyEnterLocalVisibilityClient(o, userId, ignoreVision);
@@ -1282,7 +1282,7 @@ namespace PacketDefinitions420
         {
             var fxPacket = ConstructFXCreateGroupPacket(particle);
 
-            if (userId <= 0)
+            if (userId < 0)
             {
                 // Broadcast only to specific team.
                 if (particle.SpecificTeam != TeamId.TEAM_NEUTRAL)
@@ -1379,7 +1379,7 @@ namespace PacketDefinitions420
                 fxVisPacket.VisibilityTeam = 1;
             }
 
-            if (userId <= 0)
+            if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacketTeam(team, fxVisPacket.GetBytes(), Channel.CHL_S2C);
             }
@@ -1399,7 +1399,7 @@ namespace PacketDefinitions420
             {
                 EnablePause = true
             };
-            if (userId <= 0)
+            if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacket(start.GetBytes(), Channel.CHL_S2C);
             }
@@ -1510,7 +1510,7 @@ namespace PacketDefinitions420
                 SenderNetID = o.NetId
             };
 
-            if (userId != -1)
+            if (userId >= 0)
             {
                 _packetHandlerManager.SendPacket(userId, leaveLocalVis.GetBytes(), Channel.CHL_S2C);
                 return;
@@ -1533,7 +1533,7 @@ namespace PacketDefinitions420
                 SenderNetID = o.NetId
             };
 
-            if (userId != -1)
+            if (userId >= 0)
             {
                 _packetHandlerManager.SendPacket(userId, leaveVis.GetBytes(), Channel.CHL_S2C);
             }
@@ -1647,7 +1647,7 @@ namespace PacketDefinitions420
                 }
             };
 
-            if (userId <= 0)
+            if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacketVision(obj, newCharData.GetBytes(), Channel.CHL_S2C);
             }
@@ -2146,14 +2146,13 @@ namespace PacketDefinitions420
         public void NotifyNPC_Die_EventHistory(IChampion ch, uint killerNetID = 0)
         {
             var history = new NPC_Die_EventHistory();
-            history.SenderNetID = ch.NetId;
             history.KillerNetID = killerNetID;
             history.Duration = 0;
             if(ch.EventHistory.Count > 0)
             {
                 float firstTimestamp = ch.EventHistory[0].Timestamp;
                 float lastTimestamp = ch.EventHistory[ch.EventHistory.Count - 1].Timestamp;
-                history.Duration = lastTimestamp - firstTimestamp;
+                history.Duration = lastTimestamp - firstTimestamp; // ?
             }
             history.EventSourceType = 0; //TODO: Confirm that it is always zero
             history.Entries = ch.EventHistory;
@@ -2303,7 +2302,7 @@ namespace PacketDefinitions420
                     }
                 };
                 var channel = Channel.CHL_LOW_PRIORITY;
-                if (userId <= 0)
+                if (userId < 0)
                 {
                     _packetHandlerManager.BroadcastPacketVision(u, us.GetBytes(), channel, PacketFlags.UNSEQUENCED);
                 }
@@ -2470,7 +2469,7 @@ namespace PacketDefinitions420
         }
 
         /// <summary>
-        /// Sends a packet to all players detailing that the game has been unpaused.
+        /// Sends a packet to player detailing that the game has been unpaused.
         /// </summary>
         /// <param name="unpauser">Unit that unpaused the game.</param>
         /// <param name="showWindow">Whether or not to show a window before unpausing (delay).</param>
@@ -2499,7 +2498,7 @@ namespace PacketDefinitions420
                 SpawnDuration = monsterCamp.SpawnDuration,
                 TimerType = monsterCamp.TimerType
             };
-            if (userId <= 0)
+            if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
             }
@@ -2625,7 +2624,7 @@ namespace PacketDefinitions420
             {
                 NotifyEnterTeamVision(champion, 0, userId, heroPacket);
             }
-            else if (userId <= 0)
+            else if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacket(heroPacket.GetBytes(), Channel.CHL_S2C);
             }
@@ -2647,7 +2646,7 @@ namespace PacketDefinitions420
                 Expire = monsterCamp.Expire,
                 TimerType = monsterCamp.TimerType
             };
-            if (userId <= 0)
+            if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
             }
@@ -2672,7 +2671,7 @@ namespace PacketDefinitions420
         {
             var createTurret = ConstructCreateTurretPacket(turret);
 
-            if (userId != -1)
+            if (userId >= 0)
             {
                 _packetHandlerManager.SendPacket(userId, createTurret.GetBytes(), Channel.CHL_S2C);
                 return;
@@ -2868,7 +2867,7 @@ namespace PacketDefinitions420
             {
                 packet.KillerNetID = deathData.Killer.NetId;
             }
-            if (userId <= 0)
+            if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacket(packet.GetBytes(), Channel.CHL_S2C);
             }
@@ -2926,7 +2925,7 @@ namespace PacketDefinitions420
         {
             var enterTeamVis = ConstructOnEnterTeamVisibilityPacket(o, team);
 
-            if (userId <= 0)
+            if (userId < 0)
             {
                 // TODO: Verify if we should use BroadcastPacketTeam instead.
                 _packetHandlerManager.BroadcastPacket(enterTeamVis.GetBytes(), Channel.CHL_S2C);
@@ -2998,7 +2997,7 @@ namespace PacketDefinitions420
                 leaveTeamVis.VisibilityTeam = 1;
             }
 
-            if (userId <= 0)
+            if (userId < 0)
             {
                 // TODO: Verify if we should use BroadcastPacketTeam instead.
                 _packetHandlerManager.BroadcastPacket(leaveTeamVis.GetBytes(), Channel.CHL_S2C);
@@ -3207,7 +3206,7 @@ namespace PacketDefinitions420
                 BotCountOrder = 0,
                 BotCountChaos = 0
             };
-            if (userId <= 0)
+            if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacket(start.GetBytes(), Channel.CHL_S2C);
             }
@@ -3596,7 +3595,7 @@ namespace PacketDefinitions420
         {
             var spawnPacket = ConstructSpawnLevelPropPacket(levelProp);
 
-            if (userId != -1)
+            if (userId >= 0)
             {
                 _packetHandlerManager.SendPacket(userId, spawnPacket.GetBytes(), Channel.CHL_S2C);
             }
@@ -4043,7 +4042,7 @@ namespace PacketDefinitions420
                     }
                 };
 
-                if (userId <= 0)
+                if (userId < 0)
                 {
                     _packetHandlerManager.BroadcastPacketTeam(team, visibilityPacket.GetBytes(), Channel.CHL_S2C);
                     _packetHandlerManager.BroadcastPacketTeam(team, healthbarPacket.GetBytes(), Channel.CHL_S2C);
@@ -4070,7 +4069,7 @@ namespace PacketDefinitions420
                         packet = ConstructOnEnterTeamVisibilityPacket(obj, team); // Generic visibility packet
                     }
                 };
-                if (userId <= 0)
+                if (userId < 0)
                 {
                     _packetHandlerManager.BroadcastPacketTeam(team, packet.GetBytes(), Channel.CHL_S2C);
                 }
@@ -4200,7 +4199,7 @@ namespace PacketDefinitions420
                 Movements = new List<MovementDataNormal>() { move }
             };
 
-            if (userId <= 0)
+            if (userId < 0)
             {
                 _packetHandlerManager.BroadcastPacketVision(u, packet.GetBytes(), Channel.CHL_LOW_PRIORITY);
             }


### PR DESCRIPTION
- Fixed `userId` checks
- Not in the context of gameplay, `GetPlayers` is now called without bots, for example, bots are not allowed to vote for surrender