### PR TITLE
`DashMove` function fix and removals

### DIFF
--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -263,21 +263,11 @@ namespace GameServerCore.Domain.GameObjects
         /// </summary>
         /// <param name="newWaypoints">New path of Vector2 coordinates that the unit will move to.</param>
         /// <param name="networked">Whether or not clients should be notified of this change in waypoints at the next ObjectManager.Update.</param>
-        void SetWaypoints(List<Vector2> newWaypoints, bool networked = true);
+        bool SetWaypoints(List<Vector2> newWaypoints);
         /// <summary>
         /// Forces this unit to stop moving.
         /// </summary>
         void StopMovement();
-        /// <summary>
-        /// Returns whether this unit's waypoints will be networked to clients the next update. Movement updates do not occur for dash based movements.
-        /// </summary>
-        /// <returns>True/False</returns>
-        /// TODO: Refactor movement update logic so this can be applied to any kind of movement.
-        bool IsMovementUpdated();
-        /// <summary>
-        /// Used each object manager update after this unit has set its waypoints and the server has networked it.
-        /// </summary>
-        void ClearMovementUpdated();
         /// <summary>
         /// Enables or disables the given status on this unit.
         /// </summary>

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -489,6 +489,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             _game.PacketNotifier.NotifyNPC_Hero_Die(data);
             EventHistory.Clear();
             
+            SetDashingState(false, MoveStopReason.Death);
             _game.ObjectManager.StopTargeting(this);
         }
 


### PR DESCRIPTION
- The `_movementUpdated` variable is not used externally, so the getter and setter are removed.
- The `SetWaypoints` function now returns a `bool` to indicate that changing waypoints is not always possible.
- Added dash reset on champion death - just in case.

Explanations for most deletions:
<details>
<summary>Deleted from `ObjAIBase.RefreshWaypoints`</summary>

```csharp
if (TargetUnit != null)
{
    if (IsCollidingWith(TargetUnit))
    {
        SetDashingState(false);
    }
    else
    {
        SetWaypoints(new List<Vector2> { Position, TargetUnit.Position });
    }
}
else
{
    if (IsPathEnded())
    {
        SetDashingState(false);
    }
}
```
</details>
This is now handled by `DashMove`.

<details>
<summary>Deleted from `AttackableUnit.Update`</summary>

```csharp
if (IsMovementUpdated() && !CanChangeWaypoints())
{
    _movementUpdated = false;
}

if (MovementParameters != null && MovementParameters.FollowNetID > 0)
{
    MovementParameters.ElapsedTime += diff;
    if (MovementParameters.ElapsedTime >= MovementParameters.FollowTravelTime && MovementParameters.FollowTravelTime >= 0)
    {
        SetDashingState(false);
    }
}
```
</details>
This is now handled by `SetWaypoints` and `DashMove`.