### PR TITLE
Icons rework

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/AscRelic/AscRelicBombBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/AscRelic/AscRelicBombBuff.cs
@@ -26,7 +26,7 @@ namespace Buffs
             AddUnitPerceptionBubble(unit, 800.0f, 25000.0f, TeamId.TEAM_PURPLE, false, null, 38.08f);
             p1 = AddParticleTarget(unit, unit, "Asc_RelicPrism_Sand", unit, -1.0f, 1.0f ,direction: new Vector3(0.0f, 0.0f, -1.0f), flags: (FXFlags)304);
             AddParticleTarget(unit, unit, "Asc_relic_Sand_buf", unit, -1.0f, flags: (FXFlags)32);
-            unit.IconInfo.SwapIcon("Relic", true);
+            unit.IconInfo.ChangeIcon("Relic");
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)

--- a/Content/LeagueSandbox-Scripts/Buffs/AscWarp/AscWarp.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/AscWarp/AscWarp.cs
@@ -21,13 +21,13 @@ namespace Buffs
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             buff.SetStatusEffect(StatusFlags.Stunned, true);
-            unit.IconInfo.SwapBorder("Teleport", true, "AscWarp");
+            unit.IconInfo.ChangeBorder("Teleport", "AscWarp");
             AddParticleTarget(unit, unit, "Global_Asc_teleport", unit, buff.Duration);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            unit.IconInfo.SwapBorder("", true);
+            unit.IconInfo.ResetBorder();
             if (unit is IObjAIBase obj)
             {
                 AddBuff("AscWarpReappear", 10.0f, 1, null, unit, obj);

--- a/Content/LeagueSandbox-Scripts/Buffs/AscWarp/AscWarpTarget.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/AscWarp/AscWarpTarget.cs
@@ -22,15 +22,15 @@ namespace Buffs
         IParticle p1;
         public void OnActivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
-            unit.IconInfo.SwapBorder("Teleport", true, "ascwarptarget");
-            unit.IconInfo.SwapIcon("NoIcon", true);
+            unit.IconInfo.ChangeBorder("Teleport", "ascwarptarget");
+            unit.IconInfo.ChangeIcon("NoIcon");
             p1 = AddParticleTarget(buff.SourceUnit, null, "global_asc_teleport_target", unit, -1);
         }
 
         public void OnDeactivate(IAttackableUnit unit, IBuff buff, ISpell ownerSpell)
         {
             RemoveParticle(p1);
-            unit.IconInfo.SwapBorder("", true);
+            unit.IconInfo.ResetBorder();
             TeleportTo(buff.SourceUnit, unit.Position.X, unit.Position.Y);
             if (buff.SourceUnit is IChampion ch)
             {

--- a/Content/LeagueSandbox-Scripts/Buffs/OdinCenterRelic/OdinBombBuff.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/OdinCenterRelic/OdinBombBuff.cs
@@ -58,13 +58,12 @@ namespace Buffs
             }
 
             string iconCategory = "CenterRelicLeft";
-
             if (unit.Team == TeamId.TEAM_PURPLE)
             {
                 iconCategory = "CenterRelicRight";
             }
 
-            unit.IconInfo.SwapIcon(iconCategory, true);
+            unit.IconInfo.ChangeIcon(iconCategory);
         }
         public void OnDeath(IDeathData deathData)
         {

--- a/Content/LeagueSandbox-Scripts/Characters/Global/Recall.cs
+++ b/Content/LeagueSandbox-Scripts/Characters/Global/Recall.cs
@@ -21,55 +21,28 @@ namespace Spells
 
         IParticle recallParticle;
 
-        public void OnActivate(IObjAIBase owner, ISpell spell)
-        {
-        }
-
-        public void OnTakeDamage(IAttackableUnit unit, IAttackableUnit attacker)
-        {
-        }
-
-        public void OnDeactivate(IObjAIBase owner, ISpell spell)
-        {
-        }
-
-        public void OnSpellPreCast(IObjAIBase owner, ISpell spell, IAttackableUnit target, Vector2 start, Vector2 end)
-        {
-        }
-
-        public void OnSpellCast(ISpell spell)
-        {
-        }
-
-        public void OnSpellPostCast(ISpell spell)
-        {
-        }
-
         public void OnSpellChannel(ISpell spell)
         {
             var owner = spell.CastInfo.Owner;
             recallParticle = AddParticleTarget(owner, owner, "TeleportHome", owner, 8.0f, flags: 0);
             AddBuff("Recall", 7.9f, 1, spell, owner, owner);
+            owner.IconInfo.ChangeBorder("Recall", "recall");
         }
 
         public void OnSpellChannelCancel(ISpell spell, ChannelingStopSource reason)
         {
+            var owner = spell.CastInfo.Owner;
             recallParticle.SetToRemove();
-            RemoveBuff(spell.CastInfo.Owner, "Recall");
+            RemoveBuff(owner, "Recall");
+            owner.IconInfo.ResetBorder();
         }
 
         public void OnSpellPostChannel(ISpell spell)
         {
             var owner = spell.CastInfo.Owner as IChampion;
-
             owner.Recall();
-
             AddParticleTarget(owner, owner, "TeleportArrive", owner, flags: 0);
-        }
-
-        public void OnUpdate(float diff)
-        {
+            owner.IconInfo.ResetBorder();
         }
     }
 }
