### PR TITLE
Stat Fixes

### DIFF
--- a/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQTwoDash.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/LeeSin/BlindMonkQTwoDash.cs
@@ -35,7 +35,7 @@ namespace Buffs
             ApiEventManager.OnMoveEnd.AddListener(this, unit, OnMoveEnd, true);
             ApiEventManager.OnMoveSuccess.AddListener(this, unit, OnMoveSuccess, true);
 
-            var dashSpeed = 1350f + owner.GetTrueMoveSpeed();
+            var dashSpeed = 1350f + owner.Stats.GetTrueMoveSpeed();
 
             ForceMovement(owner, target, "", dashSpeed, 0f, Vector2.Distance(target.Position, owner.Position), 0f, -1f, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
 

--- a/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoE.cs
+++ b/Content/LeagueSandbox-Scripts/Buffs/Yasuo/YasuoE.cs
@@ -27,7 +27,7 @@ namespace Buffs
             AddParticleTarget(owner, unit, "Yasuo_Base_E_Dash", unit);
             AddParticleTarget(owner, target, "Yasuo_Base_E_dash_hit", target);
             var to = Vector2.Normalize(target.Position - unit.Position);
-            ForceMovement(unit, "Spell3", new Vector2(target.Position.X + to.X * 175f, target.Position.Y + to.Y * 175f), 750f + unit.GetTrueMoveSpeed() * 0.6f, 0, 0, 0);
+            ForceMovement(unit, "Spell3", new Vector2(target.Position.X + to.X * 175f, target.Position.Y + to.Y * 175f), 750f + unit.Stats.GetTrueMoveSpeed() * 0.6f, 0, 0, 0);
             target.TakeDamage(unit, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
         }
 

--- a/Content/LeagueSandbox-Scripts/Talents/Offense/Brute Force.cs
+++ b/Content/LeagueSandbox-Scripts/Talents/Offense/Brute Force.cs
@@ -10,7 +10,9 @@ namespace Talents
         public void OnActivate(IObjAIBase owner, byte rank)
         {
             var attackPerLevel = new StatsModifier();
-            attackPerLevel.AttackDamagePerLevel.FlatBonus = 0.22f * rank;
+            float[] statPerRank = new[] { 0.22f, 0.39f, 0.55f };
+            attackPerLevel.AttackDamagePerLevel.FlatBonus = statPerRank[rank - 1];
+
             owner.AddStatModifier(attackPerLevel);
         }
     }

--- a/Content/LeagueSandbox-Scripts/Talents/Offense/Martial Mastery.cs
+++ b/Content/LeagueSandbox-Scripts/Talents/Offense/Martial Mastery.cs
@@ -10,7 +10,7 @@ namespace Talents
         public void OnActivate(IObjAIBase owner, byte rank)
         {
             var attackDamage = new StatsModifier();
-            attackDamage.AttackDamagePerLevel.FlatBonus = 5.0f;
+            attackDamage.AttackDamage.FlatBonus = 5.0f;
             owner.AddStatModifier(attackDamage);
         }
     }

--- a/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
+++ b/GameServerCore/Domain/GameObjects/IAttackableUnit.cs
@@ -238,16 +238,6 @@ namespace GameServerCore.Domain.GameObjects
         /// <returns>Float units/sec.</returns>
         float GetMoveSpeed();
         /// <summary>
-        /// Processes the unit's move speed
-        /// </summary>
-        void CalculateTrueMoveSpeed();
-        /// <summary>
-        /// Returns the true movespeed of an unit
-        /// </summary>
-        /// <returns></returns>
-        float GetTrueMoveSpeed();
-        void ClearSlows();
-        /// <summary>
         /// Teleports this unit to the given position, and optionally repaths from the new position.
         /// </summary>
         /// <param name="x">X coordinate to teleport to.</param>

--- a/GameServerCore/Domain/GameObjects/IStats.cs
+++ b/GameServerCore/Domain/GameObjects/IStats.cs
@@ -63,8 +63,8 @@ namespace GameServerCore.Domain.GameObjects
         void LevelUp();
 
         float GetTotalAttackSpeed();
-        public float GetTrueMoveSpeed();
-        public void ClearSlows();
+        float GetTrueMoveSpeed();
+        void ClearSlows();
 
         bool GetActionState(ActionState state);
         bool GetSpellEnabled(byte id);

--- a/GameServerCore/Domain/GameObjects/IStats.cs
+++ b/GameServerCore/Domain/GameObjects/IStats.cs
@@ -63,6 +63,9 @@ namespace GameServerCore.Domain.GameObjects
         void LevelUp();
 
         float GetTotalAttackSpeed();
+        public float GetTrueMoveSpeed();
+        public void ClearSlows();
+
         bool GetActionState(ActionState state);
         bool GetSpellEnabled(byte id);
         float GetPostMitigationDamage(float damage, DamageType type, IAttackableUnit attacker);

--- a/GameServerCore/Domain/IDamageData.cs
+++ b/GameServerCore/Domain/IDamageData.cs
@@ -16,7 +16,7 @@ namespace GameServerCore.Domain
         /// <summary>
         /// The result of this damage (Ex. Dodged, Missed, Invulnerable or Crit)
         /// </summary>
-        public DamageResultType DamageResultType { get; set; }
+        DamageResultType DamageResultType { get; set; }
         /// <summary>
         /// Source of the damage.
         /// </summary>

--- a/GameServerCore/Domain/IDamageData.cs
+++ b/GameServerCore/Domain/IDamageData.cs
@@ -1,5 +1,4 @@
 ﻿using GameServerCore.Domain.GameObjects;
-using GameServerCore.Domain.GameObjects.Spell;
 using GameServerCore.Enums;
 
 namespace GameServerCore.Domain
