### PR TITLE
`DashMove` and new `Move` (part of #1463)

### DIFF
--- a/GameServerCore/Domain/GameObjects/IForceMovementParameters.cs
+++ b/GameServerCore/Domain/GameObjects/IForceMovementParameters.cs
@@ -9,7 +9,11 @@ namespace GameServerCore.Domain.GameObjects
         /// <summary>
         /// Amount of time passed since the unit started dashing.
         /// </summary>
-        float ElapsedTime { get; }
+        float ElapsedTime { get; set; }
+        /// <summary>
+        /// The distance traveled from the beginning of the dash.
+        /// </summary>
+        float PassedDistance { get; set; }
         /// <summary>
         /// Speed to use for the movement.
         /// </summary>
@@ -42,7 +46,5 @@ namespace GameServerCore.Domain.GameObjects
         /// Maximum amount of time to follow the FollowNetID.
         /// </summary>
         float FollowTravelTime { get; }
-
-        void SetTimeElapsed(float time);
     }
 }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -285,6 +285,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             Stats.CurrentHealth = Stats.HealthPoints.Total;
             IsDead = false;
             RespawnTimer = -1;
+            SetDashingState(false, MoveStopReason.HeroReincarnate);
             ApiEventManager.OnResurrect.Publish(this);
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/ForceMovementParameters.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/ForceMovementParameters.cs
@@ -15,6 +15,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// </summary>
         public float ElapsedTime { get; set; }
         /// <summary>
+        /// The distance traveled from the beginning of the dash.
+        /// </summary>
+        public float PassedDistance { get; set; }
+        /// <summary>
         /// Speed to use for the movement.
         /// </summary>
         public float PathSpeedOverride { get; set; }
@@ -47,10 +51,5 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// Maximum amount of time to follow the FollowNetID.
         /// </summary>
         public float FollowTravelTime { get; set; }
-
-        public void SetTimeElapsed(float time)
-        {
-            ElapsedTime = time;
-        }
     }
 }


### PR DESCRIPTION
- The `Move` function has been rewritten from scratch, it is freed from the dependence on `deltaMovement`, so the possibility of "flying" past the waypoint is excluded.
- Added separate `DashMove` function to control movement while dashing. It follows time and distance constraints, and the remaining frame time after dash end can then be given to the `Move` function.
- Calling `SetDashingState(false)` will now `ResetWaypoints` as it is assumed that they were set at the beginning of the dash and that the unit does not then follow them afterwards, pushing the target of the dash.
- After the resurrection of champions, the dash is forcibly reset so that the players who died "in flight" do not fly from the base later.