### PR TITLE
Map11 NullReference Micro Fix

### DIFF
--- a/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScriptObjects.cs
+++ b/Content/LeagueSandbox-Scripts/Maps/Map11/LevelScriptObjects.cs
@@ -20,7 +20,7 @@ namespace MapScripts.Map11
         public static Dictionary<LaneID, List<Vector2>> MinionPaths = new Dictionary<LaneID, List<Vector2>> { { LaneID.TOP, new List<Vector2>() }, { LaneID.BOTTOM, new List<Vector2>() } };
         public static Dictionary<TeamId, bool> AllInhibitorsAreDead = new Dictionary<TeamId, bool> { { TeamId.TEAM_BLUE, false }, { TeamId.TEAM_PURPLE, false } };
         static Dictionary<TeamId, Dictionary<IInhibitor, float>> DeadInhibitors = new Dictionary<TeamId, Dictionary<IInhibitor, float>> { { TeamId.TEAM_BLUE, new Dictionary<IInhibitor, float>() }, { TeamId.TEAM_PURPLE, new Dictionary<IInhibitor, float>() } };
-        static List<INexus> NexusList;
+        static List<INexus> NexusList = new List<INexus>();
         static string LaneTurretAI = "TurretAI";
 
         static Dictionary<TeamId, Dictionary<LaneID, List<ILaneTurret>>> TurretList = new Dictionary<TeamId, Dictionary<LaneID, List<ILaneTurret>>>

--- a/GameServerLib/Chatbox/Commands/SpeedCommand.cs
+++ b/GameServerLib/Chatbox/Commands/SpeedCommand.cs
@@ -9,7 +9,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         private readonly IPlayerManager _playerManager;
 
         public override string Command => "speed";
-        public override string Syntax => $"{Command} parameter [p (percent), f (flat)] speed";
+        public override string Syntax => $"{Command} [flat speed] [percent speed]";
 
         public SpeedCommand(ChatCommandManager chatCommandManager, Game game)
             : base(chatCommandManager, game)
@@ -20,7 +20,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         public override void Execute(int userId, bool hasReceivedArguments, string arguments = "")
         {
             var split = arguments.ToLower().Split(' ');
-            if (split.Length < 2)
+            if (split.Length < 2 || split.Length > 3)
             {
                 ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.SYNTAXERROR);
                 ShowSyntax();
@@ -30,24 +30,18 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             {
                 IStatsModifier stat = new StatsModifier();
 
-                switch (split[1])
+                if (split.Length == 3)
                 {
-                    case "p":
-                        stat.MoveSpeed.PercentBonus = float.Parse(split[2]) / 100;
-                        break;
-                    case "f":
-                        stat.MoveSpeed.FlatBonus = float.Parse(split[2]);
-                        break;
-                    default:
-                        ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.ERROR, "Incorrect parameter");
-                        break;
+                    stat.MoveSpeed.PercentBonus = float.Parse(split[2]) / 100;
                 }
+                stat.MoveSpeed.FlatBonus = float.Parse(split[1]);
 
                 _playerManager.GetPeerInfo(userId).Champion.AddStatModifier(stat);
             }
             catch
             {
-                ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.ERROR, "Incorrect parameter");
+                ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.SYNTAXERROR);
+                ShowSyntax();
             }
         }
     }


### PR DESCRIPTION
* Fixed Map11's script mentioning an uninitialized List variable.
* Reworked a bit how the speed command works, now instead of typing `!speed [f or p] [ammount]`, you just have to type `!speed [f ammount] [p ammount]`. 
This resembles how it used to work if you just wanted flat move speed, but now with the optional extra parameter for the percent move speed