@@ -7,32 +6,37 @@ namespace GameServerCore.Domain
     public interface IDamageData
     {
         /// <summary>
-        /// Wheter or not the damage came from an auttoatack or a Spell
-        /// </summary>
-        bool IsAutoAttack { get; }
-        /// <summary>
-        /// Unit that received the damage.
-        /// </summary>
-        IAttackableUnit Target { get; }
-        /// <summary>
         /// Unit that inflicted the damage.
         /// </summary>
         IAttackableUnit Attacker { get; }
-        /// <summary>
-        /// Type of damage received.
-        /// </summary>
-        DamageType DamageType { get; }
-        /// <summary>
-        /// Source of the damage.
-        /// </summary>
-        DamageSource DamageSource { get; }
         /// <summary>
         /// The raw ammount of damage to be inflicted (Pre-Mitigation damage)
         /// </summary>
         float Damage { get; }
         /// <summary>
+        /// The result of this damage (Ex. Dodged, Missed, Invulnerable or Crit)
+        /// </summary>
+        public DamageResultType DamageResultType { get; set; }
+        /// <summary>
+        /// Source of the damage.
+        /// </summary>
+        DamageSource DamageSource { get; }
+        /// <summary>
+        /// Type of damage received.
+        /// </summary>
+        DamageType DamageType { get; }
+
+        /// <summary>
+        /// Wheter or not the damage came from an auttoatack or a Spell
+        /// </summary>
+        bool IsAutoAttack { get; }
+        /// <summary>
         /// Damage after being reduced by MR/Armor
         /// </summary>
         float PostMitigationdDamage { get; }
+        /// <summary>
+        /// Unit that received the damage.
+        /// </summary>
+        IAttackableUnit Target { get; }
     }
 }

--- a/GameServerCore/Domain/IDamageData.cs
+++ b/GameServerCore/Domain/IDamageData.cs
@@ -33,7 +33,7 @@ namespace GameServerCore.Domain
         /// <summary>
         /// Damage after being reduced by MR/Armor
         /// </summary>
-        float PostMitigationdDamage { get; }
+        float PostMitigationDamage { get; }
         /// <summary>
         /// Unit that received the damage.
         /// </summary>

--- a/GameServerCore/Domain/IDamageData.cs
+++ b/GameServerCore/Domain/IDamageData.cs
@@ -10,7 +10,7 @@ namespace GameServerCore.Domain
         /// </summary>
         IAttackableUnit Attacker { get; }
         /// <summary>
-        /// The raw ammount of damage to be inflicted (Pre-Mitigation damage)
+        /// The raw amount of damage to be inflicted (Pre-Mitigation damage)
         /// </summary>
         float Damage { get; }
         /// <summary>

--- a/GameServerCore/Domain/IDamageData.cs
+++ b/GameServerCore/Domain/IDamageData.cs
@@ -27,7 +27,7 @@ namespace GameServerCore.Domain
         DamageType DamageType { get; }
 
         /// <summary>
-        /// Wheter or not the damage came from an auttoatack or a Spell
+        /// Whether or not the damage came from an autoatack or a Spell
         /// </summary>
         bool IsAutoAttack { get; }
         /// <summary>

--- a/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
+++ b/GameServerCore/Packets/Interfaces/IPacketNotifier.cs
@@ -908,7 +908,7 @@ namespace GameServerCore.Packets.Interfaces
         /// <param name="isGlobal">Whether or not the packet should be sent to all players.</param>
         /// <param name="sourceId">ID of the user who dealt the damage that should receive the packet.</param>
         /// <param name="targetId">ID of the user who is taking the damage that should receive the packet.</param>
-        void NotifyUnitApplyDamage(IAttackableUnit source, IAttackableUnit target, float amount, DamageType type, DamageResultType damagetext, bool isGlobal = true, int sourceId = 0, int targetId = 0);
+        void NotifyUnitApplyDamage(IDamageData damageData, bool isGlobal = true);
         /// <summary>
         /// Sends a packet to the specified player detailing that the specified target GameObject's (debug?) path drawing mode has been set to the specified mode.
         /// </summary>

--- a/GameServerLib/API/ApiFunctionManager.cs
+++ b/GameServerLib/API/ApiFunctionManager.cs
@@ -382,8 +382,7 @@ namespace LeagueSandbox.GameServer.API
         /// <returns>New particle instance.</returns>
         public static IParticle AddParticle(IGameObject caster, IGameObject bindObj, string particle, Vector2 position, float lifetime = 1.0f, float size = 1.0f, string bone = "", string targetBone = "", Vector3 direction = new Vector3(), bool followGroundTilt = false, TeamId teamOnly = TeamId.TEAM_NEUTRAL, IGameObject unitOnly = null, FXFlags flags = FXFlags.BindDirection)
         {
-            var p = new Particle(_game, caster, bindObj, position, particle, size, bone, targetBone, 0, direction, followGroundTilt, lifetime, teamOnly, unitOnly, flags);
-            return p;
+            return new Particle(_game, caster, bindObj, position, particle, size, bone, targetBone, 0, direction, followGroundTilt, lifetime, teamOnly, unitOnly, flags);
         }
 
         /// <summary>

--- a/GameServerLib/Chatbox/Commands/ClearSlowsCommand.cs
+++ b/GameServerLib/Chatbox/Commands/ClearSlowsCommand.cs
@@ -17,7 +17,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
 
         public override void Execute(int userId, bool hasReceivedArguments, string arguments = "")
         {
-            _playerManager.GetPeerInfo(userId).Champion.ClearSlows();
+            _playerManager.GetPeerInfo(userId).Champion.Stats.ClearSlows();
             ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "Your slows have been cleared!");
         }
     }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -329,14 +329,14 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 Stats.Experience = expMap[Stats.Level - 1];
             }
 
