### PR TITLE
Output a stack trace of unhandled exceptions to a log file

### DIFF
--- a/GameServerConsole/Program.cs
+++ b/GameServerConsole/Program.cs
@@ -23,6 +23,9 @@ namespace LeagueSandbox.GameServerConsole
 
         private static void Main(string[] args)
         {
+            try
+            {
+
             // If the command line interface was ran with additional parameters (perhaps via a shortcut or just via another command line)
             // Refer to ArgsOptions for all possible launch parameters
             var parsedArgs = ArgsOptions.Parse(args);
@@ -90,6 +93,12 @@ namespace LeagueSandbox.GameServerConsole
 #endif
             // This is where the actual GameServer starts.
             gameServerLauncher.StartNetworkLoop();
+
+            }
+            catch(Exception e)
+            {
+                _logger.Fatal(null, e);
+            }
         }
 
         /// <summary>
@@ -119,7 +128,7 @@ namespace LeagueSandbox.GameServerConsole
             }
             catch (Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
 
             return defaultJsonString;

--- a/GameServerConsole/Program.cs
+++ b/GameServerConsole/Program.cs
@@ -23,8 +23,9 @@ namespace LeagueSandbox.GameServerConsole
 
         private static void Main(string[] args)
         {
-            try
-            {
+            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(
+                (sender, args) => _logger.Fatal(null, (Exception)args.ExceptionObject)
+            );
 
             // If the command line interface was ran with additional parameters (perhaps via a shortcut or just via another command line)
             // Refer to ArgsOptions for all possible launch parameters
@@ -93,12 +94,6 @@ namespace LeagueSandbox.GameServerConsole
 #endif
             // This is where the actual GameServer starts.
             gameServerLauncher.StartNetworkLoop();
-
-            }
-            catch(Exception e)
-            {
-                _logger.Fatal(null, e);
-            }
         }
 
         /// <summary>

--- a/GameServerLib/Chatbox/Commands/JunglespawnCommand.cs
+++ b/GameServerLib/Chatbox/Commands/JunglespawnCommand.cs
@@ -26,7 +26,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
             _logger.Info($"{ChatCommandManager.CommandStarterCharacter}{Command} Jungle Spawned!");
             ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.NORMAL, "Jungle Spawned!");

--- a/GameServerLib/Game.cs
+++ b/GameServerLib/Game.cs
@@ -446,7 +446,7 @@ namespace LeagueSandbox.GameServer
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
         }
 

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -223,7 +223,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
         }
 
@@ -240,7 +240,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
         }
 
@@ -1075,7 +1075,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
 
             if (!_aiPaused)
@@ -1086,7 +1086,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 }
                 catch(Exception e)
                 {
-                    _logger.Error(e);
+                    _logger.Error(null, e);
                 }
             }
 
@@ -1154,7 +1154,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                         }
                         catch(Exception e)
                         {
-                            _logger.Error(e);
+                            _logger.Error(null, e);
                         }
                     }
                 }

--- a/GameServerLib/GameObjects/Buff.cs
+++ b/GameServerLib/GameObjects/Buff.cs
@@ -117,7 +117,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
         }
 
@@ -135,7 +135,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
 
             ApiEventManager.RemoveAllListenersForOwner(BuffScript);
@@ -216,7 +216,7 @@ namespace LeagueSandbox.GameServer.GameObjects
                     }
                     catch(Exception e)
                     {
-                        _logger.Error(e);
+                        _logger.Error(null, e);
                     }
                     if (TimeElapsed >= Duration)
                     {

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -171,7 +171,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
         }
 
@@ -442,7 +442,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
 
             if (_game.Config.GameFeatures.HasFlag(FeatureFlags.EnableManaCosts))
@@ -594,7 +594,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
 
             var stats = CastInfo.Owner.Stats;
@@ -1087,7 +1087,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
         }
 
@@ -1582,7 +1582,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Spell
                 }
                 catch(Exception e)
                 {
-                    _logger.Error(e);
+                    _logger.Error(null, e);
                 }
             }
 

--- a/GameServerLib/Handlers/MapScriptHandler.cs
+++ b/GameServerLib/Handlers/MapScriptHandler.cs
@@ -148,7 +148,7 @@ namespace LeagueSandbox.GameServer.Handlers
             }
             catch(Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
         }
     }

--- a/GameServerLib/Inventory/Inventory.cs
+++ b/GameServerLib/Inventory/Inventory.cs
@@ -88,7 +88,7 @@ namespace LeagueSandbox.GameServer.Inventory
                 }
                 catch(Exception e)
                 {
-                    _logger.Error(e);
+                    _logger.Error(null, e);
                 }
             }
         }
@@ -171,7 +171,7 @@ namespace LeagueSandbox.GameServer.Inventory
                         }
                         catch(Exception e)
                         {
-                            _logger.Error(e);
+                            _logger.Error(null, e);
                         }
                         if (ItemScripts[itemID].StatsModifier != null)
                         {
@@ -252,7 +252,7 @@ namespace LeagueSandbox.GameServer.Inventory
                     }
                     catch(Exception e)
                     {
-                        _logger.Error(e);
+                        _logger.Error(null, e);
                     }
                 }
             }

--- a/GameServerLib/Inventory/InventoryManager.cs
+++ b/GameServerLib/Inventory/InventoryManager.cs
@@ -190,7 +190,7 @@ namespace LeagueSandbox.GameServer.Inventory
                 }
                 catch(Exception e)
                 {
-                    _logger.Error(e);
+                    _logger.Error(null, e);
                 }
             }
         }

--- a/GameServerLib/Program.cs
+++ b/GameServerLib/Program.cs
@@ -54,7 +54,7 @@ namespace LeagueSandbox.GameServer
             }
             catch (Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
 #endif
         }
@@ -73,7 +73,7 @@ namespace LeagueSandbox.GameServer
             }
             catch (Exception e)
             {
-                _logger.Error(e);
+                _logger.Error(null, e);
             }
 #endif
         }


### PR DESCRIPTION
Otherwise, it is difficult to debug the server, having access only to the logs.
`_logger.Error(e)` -> `_logger.Error(null, e)` + `Fatal` in `GameServerConsole.Program.Main` just in case **everything** goes wrong
```cs
//     WARNING Note that passing an System.Exception to this method will print the name
//     of the System.Exception but no stack trace. To print a stack trace use the Error(object,Exception)
//     form instead.
void Error(object message);
```
-- From `log4net.ILog`