-

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScriptObjectsAscension.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/LevelScriptObjectsAscension.cs
@@ -103,7 +103,7 @@ namespace MapScripts.Map8
         public static void CreateTeleportPoint(Vector2 position, TeamId team, string mapIcon)
         {
             var point = CreateMinion("AscWarpIcon", "AscWarpIcon", position, team: team, ignoreCollision: false, isTargetable: false);
-            point.IconInfo.SwapIcon(mapIcon, true);
+            point.IconInfo.ChangeIcon(mapIcon);
             TeleportPlates.Add(point);
             point.PauseAI(true);
         }

--- a/Content/LeagueSandbox-Scripts/Maps/Map8/NeutralMinionSpawnAscension.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map8/NeutralMinionSpawnAscension.cs
@@ -131,7 +131,7 @@ public class AscXerath
     public void SpawnXerath()
     {
         var ascXerath = Camp.AddMonster(Xerath);
-        ascXerath.IconInfo.SwapIcon("Dragon", true);
+        ascXerath.IconInfo.ChangeIcon("Dragon");
         ApiEventManager.OnDeath.AddListener(ascXerath, ascXerath, OnXerathDeath, true);
         RespawnTimer = 30.0f * 1000;
     }
@@ -169,7 +169,7 @@ public class AscensionCrystal
     {
         var crystal = CreateMinion("AscRelic", "AscRelic", Position, ignoreCollision: true, isTargetable: false);
         ApiEventManager.OnDeath.AddListener(crystal, crystal, OnDeath, true);
-        crystal.IconInfo.SwapIcon("Relic", true);
+        crystal.IconInfo.ChangeIcon("Relic");
         IsDead = false;
         RespawnTimer = 20.0f * 1000f;
 

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -309,6 +309,5 @@ namespace GameServerCore.Domain.GameObjects
         /// First string is the animation to override, second string is the animation to play in place of the first.
         /// <param name="animPairs">Dictionary of animations to set.</param>
         void SetAnimStates(Dictionary<string, string> animPairs);
-        void UpdateIcon();
     }
 }

--- a/GameServerCore/Domain/IIconInfo.cs
+++ b/GameServerCore/Domain/IIconInfo.cs
@@ -7,13 +7,11 @@ namespace GameServerCore.Domain
     public interface IIconInfo
     {
         string IconCategory { get; }
-        bool ChangeIcon { get; }
         string BorderCategory { get; }
-        bool ChangeBorder { get; }
         string BorderScriptName { get; }
-        List<TeamId> TeamsNotified { get; }
-        void SwapIcon(string iconCategory, bool changeIcon);
-        void SwapBorder(string borderCategory, bool changeBorder, string borderScriptName = "");
-        void AddNotifiedTeam(TeamId team);
+        void ChangeIcon(string iconCategory);
+        void ResetIcon();
+        void ChangeBorder(string borderCategory, string borderScriptName);
+        void ResetBorder();
     }
 }

--- a/GameServerCore/Domain/IIconInfo.cs
+++ b/GameServerCore/Domain/IIconInfo.cs
@@ -13,5 +13,6 @@ namespace GameServerCore.Domain
         void ResetIcon();
         void ChangeBorder(string borderCategory, string borderScriptName);
         void ResetBorder();