-            if (stats.Level < _game.Map.MapScript.MapScriptMetadata.MaxLevel && (stats.Level < 1 || (stats.Experience >= expMap[stats.Level - 1]))) //The - 1s is there because the XP files don't have level 1
+            if (stats.Level < _game.Map.MapScript.MapScriptMetadata.MaxLevel && (stats.Level < 1 || (stats.Experience >= expMap[stats.Level - 1])))
             {
-                _logger.Debug("Champion " + Model + " leveled up to " + stats.Level);
                 if (stats.Level <= 18)
                 {
                     SkillPoints++;
                 }
                 base.LevelUp(force);
+                _logger.Debug("Champion " + Model + " leveled up to " + stats.Level);
 
                 return true;
             }

--- a/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -269,7 +269,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 Attacker = this,
                 Target = target,
                 Damage = damage,
-                PostMitigationdDamage = target.Stats.GetPostMitigationDamage(damage, DamageType.DAMAGE_TYPE_PHYSICAL, this),
+                PostMitigationDamage = target.Stats.GetPostMitigationDamage(damage, DamageType.DAMAGE_TYPE_PHYSICAL, this),
                 DamageSource = DamageSource.DAMAGE_SOURCE_ATTACK,
                 DamageType = DamageType.DAMAGE_TYPE_PHYSICAL,
             };

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -481,7 +481,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 Attacker = attacker,
                 Target = this,
                 Damage = damage,
-                PostMitigationdDamage = Stats.GetPostMitigationDamage(damage, type, attacker),
+                PostMitigationDamage = Stats.GetPostMitigationDamage(damage, type, attacker),
                 DamageSource = source,
                 DamageType = type,
                 DamageResultType = damageText
@@ -531,7 +531,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             var attackerStats = damageData.Attacker.Stats;
             var type = damageData.DamageType;
             var source = damageData.DamageSource;
-            var postMitigationDamage = damageData.PostMitigationdDamage;
+            var postMitigationDamage = damageData.PostMitigationDamage;
 
 
             ApiEventManager.OnPreTakeDamage.Publish(damageData.Target, damageData);

--- a/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -16,6 +16,7 @@ using LeagueSandbox.GameServer.Logging;
 using log4net;
 using GameServerCore.Scripting.CSharp;
 using PacketDefinitions420;
+using LeagueSandbox.GameServer.GameObjects.Stats;
 
 namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 {
@@ -80,14 +81,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// TODO: Verify if we can remove this in favor of BuffSlots while keeping the functions which allow for easy accessing of individual buff instances.
         private List<IBuff> BuffList { get; }
         /// <summary>
-        /// List of all slows applied to this unit
-        /// </summary>
-        private List<float> _slows = new List<float>();
-        /// <summary>
-        /// The true movement speed of an unit, after mitigation and softcaps
-        /// </summary>
-        private float _trueMoveSpeed;
-        /// <summary>
         /// Waypoints that make up the path a game object is walking in.
         /// </summary>
         public List<Vector2> Waypoints { get; protected set; }
@@ -99,7 +92,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         {
             get { return Waypoints[CurrentWaypointKey]; }
         }
-        
+
         /// <summary>
         /// Status effects enabled on this unit. Refer to StatusFlags enum.
         /// </summary>
@@ -150,8 +143,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             Waypoints = new List<Vector2> { Position };
             CurrentWaypointKey = 1;
             SetStatus(
-                StatusFlags.CanAttack | StatusFlags.CanCast     |
-                StatusFlags.CanMove   | StatusFlags.CanMoveEver |
+                StatusFlags.CanAttack | StatusFlags.CanCast |
+                StatusFlags.CanMove | StatusFlags.CanMoveEver |
                 StatusFlags.Targetable, true
             );
             MovementParameters = null;
@@ -162,7 +155,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             ParentBuffs = new Dictionary<string, IBuff>();
             BuffList = new List<IBuff>();
             IconInfo = new IconInfo(_game, this);
-            CalculateTrueMoveSpeed();
         }
 
         /// <summary>
@@ -246,11 +238,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             if (CanMove())
             {
                 float remainingFrameTime = diff;
-                if(MovementParameters != null)
+                if (MovementParameters != null)
                 {
                     remainingFrameTime = DashMove(diff);
                 }
-                if(MovementParameters == null)
+                if (MovementParameters == null)
                 {
                     Move(remainingFrameTime);
                 }
@@ -455,14 +447,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// <param name="statModifier">Modifier to add.</param>
         public void AddStatModifier(IStatsModifier statModifier)
         {
-            if (statModifier.MoveSpeed.PercentBonus < 0)
-            {
-                _slows.Add(statModifier.MoveSpeed.PercentBonus);
-                statModifier.MoveSpeed.PercentBonus = 0;
-            }
-
             Stats.AddModifier(statModifier);
-            CalculateTrueMoveSpeed();
         }
 
         /// <summary>
@@ -471,14 +456,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// <param name="statModifier">Stat modifier instance to remove.</param>
         public void RemoveStatModifier(IStatsModifier statModifier)
         {
-            if (statModifier.MoveSpeed.PercentBonus < 0)
-            {
-                _slows.Remove(statModifier.MoveSpeed.PercentBonus);
-                statModifier.MoveSpeed.PercentBonus = 0;
-            }
-
             Stats.RemoveModifier(statModifier);
-            CalculateTrueMoveSpeed();
         }
 
         public virtual void TakeHeal(IAttackableUnit caster, float amount, IEventSource sourceScript = null)
@@ -496,6 +474,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// <param name="damageText">Type of damage the damage text should be.</param>
         public void TakeDamage(IAttackableUnit attacker, float damage, DamageType type, DamageSource source, DamageResultType damageText, IEventSource sourceScript = null)
         {
+            //TODO: Make all TakeDamage functions return DamageData
             IDamageData damageData = new DamageData
             {
                 IsAutoAttack = source == DamageSource.DAMAGE_SOURCE_ATTACK,
@@ -505,6 +484,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 PostMitigationdDamage = Stats.GetPostMitigationDamage(damage, type, attacker),
                 DamageSource = source,
                 DamageType = type,
+                DamageResultType = damageText
             };
             this.TakeDamage(damageData, damageText, sourceScript);
         }
@@ -552,6 +532,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             var type = damageData.DamageType;
             var source = damageData.DamageSource;
             var postMitigationDamage = damageData.PostMitigationdDamage;
+
 
             ApiEventManager.OnPreTakeDamage.Publish(damageData.Target, damageData);
 
@@ -611,28 +592,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 };
             }
 
