### PR TITLE
`CurrentWaypoint` split (part of #1463)

### DIFF
--- a/Content/LeagueSandbox-Scripts/Characters/Diana/CharScriptDiana.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Diana/CharScriptDiana.cs
@@ -30,7 +30,7 @@ namespace CharScripts
             if (diana != null)
             {
                 // Not moving
-                if (diana.CurrentWaypoint.Value == diana.Position && !beginStance)
+                if (diana.CurrentWaypoint == diana.Position && !beginStance)
                 {
                     PlayAnimation(diana, "Attack1", 5f);
                     beginStance = true;

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -36,7 +36,8 @@ namespace GameServerCore.Domain.GameObjects
         /// <summary>
         /// Index of the waypoint in the list of waypoints that the object is currently on.
         /// </summary>
-        KeyValuePair<int, Vector2> CurrentWaypoint { get; }
+        int CurrentWaypointKey { get; }
+        Vector2 CurrentWaypoint { get; }
         /// <summary>
         /// Status effects enabled on this unit. Refer to StatusFlags enum.
         /// </summary>
@@ -253,10 +254,6 @@ namespace GameServerCore.Domain.GameObjects
         /// <param name="y">Y coordinate to teleport to.</param>
         /// <param name="repath">Whether or not to repath from the new position.</param>
         void TeleportTo(float x, float y, bool repath = false);
-        /// <summary>
-        /// Returns the next waypoint. If all waypoints have been reached then this returns a -inf Vector2
-        /// </summary>
-        Vector2 GetNextWaypoint();
         /// <summary>
         /// Returns whether this unit has reached the last waypoint in its path of waypoints.
         /// </summary>

--- a/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
+++ b/GameServerLib/Chatbox/Commands/DebugModeCommand.cs
@@ -190,7 +190,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
                     }
                 }
 
-                for (int waypoint = u.CurrentWaypoint.Key; waypoint < u.Waypoints.Count; waypoint++)
+                for (int waypoint = u.CurrentWaypointKey; waypoint < u.Waypoints.Count; waypoint++)
                 {
                     var current = u.Waypoints[waypoint - 1];
 

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -93,7 +93,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// <summary>
         /// Index of the waypoint in the list of waypoints that the object is currently on.
         /// </summary>
-        public KeyValuePair<int, Vector2> CurrentWaypoint { get; protected set; }
+        public int CurrentWaypointKey { get; protected set; }
+        public Vector2 CurrentWaypoint
+        {
+            get { return Waypoints[CurrentWaypointKey]; }
+        }
         
         /// <summary>
         /// Status effects enabled on this unit. Refer to StatusFlags enum.
@@ -143,7 +147,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
 
             Waypoints = new List<Vector2> { Position };
-            CurrentWaypoint = new KeyValuePair<int, Vector2>(1, Position);
+            CurrentWaypointKey = 1;
             SetStatus(
                 StatusFlags.CanAttack | StatusFlags.CanCast     |
                 StatusFlags.CanMove   | StatusFlags.CanMoveEver |
@@ -970,7 +974,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         {
             // current -> next positions
             var cur = Position;
-            var next = CurrentWaypoint.Value;
+            var next = CurrentWaypoint;
 
             var goingTo = next - cur;
 
@@ -1028,7 +1032,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             // REVIEW (of previous code): (deltaMovement * 2) being used here is problematic; if the server lags, the diff will be much greater than the usual values
             if ((cur - next).LengthSquared() < MOVEMENT_EPSILON * MOVEMENT_EPSILON)
             {
-                var nextIndex = CurrentWaypoint.Key + 1;
+                var nextIndex = CurrentWaypointKey + 1;
                 // stop moving because we have reached our last waypoint
                 if (nextIndex >= Waypoints.Count)
                 {
@@ -1045,23 +1049,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 // start moving to our next waypoint
                 else
                 {
-                    CurrentWaypoint = new KeyValuePair<int, Vector2>(nextIndex, Waypoints[nextIndex]);
+                    CurrentWaypointKey = nextIndex;
                 }
             }
 
             return true;
-        }
-
-        /// <summary>
-        /// Returns the next waypoint. If all waypoints have been reached then this returns a -inf Vector2
-        /// </summary>
-        public Vector2 GetNextWaypoint()
-        {
-            if (CurrentWaypoint.Key < Waypoints.Count)
-            {
-                return CurrentWaypoint.Value;
-            }
-            return new Vector2(float.NegativeInfinity, float.NegativeInfinity);
         }
 
         /// <summary>
@@ -1070,7 +1062,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public void ResetWaypoints()
         {
             Waypoints = new List<Vector2> { Position };
-            CurrentWaypoint = new KeyValuePair<int, Vector2>(1, Position);
+            CurrentWaypointKey = 1;
         }
 
         /// <summary>
@@ -1078,7 +1070,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// </summary>
         public bool IsPathEnded()
         {
-            return CurrentWaypoint.Key >= Waypoints.Count;
+            return CurrentWaypointKey >= Waypoints.Count;
         }
 
         /// <summary>
@@ -1102,7 +1094,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 _movementUpdated = true;
             }
             Waypoints = newWaypoints;
-            CurrentWaypoint = new KeyValuePair<int, Vector2>(1, Waypoints[1]);
+            CurrentWaypointKey = 1;
         }
 
         /// <summary>

--- a/GameServerLib/Handlers/PathingHandler.cs
+++ b/GameServerLib/Handlers/PathingHandler.cs
@@ -75,7 +75,7 @@ namespace LeagueSandbox.GameServer.Handlers
             }
 
             var lastWaypoint = path[path.Count - 1];
-            if (obj.CurrentWaypoint.Value.Equals(lastWaypoint) && lastWaypoint.Equals(obj.Position))
+            if (obj.CurrentWaypoint.Equals(lastWaypoint) && lastWaypoint.Equals(obj.Position))
             {
                 return;
             }

--- a/PacketDefinitions420/PacketExtensions.cs
+++ b/PacketDefinitions420/PacketExtensions.cs
@@ -101,7 +101,7 @@ namespace PacketDefinitions420
             var currentWaypoints = new List<Vector2>(unit.Waypoints);
             currentWaypoints[0] = unit.Position;
 
-            int count = 2 + ((currentWaypoints.Count - 1) - unit.CurrentWaypoint.Key);
+            int count = 2 + ((currentWaypoints.Count - 1) - unit.CurrentWaypointKey);
             if (count >= 2)
             {
                 currentWaypoints.RemoveRange(1, currentWaypoints.Count - count);


### PR DESCRIPTION
- `KeyValuePair<int, Vector2> CurrentWaypoint` is split into `Vector2 CurrentWaypoint` and `int CurrentWaypointKey`. This makes it easier to move on to the next waypoint and eliminates the possibility of a situation where the waypoint position does not match its index.
- Removed unused `GetNextWaypoint` function. It is better to check the waypoint index right away than to compare it with infinity later or forget to check it.