+        void Sync(int userId, bool visible, bool force = false);
     }
 }

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -743,8 +743,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="attacked">Unit that is being attacked.</param>
         /// <param name="attackType">AttackType that the attacker is using to attack.</param>
         void NotifyS2C_UnitSetLookAt(IAttackableUnit attacker, IAttackableUnit attacked, AttackType attackType);
-        void NotifyS2C_UnitSetMinimapIcon(IAttackableUnit unit, TeamId team);
-        void NotifyS2C_UnitSetMinimapIcon(IAttackableUnit unit);
+        void NotifyS2C_UnitSetMinimapIcon(int userId, IAttackableUnit unit, bool changeIcon, bool changeBorder);
         void NotifyS2C_UpdateAscended(IObjAIBase ascendant = null);
         /// <summary>
         /// Sends a packet to all players detailing the attack speed cap overrides for this game.

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -15,6 +15,7 @@ using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.Logging;
 using log4net;
 using GameServerCore.Scripting.CSharp;
+using PacketDefinitions420;
 
 namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 {
@@ -116,7 +117,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// Information about this object's icon on the minimap.
         /// </summary>
         /// TODO: Move this to GameObject.
-        public IIconInfo IconInfo { get; }
+        public IIconInfo IconInfo => _iconInfo;
+        private IconInfo _iconInfo; // A little hack so that the compiler understands everything correctly.
         public override bool IsAffectedByFoW => true;
         public override bool SpawnShouldBeHidden => true;
 
@@ -160,7 +162,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             BuffSlots = new IBuff[256];
             ParentBuffs = new Dictionary<string, IBuff>();
             BuffList = new List<IBuff>();
-            IconInfo = new IconInfo(this);
+            _iconInfo = new IconInfo(_game, this);
             CalculateTrueMoveSpeed();
         }
 
@@ -318,34 +320,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             }
         }
 
-        protected override void OnSpawn(int userId, TeamId team, bool doVision)
+        public override void Sync(int userId, TeamId team, bool visible, bool forceSpawn = false)
         {
-            base.OnSpawn(userId, team, doVision);
-            UpdateIconVision(team);
-        }
-        protected override void OnEnterVision(int userId, TeamId team)
-        {
-            base.OnEnterVision(userId, team);
-            UpdateIconVision(team);
-        }
-
-        public void UpdateIconVision(TeamId team)
-        {
-            if (!IconInfo.TeamsNotified.Contains(team))
-            {
-                IconInfo.AddNotifiedTeam(team);
-                _game.PacketNotifier.NotifyS2C_UnitSetMinimapIcon(this, team);
-            }
-        }
-
-        public void UpdateIcon()
-        {
-            IconInfo.TeamsNotified.Clear();
-            _game.PacketNotifier.NotifyS2C_UnitSetMinimapIcon(this);
-            foreach (TeamId team in TeamsWithVision())
-            {
-                IconInfo.TeamsNotified.Add(team);
-            }
+            base.Sync(userId, team, visible, forceSpawn);
+            _iconInfo.Sync(userId, visible, forceSpawn);
         }
 
         protected override void OnSync(int userId, TeamId team)

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -117,8 +117,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// Information about this object's icon on the minimap.
         /// </summary>
         /// TODO: Move this to GameObject.
-        public IIconInfo IconInfo => _iconInfo;
-        private IconInfo _iconInfo; // A little hack so that the compiler understands everything correctly.
+        public IIconInfo IconInfo { get; protected set; }
         public override bool IsAffectedByFoW => true;
         public override bool SpawnShouldBeHidden => true;
 
@@ -162,7 +161,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             BuffSlots = new IBuff[256];
             ParentBuffs = new Dictionary<string, IBuff>();
             BuffList = new List<IBuff>();
-            _iconInfo = new IconInfo(_game, this);
+            IconInfo = new IconInfo(_game, this);
             CalculateTrueMoveSpeed();
         }
 