-            int attackerId = 0, targetId = 0;
-
-            // todo: check if damage dealt by disconnected players cause anything bad
-            if (attacker is IChampion attackerChamp)
-            {
-                attackerId = _game.PlayerManager.GetClientInfoByChampion(attackerChamp).ClientId;
-            }
-
-            if (this is IChampion targetChamp)
-            {
-                targetId = _game.PlayerManager.GetClientInfoByChampion(targetChamp).ClientId;
-            }
-            // Show damage text for owner of pet
-            if (attacker is IPet attackerPet && attackerPet.Owner is IChampion)
-            {
-                attackerId = _game.PlayerManager.GetClientInfoByChampion((IChampion)attackerPet.Owner).ClientId;
-            }
-
             if (attacker.Team != Team)
             {
-                _game.PacketNotifier.NotifyUnitApplyDamage(attacker, this, postMitigationDamage, type, damageText,
-                    _game.Config.IsDamageTextGlobal, attackerId, targetId);
+                _game.PacketNotifier.NotifyUnitApplyDamage(damageData, _game.Config.IsDamageTextGlobal);
             }
 
             // Get health from lifesteal/spellvamp
@@ -730,48 +692,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 return MovementParameters.PathSpeedOverride;
             }
 
-            return GetTrueMoveSpeed();
-        }
-
-        /// <summary>
-        /// Processes the unit's move speed
-        /// </summary>
-        public void CalculateTrueMoveSpeed()
-        {
-            float speed = Stats.MoveSpeed.BaseValue + Stats.MoveSpeed.FlatBonus;
-            if (speed > 490.0f)
-            {
-                speed = speed * 0.5f + 230.0f;
-            }
-            else if (speed >= 415.0f)
-            {
-                speed = speed * 0.8f + 83.0f;
-            }
-            else if (speed < 220.0f)
-            {
-                speed = speed * 0.5f + 110.0f;
-            }
-
-            speed = speed * (1 + Stats.MoveSpeed.PercentBonus) * (1 + Stats.MultiplicativeSpeedBonus);
-
-            if (_slows.Count > 0)
-            {
-                //Only takes into account the highest slow
-                speed *= 1 + _slows.Max(z => z) * (1 - Stats.SlowResistPercent);
-            }
-
-            _trueMoveSpeed = speed;
-        }
-
-        public float GetTrueMoveSpeed()
-        {
-            return _trueMoveSpeed;
-        }
-
-        public void ClearSlows()
-        {
-            _slows.Clear();
-            CalculateTrueMoveSpeed();
+            return Stats.GetTrueMoveSpeed();
         }
 
         /// <summary>
@@ -800,7 +721,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 
             UpdateActionState();
         }
-    
+
         void UpdateActionState()
         {
             // CallForHelpSuppressor
@@ -810,12 +731,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             Stats.SetActionState(ActionState.CAN_NOT_MOVE, !Status.HasFlag(StatusFlags.CanMoveEver));
             Stats.SetActionState(ActionState.CHARMED, Status.HasFlag(StatusFlags.Charmed));
             // DisableAmbientGold
-            
+
             bool feared = Status.HasFlag(StatusFlags.Feared);
             Stats.SetActionState(ActionState.FEARED, feared);
             // TODO: Verify
             Stats.SetActionState(ActionState.IS_FLEEING, feared);
-            
+
             Stats.SetActionState(ActionState.FORCE_RENDER_PARTICLES, Status.HasFlag(StatusFlags.ForceRenderParticles));
             // GhostProof
             Stats.SetActionState(ActionState.IS_GHOSTED, Status.HasFlag(StatusFlags.Ghosted));
@@ -859,7 +780,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             );
 
             Stats.SetActionState(
-                ActionState.CAN_NOT_ATTACK, 
+                ActionState.CAN_NOT_ATTACK,
                 !Status.HasFlag(StatusFlags.CanAttack)
                 || Status.HasFlag(StatusFlags.Charmed)
                 || Status.HasFlag(StatusFlags.Disarmed)
@@ -871,7 +792,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                 || Status.HasFlag(StatusFlags.Suppressed)
             );
         }
