### PR TITLE
Resolve #326 -- Server patience

### DIFF
--- a/Content/LeagueSandbox-Scripts/Characters/Ezreal/Q.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Ezreal/Q.cs
@@ -111,7 +111,6 @@ namespace Spells
             {
                 source = new EventSource(3693728257, HashString("EzrealMysticShot"));
             }
-            System.Console.WriteLine($"Q {source.ScriptNameHash} {source?.ParentScript.ScriptNameHash}");
             target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false, source);
 
             for (byte i = 0; i < 4; i++)

--- a/GameServerConsole/Settings/GameInfo.json.template
+++ b/GameServerConsole/Settings/GameInfo.json.template
@@ -78,5 +78,6 @@
         "MINION_SPAWNS_ENABLED": false,
         "CONTENT_PATH": "../../../../../Content",
         "IS_DAMAGE_TEXT_GLOBAL": false
-    }
+    },
+    "forcedStart": 60
 }

--- a/GameServerCore/IGame.cs
+++ b/GameServerCore/IGame.cs
@@ -38,5 +38,11 @@ namespace GameServerCore
         /// Interface of functions containing value assignments for packets sent from the server to clients.
         /// </summary>
         IPacketNotifier PacketNotifier { get; }
+
+        /// <summary>
+        /// Checks for the presence of players on the server and if there are none, ends the game.
+        /// </summary>
+        /// <returns>true if no one is left.</returns>
+        bool CheckIfAllPlayersLeft();
     }
 }

--- a/GameServerCore/NetInfo/ClientInfo.cs
+++ b/GameServerCore/NetInfo/ClientInfo.cs
@@ -8,7 +8,13 @@ namespace GameServerCore.NetInfo
         public long PlayerId { get; private set; }
         public int ClientId { get; set; }
         public bool IsMatchingVersion { get; set; }
+        /// <summary>
+        /// False if the client sent a StartGame request.
+        /// </summary>
         public bool IsDisconnected { get; set; }
+        /// <summary>
+        /// True if the client sent a Handshake request.
+        /// </summary>
         public bool IsStartedClient { get; set; }
         public int SkinNo { get; private set; }
         public string[] SummonerSkills { get; private set; }
@@ -44,10 +50,10 @@ namespace GameServerCore.NetInfo
             Icon = icon;
             SkinNo = skinNo;
             IsMatchingVersion = true;
-            IsDisconnected = false;
             Name = name;
             SummonerSkills = summonerSkills;
             PlayerId = playerId;
+            IsDisconnected = true;
             IsStartedClient = false;
         }
     }

--- a/GameServerLib/Config.cs
+++ b/GameServerLib/Config.cs
@@ -33,6 +33,8 @@ namespace LeagueSandbox.GameServer
         public string ContentPath { get; private set; }
         public bool IsDamageTextGlobal { get; private set; }
 
+        public float ForcedStart { get; private set; }
+
         private Config()
         {
         }
@@ -91,6 +93,8 @@ namespace LeagueSandbox.GameServer
                 var playerConfig = new PlayerConfig(player, game);
                 Players.Add(playerConfig);
             }
+
+            ForcedStart = (float)(data.SelectToken("forcedStart") ?? 0) * 1000;
         }
 
         private string GetContentPath()

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -113,6 +113,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
             Stats.SetSummonerSpellEnabled(0, true);
             Stats.SetSummonerSpellEnabled(1, true);
+
+            while (Stats.Level < _game.Map.MapScript.MapScriptMetadata.InitialLevel)
+            {
+                this.LevelUp(true);
+            }
         }
 
         protected override void OnSpawn(int userId, TeamId team, bool doVision)

--- a/GameServerLib/Packets/PacketHandlers/HandleExit.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleExit.cs
@@ -1,29 +1,22 @@
 ﻿using GameServerCore.Packets.PacketDefinitions.Requests;
-using GameServerCore;
 using GameServerCore.Packets.Handlers;
 using LeaguePackets.Game.Events;
+using PacketDefinitions420;
 
 namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 {
     public class HandleExit : PacketHandlerBase<ExitRequest>
     {
-        private readonly Game _game;
-        private readonly IPlayerManager _playerManager;
+        private readonly IPacketHandlerManager _packetHandlerManager;
 
-        public HandleExit(Game game)
+        public HandleExit(IPacketHandlerManager packetHandlerManager)
         {
-            _game = game;
-            _playerManager = game.PlayerManager;
+            _packetHandlerManager = packetHandlerManager;
         }
 
         public override bool HandlePacket(int userId, ExitRequest req)
         {
-            var peerinfo = _playerManager.GetPeerInfo(userId);
-            var annoucement = new OnQuit { OtherNetID = peerinfo.Champion.NetId };
-            _game.PacketNotifier.NotifyS2C_OnEventWorld(annoucement, peerinfo.Champion);
-            peerinfo.IsDisconnected = true;
-
-            return true;
+            return _packetHandlerManager.HandleDisconnect(userId);
         }
     }
 }

--- a/PacketDefinitions420/IPacketHandlerManager.cs
+++ b/PacketDefinitions420/IPacketHandlerManager.cs
@@ -17,5 +17,6 @@ namespace PacketDefinitions420
         bool HandlePacket(Peer peer, Packet packet, Channel channelId);
         bool SendPacket(int userId, byte[] source, Channel channelNo, PacketFlags flag = PacketFlags.RELIABLE);
         bool HandleDisconnect(Peer peer);
+        bool HandleDisconnect(int clientId);
     }
 }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3919,7 +3919,7 @@ namespace PacketDefinitions420
         /// <param name="isGlobal">Whether or not the packet should be sent to all players.</param>
         /// <param name="sourceId">ID of the user who dealt the damage that should receive the packet.</param>
         /// <param name="targetId">ID of the user who is taking the damage that should receive the packet.</param>
-        public void NotifyUnitApplyDamage(IAttackableUnit source, IAttackableUnit target, float amount, DamageType type, DamageResultType damagetext, bool isGlobal = true, int sourceId = 0, int targetId = 0)
+        public void NotifyUnitApplyDamage(IAttackableUnit source, IAttackableUnit target, float amount, DamageType type, DamageResultType damagetext, bool isGlobal = true, int sourceId = -1, int targetId = -1)
         {
             var damagePacket = new UnitApplyDamage
             {
@@ -3937,11 +3937,11 @@ namespace PacketDefinitions420
             }
             else
             {
-                if (sourceId > 0)
+                if (sourceId >= 0)
                 {
                     _packetHandlerManager.SendPacket(sourceId, damagePacket.GetBytes(), Channel.CHL_S2C);
                 }
-                if (targetId > 0)
+                if (targetId >= 0)
                 {
                     _packetHandlerManager.SendPacket(targetId, damagePacket.GetBytes(), Channel.CHL_S2C);
                 }


### PR DESCRIPTION
- If the server's patience has run out:
  - If no one has connected, the server dies.
  - Otherwise, if there is at least one player who has confirmed readiness, the game starts.
  - Otherwise the server is waiting for someone to be ready to start the game, or for everyone to disconnect.
- If all players disconnect, the server dies.

Patience is set in the config as `"forceStart"` in seconds, zero to disable. 60 seconds in default _GameInfo.json_ config.