@@ -323,7 +322,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public override void Sync(int userId, TeamId team, bool visible, bool forceSpawn = false)
         {
             base.Sync(userId, team, visible, forceSpawn);
-            _iconInfo.Sync(userId, visible, forceSpawn);
+            IconInfo.Sync(userId, visible, forceSpawn);
         }
 
         protected override void OnSync(int userId, TeamId team)

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3442,8 +3442,6 @@ namespace PacketDefinitions420
 
         public void NotifyS2C_UnitSetMinimapIcon(int userId, IAttackableUnit unit, bool changeIcon, bool changeBorder)
         {
-            Console.WriteLine($"NotifyS2C_UnitSetMinimapIcon({userId}, {unit.Model}#{unit.NetId}, {changeIcon}, {changeBorder})");
-
             var packet = new S2C_UnitSetMinimapIcon
             {
                 UnitNetID = unit.NetId,
@@ -3462,12 +3460,6 @@ namespace PacketDefinitions420
                 packet.BorderCategory = unit.IconInfo.BorderCategory;
                 packet.BorderScriptName = unit.IconInfo.BorderScriptName;
             }
-            Console.WriteLine(
-                Newtonsoft.Json.JsonConvert.SerializeObject(
-                    packet,
-                    Newtonsoft.Json.Formatting.Indented
-                )
-            );
             _packetHandlerManager.SendPacket(userId, packet.GetBytes(), Channel.CHL_S2C);
         }
 

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -12,7 +12,6 @@ using LeaguePackets.Game;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Timers;
 using PingLoadInfoRequest = GameServerCore.Packets.PacketDefinitions.Requests.PingLoadInfoRequest;
 using ViewRequest = GameServerCore.Packets.PacketDefinitions.Requests.ViewRequest;
 using LeaguePackets.Game.Common;
@@ -3441,34 +3440,35 @@ namespace PacketDefinitions420
             _packetHandlerManager.BroadcastPacketTeam(team, dm.GetBytes(), Channel.CHL_S2C);
         }
 
-        public void NotifyS2C_UnitSetMinimapIcon(IAttackableUnit unit, TeamId team)
+        public void NotifyS2C_UnitSetMinimapIcon(int userId, IAttackableUnit unit, bool changeIcon, bool changeBorder)
         {
+            Console.WriteLine($"NotifyS2C_UnitSetMinimapIcon({userId}, {unit.Model}#{unit.NetId}, {changeIcon}, {changeBorder})");
+
             var packet = new S2C_UnitSetMinimapIcon
             {
                 UnitNetID = unit.NetId,
-                IconCategory = unit.IconInfo.IconCategory,
-                ChangeIcon = unit.IconInfo.ChangeIcon,
-                BorderCategory = unit.IconInfo.BorderCategory,
-                ChangeBorder = unit.IconInfo.ChangeBorder,
-                BorderScriptName = unit.IconInfo.BorderScriptName
+                ChangeIcon = changeIcon,
+                IconCategory = "",
+                ChangeBorder = changeBorder,
+                BorderCategory = "",
+                BorderScriptName = ""
             };
-
-            _packetHandlerManager.BroadcastPacketTeam(team, packet.GetBytes(), Channel.CHL_S2C);
-        }
-
-        public void NotifyS2C_UnitSetMinimapIcon(IAttackableUnit unit)
-        {
-            var packet = new S2C_UnitSetMinimapIcon
+            if(changeIcon)
             {
-                UnitNetID = unit.NetId,
-                IconCategory = unit.IconInfo.IconCategory,
-                ChangeIcon = unit.IconInfo.ChangeIcon,
-                BorderCategory = unit.IconInfo.BorderCategory,
-                ChangeBorder = unit.IconInfo.ChangeBorder,
-                BorderScriptName = unit.IconInfo.BorderScriptName
-            };
-
-            _packetHandlerManager.BroadcastPacketVision(unit, packet.GetBytes(), Channel.CHL_S2C);
+                packet.IconCategory = unit.IconInfo.IconCategory;
+            }
+            if(changeBorder)
+            {
+                packet.BorderCategory = unit.IconInfo.BorderCategory;
+                packet.BorderScriptName = unit.IconInfo.BorderScriptName;
+            }
+            Console.WriteLine(
+                Newtonsoft.Json.JsonConvert.SerializeObject(
+                    packet,
+                    Newtonsoft.Json.Formatting.Indented
+                )
+            );
+            _packetHandlerManager.SendPacket(userId, packet.GetBytes(), Channel.CHL_S2C);
         }
 
         /// <summary>


### PR DESCRIPTION
- Icons are now displayed correctly for reconnected players.
- The server now sets the correct `ChangeIcon` and `ChangeBorder` parameters and the names are not transferred unnecessarily.
- The border around the player icon on the minimap now changes when recalling.