### PR TITLE
Deprecation of `SyncId` (part of #1463)

### DIFF
--- a/GameServerCore/Domain/GameObjects/IGameObject.cs
+++ b/GameServerCore/Domain/GameObjects/IGameObject.cs
@@ -33,10 +33,6 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         Vector3 Direction { get; }
         /// <summary>
-        /// Used to synchronize movement between client and server. Is currently assigned Env.TickCount.
-        /// </summary>
-        int SyncId { get; }
-        /// <summary>
         /// Team identifier, refer to TeamId enum.
         /// </summary>
         TeamId Team { get; }

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -70,10 +70,6 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// </summary>
         public Vector3 Direction { get; protected set; }
         /// <summary>
-        /// Used to synchronize movement between client and server. Is currently assigned Env.TickCount.
-        /// </summary>
-        public int SyncId { get; }
-        /// <summary>
         /// Team identifier, refer to TeamId enum.
         /// </summary>
         public TeamId Team { get; protected set; }
@@ -102,7 +98,6 @@ namespace LeagueSandbox.GameServer.GameObjects
             }
             Position = position;
             Direction = Vector3.Zero;
-            SyncId = Environment.TickCount; // TODO: use movement manager to generate this
             CollisionRadius = collisionRadius;
             PathfindingRadius = pathingRadius;
             VisionRadius = visionRadius;

--- a/PacketDefinitions420/PacketExtensions.cs
+++ b/PacketDefinitions420/PacketExtensions.cs
@@ -78,7 +78,7 @@ namespace PacketDefinitions420
         {
             return new MovementDataStop
             {
-                SyncID = (int)o.SyncId,
+                SyncID = Environment.TickCount,
                 Position = o.Position,
                 Forward = new Vector2(o.Direction.X, o.Direction.Z)
             };
@@ -92,7 +92,7 @@ namespace PacketDefinitions420
         {
             return new MovementDataNone
             {
-                SyncID = (int)o.SyncId
+                SyncID = 0 // Always zero in replays
             };
         }
 
@@ -139,7 +139,7 @@ namespace PacketDefinitions420
 
             return new MovementDataNormal
             {
-                SyncID = unit.SyncId,
+                SyncID = Environment.TickCount,
                 TeleportNetID = unit.NetId,
                 HasTeleportID = useTeleportID,
                 TeleportID = useTeleportID ? unit.TeleportID : (byte)0,
@@ -184,7 +184,7 @@ namespace PacketDefinitions420
 
             return new MovementDataWithSpeed
             {
-                SyncID = unit.SyncId,
+                SyncID = Environment.TickCount,
                 TeleportNetID = unit.NetId,
                 HasTeleportID = useTeleportID,
                 TeleportID = useTeleportID ? unit.TeleportID : (byte)0,

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -2067,7 +2067,7 @@ namespace PacketDefinitions420
             var castAnsPacket = new NPC_CastSpellAns
             {
                 SenderNetID = s.CastInfo.Owner.NetId,
-                CasterPositionSyncID = s.CastInfo.Owner.SyncId,
+                CasterPositionSyncID = Environment.TickCount,
                 // TODO: Find what this is (if false, causes CasterPositionSyncID to be used)
                 Unknown1 = false,
                 CastInfo = castInfo
@@ -2146,13 +2146,14 @@ namespace PacketDefinitions420
         public void NotifyNPC_Die_EventHistory(IChampion ch, uint killerNetID = 0)
         {
             var history = new NPC_Die_EventHistory();
+            history.SenderNetID = ch.NetId;
             history.KillerNetID = killerNetID;
             history.Duration = 0;
             if(ch.EventHistory.Count > 0)
             {
                 float firstTimestamp = ch.EventHistory[0].Timestamp;
                 float lastTimestamp = ch.EventHistory[ch.EventHistory.Count - 1].Timestamp;
-                history.Duration = lastTimestamp - firstTimestamp; // ?
+                history.Duration = lastTimestamp - firstTimestamp;
             }
             history.EventSourceType = 0; //TODO: Confirm that it is always zero
             history.Entries = ch.EventHistory;
@@ -3828,7 +3829,7 @@ namespace PacketDefinitions420
         {
             var md = new MovementDataNormal()
             {
-                SyncID = unit.SyncId,
+                SyncID = Environment.TickCount,
                 TeleportNetID = unit.NetId,
                 HasTeleportID = true,
                 TeleportID = unit.TeleportID,
@@ -4226,7 +4227,7 @@ namespace PacketDefinitions420
 
             var speedWpGroup = new WaypointGroupWithSpeed
             {
-                SyncID = u.SyncId,
+                SyncID = Environment.TickCount,
                 // TOOD: Implement support for multiple speed-based movements (functionally known as dashes).
                 Movements = new List<MovementDataWithSpeed> { md }
             };
@@ -4243,7 +4244,7 @@ namespace PacketDefinitions420
             var wpList = new WaypointList
             {
                 SenderNetID = unit.NetId,
-                SyncID = unit.SyncId,
+                SyncID = Environment.TickCount,
                 Waypoints = unit.Waypoints
             };
 
@@ -4259,7 +4260,7 @@ namespace PacketDefinitions420
             var wpList = new WaypointList
             {
                 SenderNetID = obj.NetId,
-                SyncID = obj.SyncId,
+                SyncID = Environment.TickCount,
                 Waypoints = waypoints
             };
 
@@ -4314,7 +4315,7 @@ namespace PacketDefinitions420
             var speedWpGroup = new WaypointListHeroWithSpeed
             {
                 SenderNetID = u.NetId,
-                SyncID = u.SyncId,
+                SyncID = Environment.TickCount,
                 // TOOD: Implement support for multiple speed-based movements (functionally known as dashes).
                 WaypointSpeedParams = speeds,
                 Waypoints = u.Waypoints


### PR DESCRIPTION
The `SyncId` of objects is static, but for motion packets it needs to be incremented. Therefore, in all such packets, `Environment.TickCount` is used. Almost in all. Due to the fact that `SyncId` was still used in some places, part of the dashing problems occur.