-        
+
         void UpdateBuffs(float diff)
         {
             // Combine the status effects of all the buffs
@@ -941,21 +862,21 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             float distToDest;
             float distRemaining = float.PositiveInfinity;
             float timeRemaining = float.PositiveInfinity;
-            if(MP.FollowNetID > 0)
+            if (MP.FollowNetID > 0)
             {
                 IGameObject unitToFollow = _game.ObjectManager.GetObjectById(MP.FollowNetID);
-                if(unitToFollow == null)
+                if (unitToFollow == null)
                 {
                     SetDashingState(false, MoveStopReason.LostTarget);
                     return frameTime;
                 }
                 dir = unitToFollow.Position - Position;
                 distToDest = dir.Length() - (PathfindingRadius + unitToFollow.PathfindingRadius);
-                if(MP.FollowDistance > 0)
+                if (MP.FollowDistance > 0)
                 {
                     distRemaining = MP.FollowDistance - MP.PassedDistance;
                 }
-                if(MP.FollowTravelTime > 0)
+                if (MP.FollowTravelTime > 0)
                 {
                     timeRemaining = MP.FollowTravelTime - MP.ElapsedTime;
                 }
@@ -973,19 +894,19 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             float dist = Math.Min(distPerFrame, distRemaining);
             Position += Vector2.Normalize(dir) * dist;
 
-            if(distRemaining <= distPerFrame)
+            if (distRemaining <= distPerFrame)
             {
                 SetDashingState(false);
                 return (distPerFrame - distRemaining) / speed;
             }
-            if(timeRemaining <= frameTime)
+            if (timeRemaining <= frameTime)
             {
                 SetDashingState(false);
                 return frameTime - timeRemaining;
             }
             MP.PassedDistance += dist;
             MP.ElapsedTime += time;
-            
+
             return 0;
         }
 
@@ -996,17 +917,17 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// TODO: Implement interpolation (assuming all other desync related issues are already fixed).
         public virtual bool Move(float delta)
         {
-            if(CurrentWaypointKey < Waypoints.Count)
+            if (CurrentWaypointKey < Waypoints.Count)
             {
                 float speed = GetMoveSpeed() * 0.001f;
                 var maxDist = speed * delta;
 
-                while(true)
+                while (true)
                 {
                     var dir = CurrentWaypoint - Position;
                     var dist = dir.Length();
 
-                    if(maxDist < dist)
+                    if (maxDist < dist)
                     {
                         Position += dir / dist * maxDist;
                         return true;
@@ -1017,7 +938,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
                         maxDist -= dist;
 
                         CurrentWaypointKey++;
-                        if(CurrentWaypointKey == Waypoints.Count || maxDist == 0)
+                        if (CurrentWaypointKey == Waypoints.Count || maxDist == 0)
                         {
                             return true;
                         }
@@ -1537,7 +1458,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         {
             foreach (IBuff b in BuffList)
             {
-                if(b.IsBuffSame(buffName))
+                if (b.IsBuffSame(buffName))
                 {
                     b.DeactivateBuff();
                 }
@@ -1607,7 +1528,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public virtual void SetDashingState(bool state, MoveStopReason reason = MoveStopReason.Finished)
         {
             _dashEffectsToDisable = 0;
-            if(state)
+            if (state)
             {
                 _dashEffectsToDisable = MovementParameters.SetStatus;
             }

--- a/GameServerLib/GameObjects/AttackableUnits/DamageData.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/DamageData.cs
@@ -11,7 +11,7 @@ namespace GameServerLib.GameObjects.AttackableUnits
         /// </summary>
         public IAttackableUnit Attacker { get; set; }
         /// <summary>
-        /// The raw ammount of damage to be inflicted (Pre-mitigated damage)
+        /// The raw amount of damage to be inflicted (Pre-mitigated damage)
         /// </summary>
         public float Damage { get; set; }
         /// <summary>
@@ -27,13 +27,13 @@ namespace GameServerLib.GameObjects.AttackableUnits
         /// </summary>
         public DamageType DamageType { get; set; }
         /// <summary>
-        /// Wheter or not the damage came from an auttoatack or a Spell
+        /// Whether or not the damage came from an autoatack or a Spell
         /// </summary>
         public bool IsAutoAttack { get; set; }
         /// <summary>
-        /// Mitigated ammount of damage (after being reduced by Armor/MR stats) 
+        /// Mitigated amount of damage (after being reduced by Armor/MR stats) 
         /// </summary>
-        public float PostMitigationdDamage { get; set; }
+        public float PostMitigationDamage { get; set; }
         /// <summary>
         /// Unit that will receive the damage.
         /// </summary>

--- a/GameServerLib/GameObjects/AttackableUnits/DamageData.cs
+++ b/GameServerLib/GameObjects/AttackableUnits/DamageData.cs
@@ -7,32 +7,36 @@ namespace GameServerLib.GameObjects.AttackableUnits
     class DamageData : IDamageData
     {
         /// <summary>
-        /// Wheter or not the damage came from an auttoatack or a Spell
-        /// </summary>
-        public bool IsAutoAttack { get; set; }
-        /// <summary>
-        /// Unit that received the damage.
-        /// </summary>
-        public IAttackableUnit Target { get; set; }
-        /// <summary>
         /// Unit that inflicted the damage.
         /// </summary>
         public IAttackableUnit Attacker { get; set; }
-        /// <summary>
-        /// Type of damage received.
-        /// </summary>
-        public DamageType DamageType { get; set; }
-        /// <summary>
-        /// Source of the damage.
-        /// </summary>
-        public DamageSource DamageSource { get; set; }
         /// <summary>
         /// The raw ammount of damage to be inflicted (Pre-mitigated damage)
         /// </summary>
         public float Damage { get; set; }
         /// <summary>
-        /// Mitigated ammount of damage (after being reduced by armor/MR stats) 
+        /// The result of this damage (Ex. Dodged, Missed, Invulnerable or Crit)
+        /// </summary>
+        public DamageResultType DamageResultType { get; set; } = DamageResultType.RESULT_NORMAL;
+        /// <summary>
+        /// Source of the damage.
+        /// </summary>
+        public DamageSource DamageSource { get; set; }
+        /// <summary>
+        /// Type of damage received.
+        /// </summary>
+        public DamageType DamageType { get; set; }
+        /// <summary>
+        /// Wheter or not the damage came from an auttoatack or a Spell
+        /// </summary>
+        public bool IsAutoAttack { get; set; }
+        /// <summary>
+        /// Mitigated ammount of damage (after being reduced by Armor/MR stats) 
         /// </summary>
         public float PostMitigationdDamage { get; set; }
+        /// <summary>
+        /// Unit that will receive the damage.
+        /// </summary>
+        public IAttackableUnit Target { get; set; }
     }
 }

--- a/GameServerLib/GameObjects/Stats/Replication/ReplicationAiTurret.cs
+++ b/GameServerLib/GameObjects/Stats/Replication/ReplicationAiTurret.cs
@@ -30,7 +30,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             UpdateFloat(Stats.HealthPoints.Total, 3, 1); //mMaxHP
             // UpdateFloat(Stats.PerceptionRange.FlatBonus, 3, 2); //mFlatBubbleRadiusMod
             // UpdateFloat(Stats.PerceptionRange.PercentBonus, 3, 3); //mPercentBubbleRadiusMod
-            UpdateFloat(Owner.GetTrueMoveSpeed(), 3, 4); //mMoveSpeed
+            UpdateFloat(Stats.GetTrueMoveSpeed(), 3, 4); //mMoveSpeed
             UpdateFloat(Stats.Size.Total, 3, 5); //mSkinScaleCoef(mistyped as mCrit)
             UpdateBool(Stats.IsTargetable, 5, 0); //mIsTargetable
             UpdateUint((uint)Stats.IsTargetableToTeam, 5, 1); //mIsTargetableToTeamFlags

--- a/GameServerLib/GameObjects/Stats/Replication/ReplicationHero.cs
+++ b/GameServerLib/GameObjects/Stats/Replication/ReplicationHero.cs
@@ -71,7 +71,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             // UpdateFloat(Stats.LifeTimeTicks, 3, 7); //mLifetimeTicks
             // UpdateFloat(Stats.PerceptionRange.FlatMod, 3, 8); //mFlatBubbleRadiusMod
             // UpdateFloat(Stats.PerceptionRange.PercentMod, 3, 9); //mPercentBubbleRadiusMod
-            UpdateFloat(Owner.GetTrueMoveSpeed(), 3, 10); //mMoveSpeed
+            UpdateFloat(Stats.GetTrueMoveSpeed(), 3, 10); //mMoveSpeed
             UpdateFloat(Stats.Size.Total, 3, 11); //mSkinScaleCoef(mistyped as mCrit)
             // UpdateFloat(Stats.FlatPathfindingRadiusMod, 3, 12); //mPathfindingRadiusMod
             UpdateUint(Stats.Level, 3, 13); //mLevelRef

--- a/GameServerLib/GameObjects/Stats/Replication/ReplicationLaneMinion.cs
+++ b/GameServerLib/GameObjects/Stats/Replication/ReplicationLaneMinion.cs
@@ -35,7 +35,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             UpdateFloat(Stats.MagicResist.PercentBonus, 1, 22); //mPercentMagicReduction
             // UpdateFloat(Stats.PerceptionRange.FlatBonus, 3, 0); //mFlatBubbleRadiusMod
             // UpdateFloat(Stats.PerceptionRange.PercentBonus, 3, 1); //mPercentBubbleRadiusMod
-            UpdateFloat(Owner.GetTrueMoveSpeed(), 3, 2); //mMoveSpeed
+            UpdateFloat(Stats.GetTrueMoveSpeed(), 3, 2); //mMoveSpeed
             UpdateFloat(Stats.Size.Total, 3, 3); //mSkinScaleCoef(mistyped as mCrit)
             UpdateBool(Stats.IsTargetable, 3, 4); //mIsTargetable
             UpdateUint((uint)Stats.IsTargetableToTeam, 3, 5); //mIsTargetableToTeamFlags

--- a/GameServerLib/GameObjects/Stats/Replication/ReplicationMinion.cs
+++ b/GameServerLib/GameObjects/Stats/Replication/ReplicationMinion.cs
@@ -35,7 +35,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             UpdateFloat(Stats.MagicResist.PercentBonus, 1, 22); //mPercentMagicReduction
             // UpdateFloat(Stats.PerceptionRange.FlatBonus, 3, 0); //mFlatBubbleRadiusMod
             // UpdateFloat(Stats.PerceptionRange.PercentBonus, 3, 1); //mPercentBubbleRadiusMod
-            UpdateFloat(Owner.GetTrueMoveSpeed(), 3, 2); //mMoveSpeed
+            UpdateFloat(Stats.GetTrueMoveSpeed(), 3, 2); //mMoveSpeed
             UpdateFloat(Stats.Size.Total, 3, 3); //mSkinScaleCoef(mistyped as mCrit)
             UpdateBool(Stats.IsTargetable, 3, 4); //mIsTargetable
             UpdateUint((uint)Stats.IsTargetableToTeam, 3, 5); //mIsTargetableToTeamFlags

--- a/GameServerLib/GameObjects/Stats/Stats.cs
+++ b/GameServerLib/GameObjects/Stats/Stats.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using GameServerCore.Domain;
 using GameServerCore.Domain.GameObjects;
 using GameServerCore.Enums;
@@ -62,7 +64,9 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
         public float Points { get; set; }
         public float SlowResistPercent { get; set; }
         public float MultiplicativeSpeedBonus { get; set; }
+        private List<float> _slows = new List<float>();
         private float _currentHealth;
+        private float _trueMoveSpeed;
         public float CurrentHealth
         {
             get => Math.Min(HealthPoints.Total, _currentHealth);
@@ -140,6 +144,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             MoveSpeed.BaseValue = charData.MoveSpeed;
             ParType = charData.ParType;
             Range.BaseValue = charData.AttackRange;
+            CalculateTrueMoveSpeed();
         }
 
         public void AddModifier(IStatsModifier modifier)
@@ -161,7 +166,17 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             MagicPenetration.ApplyStatModifier(modifier.MagicPenetration);
             ManaPoints.ApplyStatModifier(modifier.ManaPoints);
             ManaRegeneration.ApplyStatModifier(modifier.ManaRegeneration);
-            MoveSpeed.ApplyStatModifier(modifier.MoveSpeed);
+            
+            if (modifier.MoveSpeed.PercentBonus < 0)
+            {
+                _slows.Add(modifier.MoveSpeed.PercentBonus);
+            }
+            else
+            {
+                MoveSpeed.ApplyStatModifier(modifier.MoveSpeed);
+            }
+            CalculateTrueMoveSpeed();
+
             Range.ApplyStatModifier(modifier.Range);
             Size.ApplyStatModifier(modifier.Size);
             SpellVamp.ApplyStatModifier(modifier.SpellVamp);
@@ -188,7 +203,17 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             MagicPenetration.RemoveStatModifier(modifier.MagicPenetration);
             ManaPoints.RemoveStatModifier(modifier.ManaPoints);
             ManaRegeneration.RemoveStatModifier(modifier.ManaRegeneration);
-            MoveSpeed.RemoveStatModifier(modifier.MoveSpeed);
+            
+            if (modifier.MoveSpeed.PercentBonus < 0)
+            {
+                _slows.Remove(modifier.MoveSpeed.PercentBonus);
+            }
+            else
+            {
+                MoveSpeed.RemoveStatModifier(modifier.MoveSpeed);
+            }
+            CalculateTrueMoveSpeed();
+
             Range.RemoveStatModifier(modifier.Range);
             Size.RemoveStatModifier(modifier.Size);
             SpellVamp.RemoveStatModifier(modifier.SpellVamp);
@@ -200,6 +225,17 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
         public float GetTotalAttackSpeed()
         {
             return AttackSpeedFlat * AttackSpeedMultiplier.Total;
+        }
+
+        public float GetTrueMoveSpeed()
+        {
+            return _trueMoveSpeed;
+        }
+
+        public void ClearSlows()
+        {
+            _slows.Clear();
+            CalculateTrueMoveSpeed();
         }
 
         public void Update(float diff)
@@ -227,23 +263,27 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
         public void LevelUp()
         {
             Level++;
-
-            StatsModifier statsLevelUp = new StatsModifier();
-            statsLevelUp.HealthPoints.BaseValue = HealthPerLevel;
-            statsLevelUp.ManaPoints.BaseValue = ManaPerLevel;
-            statsLevelUp.AttackDamage.BaseValue = AttackDamagePerLevel.Total;
-            statsLevelUp.Armor.BaseValue = ArmorPerLevel;
-            statsLevelUp.MagicResist.BaseValue = MagicResistPerLevel;
-            statsLevelUp.HealthRegeneration.BaseValue = HealthRegenerationPerLevel;
-            statsLevelUp.ManaRegeneration.BaseValue = ManaRegenerationPerLevel;
-            if (Level > 1)
+            if(Level > 1)
             {
-                statsLevelUp.AttackSpeed.PercentBaseBonus = GrowthAttackSpeed / 100.0f;
-            }
-            AddModifier(statsLevelUp);
+                StatsModifier statsLevelUp = new StatsModifier();
+                statsLevelUp.HealthPoints.BaseValue = HealthPerLevel;
+                statsLevelUp.ManaPoints.BaseValue = ManaPerLevel;
+                statsLevelUp.AttackDamage.BaseValue = AttackDamagePerLevel.BaseValue;
+                statsLevelUp.AttackDamage.FlatBonus= AttackDamagePerLevel.FlatBonus;
+                statsLevelUp.Armor.BaseValue = ArmorPerLevel;
+                statsLevelUp.MagicResist.BaseValue = MagicResistPerLevel;
+                statsLevelUp.HealthRegeneration.BaseValue = HealthRegenerationPerLevel;
+                statsLevelUp.ManaRegeneration.BaseValue = ManaRegenerationPerLevel;
+                if (Level > 1)
+                {
+                    statsLevelUp.AttackSpeed.PercentBaseBonus = GrowthAttackSpeed / 100.0f;
+                }
+                AddModifier(statsLevelUp);
 
-            CurrentHealth = HealthPoints.Total / (HealthPoints.Total - HealthPerLevel) * CurrentHealth;
-            CurrentMana = ManaPoints.Total / (ManaPoints.Total - ManaPerLevel) * CurrentMana;
+                //Check if these are correct
+                CurrentHealth = HealthPoints.Total / (HealthPoints.Total - HealthPerLevel) * CurrentHealth;
+                CurrentMana = ManaPoints.Total / (ManaPoints.Total - ManaPerLevel) * CurrentMana;
+            }
         }
 
         public bool GetSpellEnabled(byte id)
@@ -287,31 +327,35 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
 
         public float GetPostMitigationDamage(float damage, DamageType type, IAttackableUnit attacker)
         {
-            float defense = 0;
+            if (damage <= 0f)
+            {
+                return 0.0f;
+            }
+
+            float stat = 0;
             switch (type)
             {
                 case DamageType.DAMAGE_TYPE_PHYSICAL:
-                    defense = Armor.Total;
-                    defense = (1 - attacker.Stats.ArmorPenetration.PercentBonus) * defense -
-                              attacker.Stats.ArmorPenetration.FlatBonus;
-
+                    stat = Armor.Total;
                     break;
                 case DamageType.DAMAGE_TYPE_MAGICAL:
-                    defense = MagicResist.Total;
-                    defense = (1 - attacker.Stats.MagicPenetration.PercentBonus) * defense -
-                              attacker.Stats.MagicPenetration.FlatBonus;
+                    stat = MagicResist.Total;
                     break;
                 case DamageType.DAMAGE_TYPE_TRUE:
-                    break;
+                    return damage;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);
             }
-            if (damage < 0f)
+
+            float mitigationPercent = 100 / (100 + stat);
+            
+            if (stat < 0)
             {
-                damage = 0f;
+                Console.WriteLine("Mitigation: " + mitigationPercent);
+                mitigationPercent = 2 - mitigationPercent;
             }
-            damage = defense >= 0 ? 100 / (100 + defense) * damage : (2 - 100 / (100 - defense)) * damage;
-            return damage;
+
+            return damage * mitigationPercent;
         }
 
         public void SetActionState(ActionState state, bool enabled)
@@ -324,6 +368,33 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             {
                 ActionState &= ~state;
             }
+        }
+
+        public void CalculateTrueMoveSpeed()
+        {
+            float speed = MoveSpeed.BaseValue + MoveSpeed.FlatBonus;
+            if (speed > 490.0f)
+            {
+                speed = speed * 0.5f + 230.0f;
+            }
+            else if (speed >= 415.0f)
+            {
+                speed = speed * 0.8f + 83.0f;
+            }
+            else if (speed < 220.0f)
+            {
+                speed = speed * 0.5f + 110.0f;
+            }
+
+            speed = speed * (1 + MoveSpeed.PercentBonus) * (1 + MultiplicativeSpeedBonus);
+
+            if (_slows.Count > 0)
+            {
+                //Only takes into account the highest slow
+                speed *= 1 + _slows.Max(z => z) * (1 - SlowResistPercent);
+            }
+
+            _trueMoveSpeed = speed;
         }
     }
 }

--- a/GameServerLib/GameObjects/Stats/Stats.cs
+++ b/GameServerLib/GameObjects/Stats/Stats.cs
@@ -351,7 +351,6 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
             
             if (stat < 0)
             {
-                Console.WriteLine("Mitigation: " + mitigationPercent);
                 mitigationPercent = 2 - mitigationPercent;
             }
 

--- a/GameServerLib/GameObjects/Stats/Stats.cs
+++ b/GameServerLib/GameObjects/Stats/Stats.cs
@@ -332,7 +332,7 @@ namespace LeagueSandbox.GameServer.GameObjects.Stats
                 return 0.0f;
             }
 
-            float stat = 0;
+            float stat;
             switch (type)
             {
                 case DamageType.DAMAGE_TYPE_PHYSICAL:

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3904,24 +3904,20 @@ namespace PacketDefinitions420
         /// <summary>
         /// Sends a packet to optionally all players (given isGlobal), a specified user that is the source of damage, or a specified user that is receiving the damage. The packet details an instance of damage being applied to a unit by another unit.
         /// </summary>
-        /// <param name="source">Unit which caused the damage.</param>
-        /// <param name="target">Unit which is taking the damage.</param>
-        /// <param name="amount">Amount of damage dealt to the target (usually the end result of all damage calculations).</param>
-        /// <param name="type">Type of damage being dealt; PHYSICAL/MAGICAL/TRUE</param>
-        /// <param name="damagetext">Type of text to show above the target; INVULNERABLE/DODGE/CRIT/NORMAL/MISS</param>
         /// <param name="isGlobal">Whether or not the packet should be sent to all players.</param>
         /// <param name="sourceId">ID of the user who dealt the damage that should receive the packet.</param>
         /// <param name="targetId">ID of the user who is taking the damage that should receive the packet.</param>
-        public void NotifyUnitApplyDamage(IAttackableUnit source, IAttackableUnit target, float amount, DamageType type, DamageResultType damagetext, bool isGlobal = true, int sourceId = -1, int targetId = -1)
+        public void NotifyUnitApplyDamage(IDamageData damageData, bool isGlobal = true)
         {
             var damagePacket = new UnitApplyDamage
             {
-                SenderNetID = target.NetId,
-                DamageResultType = (byte)damagetext,
-                DamageType = (byte)type,
-                TargetNetID = target.NetId,
-                SourceNetID = source.NetId,
-                Damage = amount
+                DamageResultType = (byte)damageData.DamageResultType,
+                DamageType = (byte)damageData.DamageType,
+                TargetNetID = damageData.Target.NetId,
+                SourceNetID = damageData.Attacker.NetId,
+                Damage = damageData.PostMitigationdDamage,
+                //Sender isn't always the unit itself, sometimes missiles
+                SenderNetID = damageData.Target.NetId
             };
 
             if (isGlobal)
@@ -3930,13 +3926,19 @@ namespace PacketDefinitions420
             }
             else
             {
-                if (sourceId >= 0)
+                // todo: check if damage dealt by disconnected players cause anything bad
+                if (damageData.Attacker is IChampion attackerChamp)
                 {
-                    _packetHandlerManager.SendPacket(sourceId, damagePacket.GetBytes(), Channel.CHL_S2C);
+                    _packetHandlerManager.SendPacket(attackerChamp.ClientId, damagePacket.GetBytes(), Channel.CHL_S2C);
                 }
-                if (targetId >= 0)
+                else if (damageData.Attacker is IPet pet && pet.Owner is IChampion ch)
                 {
-                    _packetHandlerManager.SendPacket(targetId, damagePacket.GetBytes(), Channel.CHL_S2C);
+                    _packetHandlerManager.SendPacket(ch.ClientId, damagePacket.GetBytes(), Channel.CHL_S2C);
+                }
+
+                if (damageData.Target is IChampion targetChamp)
+                {
+                    _packetHandlerManager.SendPacket(targetChamp.ClientId, damagePacket.GetBytes(), Channel.CHL_S2C);
                 }
             }
         }

--- a/PacketDefinitions420/PacketNotifier.cs
+++ b/PacketDefinitions420/PacketNotifier.cs
@@ -3915,7 +3915,7 @@ namespace PacketDefinitions420
                 DamageType = (byte)damageData.DamageType,
                 TargetNetID = damageData.Target.NetId,
                 SourceNetID = damageData.Attacker.NetId,
-                Damage = damageData.PostMitigationdDamage,
+                Damage = damageData.PostMitigationDamage,
                 //Sender isn't always the unit itself, sometimes missiles
                 SenderNetID = damageData.Target.NetId
             };


### PR DESCRIPTION
* Stats
    - Moved all movespeed-related functions and variable from `AttackableUnit` to `Stats`
    - Fixed Slows not being removed since the `Statsmodifier` variable would have the MoveSpeed.PercentBonus changed to 0 right after being applied.
    - Fixed the AD stats shown in the HUD, now it should properly match the player's AD #1147
    - Reworked a bit the `GetPostMitigationDamage` function.

* Damage
    - Reorganized `DamageData` in alphabetical order and introduced ` `DamageResultType`.
    - `NotifyUnitApplyDamage` now takes `DamageData` as argument instead of a bunch of variables.
    - Fixed an issue where sometimes the player would have `NotifyUnitApplyDamage` notified to them twice, resulting in the damage particle displaying double the damage it was supposed to be.

* Scripts
    - Fixed a few Talent scripts