### PR TITLE
Deprecation `TranslationMaxGridPosition` and cell centering

### DIFF
--- a/GameServerLib/Content/Navigation/NavigationGrid.cs
+++ b/GameServerLib/Content/Navigation/NavigationGrid.cs
@@ -107,68 +107,68 @@ namespace LeagueSandbox.GameServer.Content.Navigation
                     throw new Exception(string.Format("Unsupported Navigation Grid Version: {0}.{1}", major, minor));
                 }
 
-                this.MinGridPosition = br.ReadVector3();
-                this.MaxGridPosition = br.ReadVector3();
+                MinGridPosition = br.ReadVector3();
+                MaxGridPosition = br.ReadVector3();
 
-                this.CellSize = br.ReadSingle();
-                this.CellCountX = br.ReadUInt32();
-                this.CellCountY = br.ReadUInt32();
+                CellSize = br.ReadSingle();
+                CellCountX = br.ReadUInt32();
+                CellCountY = br.ReadUInt32();
 
-                this.Cells = new NavigationGridCell[this.CellCountX * this.CellCountY];
-                this.RegionTags = new uint[this.CellCountX * this.CellCountY];
+                Cells = new NavigationGridCell[CellCountX * CellCountY];
+                RegionTags = new uint[CellCountX * CellCountY];
 
                 if (major == 2 || major == 3 || major == 5)
                 {
-                    for (int i = 0; i < this.Cells.Length; i++)
+                    for (int i = 0; i < Cells.Length; i++)
                     {
-                        this.Cells[i] = NavigationGridCell.ReadVersion5(br, i);
+                        Cells[i] = NavigationGridCell.ReadVersion5(br, i);
                     }
 
                     if (major == 5)
                     {
-                        for (int i = 0; i < this.RegionTags.Length; i++)
+                        for (int i = 0; i < RegionTags.Length; i++)
                         {
-                            this.RegionTags[i] = br.ReadUInt16();
+                            RegionTags[i] = br.ReadUInt16();
                         }
                     }
                 }
                 else if (major == 7)
                 {
-                    for (int i = 0; i < this.Cells.Length; i++)
+                    for (int i = 0; i < Cells.Length; i++)
                     {
-                        this.Cells[i] = NavigationGridCell.ReadVersion7(br, i);
+                        Cells[i] = NavigationGridCell.ReadVersion7(br, i);
                     }
-                    for (int i = 0; i < this.Cells.Length; i++)
+                    for (int i = 0; i < Cells.Length; i++)
                     {
-                        this.Cells[i].SetFlags((NavigationGridCellFlags)br.ReadUInt16());
+                        Cells[i].SetFlags((NavigationGridCellFlags)br.ReadUInt16());
                     }
 
-                    for (int i = 0; i < this.RegionTags.Length; i++)
+                    for (int i = 0; i < RegionTags.Length; i++)
                     {
-                        this.RegionTags[i] = br.ReadUInt32();
+                        RegionTags[i] = br.ReadUInt32();
                     }
                 }
 
                 if(major >= 5)
                 {
                     uint groupCount = major == 5 ? 4u : 8u;
-                    this.RegionTagTable = new NavigationRegionTagTable(br, groupCount);
+                    RegionTagTable = new NavigationRegionTagTable(br, groupCount);
                 }
 
-                this.SampledHeightsCountX = br.ReadUInt32();
-                this.SampledHeightsCountY = br.ReadUInt32();
-                this.SampledHeightsDistance = br.ReadVector2();
-                this.SampledHeights = new float[this.SampledHeightsCountX * this.SampledHeightsCountY];
-                for (int i = 0; i < this.SampledHeights.Length; i++)
+                SampledHeightsCountX = br.ReadUInt32();
+                SampledHeightsCountY = br.ReadUInt32();
+                SampledHeightsDistance = br.ReadVector2();
+                SampledHeights = new float[SampledHeightsCountX * SampledHeightsCountY];
+                for (int i = 0; i < SampledHeights.Length; i++)
                 {
-                    this.SampledHeights[i] = br.ReadSingle();
+                    SampledHeights[i] = br.ReadSingle();
                 }
 
-                this.HintGrid = new NavigationHintGrid(br);
+                HintGrid = new NavigationHintGrid(br);
 
-                this.MapWidth = this.MaxGridPosition.X + this.MinGridPosition.X;
-                this.MapHeight = this.MaxGridPosition.Z + this.MinGridPosition.Z;
-                this.MiddleOfMap = new Vector2(this.MapWidth / 2, this.MapHeight / 2);
+                MapWidth = MaxGridPosition.X + MinGridPosition.X;
+                MapHeight = MaxGridPosition.Z + MinGridPosition.Z;
+                MiddleOfMap = new Vector2(MapWidth / 2, MapHeight / 2);
             }
         }
 
@@ -324,8 +324,8 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         {
             return new Vector2
             (
-                (vector.X - this.MinGridPosition.X) / this.CellSize,
-                (vector.Y - this.MinGridPosition.Z) / this.CellSize
+                (vector.X - MinGridPosition.X) / CellSize,
+                (vector.Y - MinGridPosition.Z) / CellSize
             );
         }
 
@@ -348,8 +348,8 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         {
             return new Vector2
             (
-                vector.X * this.CellSize + this.MinGridPosition.X,
-                vector.Y * this.CellSize + this.MinGridPosition.Z
+                vector.X * CellSize + MinGridPosition.X,
+                vector.Y * CellSize + MinGridPosition.Z
             );
         }
 
@@ -366,12 +366,12 @@ namespace LeagueSandbox.GameServer.Content.Navigation
 
             if (translate)
             {
-                vector = TranslateToNavGrid(new Vector2 { X = x, Y = z });
+                vector = TranslateToNavGrid(vector);
             }
 
             // TODO: Cleanup all the casting but keep the same method.
-            long index = (short)vector.Y * this.CellCountX + (short)vector.X;
-            if ((short)vector.X < 0 || (short)vector.X > this.CellCountX || (short)vector.Y < 0 || (short)vector.Y > this.CellCountY || index >= this.Cells.Length)
+            long index = (short)vector.Y * CellCountX + (short)vector.X;
+            if ((short)vector.X < 0 || (short)vector.X > CellCountX || (short)vector.Y < 0 || (short)vector.Y > CellCountY || index >= Cells.Length)
             {
                 return -1;
             }
@@ -387,13 +387,12 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         /// <returns>Cell instance.</returns>
         public NavigationGridCell GetCell(short x, short y)
         {
-            long index = y * this.CellCountX + x;
-            if (x < 0 || x > this.CellCountX || y < 0 || y > this.CellCountY || index >= this.Cells.Length)
+            long index = y * CellCountX + x;
+            if (x < 0 || x > CellCountX || y < 0 || y > CellCountY || index >= Cells.Length)
             {
                 return null;
             }
-
-            return this.Cells[index];
+            return Cells[index];
         }
 
         /// <summary>
@@ -588,15 +587,11 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         {
             if (checkRadius == 0)
             {
-                Vector2 vector = new Vector2 { X = coords.X, Y = coords.Y };
-
                 if (translate)
                 {
-                    vector = TranslateToNavGrid(new Vector2 { X = coords.X, Y = coords.Y });
+                    coords = TranslateToNavGrid(coords);
                 }
-
-                NavigationGridCell cell = GetCell((short)vector.X, (short)vector.Y);
-
+                NavigationGridCell cell = GetCell((short)coords.X, (short)coords.Y);
                 return IsWalkable(cell);
             }
 
@@ -637,17 +632,12 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         /// <returns>True/False.</returns>
         public bool IsVisible(Vector2 coords, bool translate = true)
         {
-            Vector2 vector = new Vector2 { X = coords.X, Y = coords.Y };
-
             if (translate)
             {
-                vector = TranslateToNavGrid(new Vector2 { X = coords.X, Y = coords.Y });
+                coords = TranslateToNavGrid(coords);
             }
-
-            NavigationGridCell cell = GetCell((short)vector.X, (short)vector.Y);
-
-            //TODO: implement bush logic here
-            return IsVisible(cell);
+            NavigationGridCell cell = GetCell((short)coords.X, (short)coords.Y);
+            return IsVisible(cell); //TODO: implement bush logic here
         }
 
         bool IsVisible(NavigationGridCell cell)
@@ -666,15 +656,11 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         /// <returns>True/False.</returns>
         public bool HasFlag(Vector2 coords, NavigationGridCellFlags flag, bool translate = true)
         {
-            Vector2 vector = new Vector2 { X = coords.X, Y = coords.Y };
-
             if (translate)
             {
-                vector = TranslateToNavGrid(new Vector2 { X = coords.X, Y = coords.Y });
+                coords = TranslateToNavGrid(coords);
             }
-
-            NavigationGridCell cell = GetCell((short)vector.X, (short)vector.Y);
-
+            NavigationGridCell cell = GetCell((short)coords.X, (short)coords.Y);
             return cell != null && cell.HasFlag(flag);
         }
 
@@ -688,11 +674,11 @@ namespace LeagueSandbox.GameServer.Content.Navigation
             // Uses SampledHeights to get the height of a given location on the Navigation Grid
             // This is the method the game uses to get height data
 
-            if (location.X >= this.MinGridPosition.X && location.Y >= this.MinGridPosition.Z &&
-                location.X <= this.MaxGridPosition.X && location.Y <= this.MaxGridPosition.Z)
+            if (location.X >= MinGridPosition.X && location.Y >= MinGridPosition.Z &&
+                location.X <= MaxGridPosition.X && location.Y <= MaxGridPosition.Z)
             {
-                float reguestedHeightX = (location.X - this.MinGridPosition.X) / this.SampledHeightsDistance.X;
-                float requestedHeightY = (location.Y - this.MinGridPosition.Z) / this.SampledHeightsDistance.Y;
+                float reguestedHeightX = (location.X - MinGridPosition.X) / SampledHeightsDistance.X;
+                float requestedHeightY = (location.Y - MinGridPosition.Z) / SampledHeightsDistance.Y;
 
                 int sampledHeight1IndexX = (int)reguestedHeightX;
                 int sampledHeight1IndexY = (int)requestedHeightY;
@@ -702,7 +688,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
                 float v13;
                 float v15;
 
-                if (reguestedHeightX >= this.SampledHeightsCountX - 1)
+                if (reguestedHeightX >= SampledHeightsCountX - 1)
                 {
                     v13 = 1.0f;
                     sampledHeight2IndexX = sampledHeight1IndexX--;
@@ -712,7 +698,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
                     v13 = 0.0f;
                     sampledHeight2IndexX = sampledHeight1IndexX + 1;
                 }
-                if (requestedHeightY >= this.SampledHeightsCountY - 1)
+                if (requestedHeightY >= SampledHeightsCountY - 1)
                 {
                     v15 = 1.0f;
                     sampledHeight2IndexY = sampledHeight1IndexY--;
@@ -723,8 +709,8 @@ namespace LeagueSandbox.GameServer.Content.Navigation
                     sampledHeight2IndexY = sampledHeight1IndexY + 1;
                 }
 
-                uint sampledHeightsCount = this.SampledHeightsCountX * this.SampledHeightsCountY;
-                int v1 = (int)this.SampledHeightsCountX * sampledHeight1IndexY;
+                uint sampledHeightsCount = SampledHeightsCountX * SampledHeightsCountY;
+                int v1 = (int)SampledHeightsCountX * sampledHeight1IndexY;
                 int x0y0 = v1 + sampledHeight1IndexX;
 
                 if (v1 + sampledHeight1IndexX < sampledHeightsCount)
@@ -732,7 +718,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
                     int v19 = sampledHeight2IndexX + v1;
                     if (v19 < sampledHeightsCount)
                     {
-                        int v20 = sampledHeight2IndexY * (int)this.SampledHeightsCountX;
+                        int v20 = sampledHeight2IndexY * (int)SampledHeightsCountX;
                         int v21 = v20 + sampledHeight1IndexX;
 
                         if (v21 < sampledHeightsCount)
@@ -740,10 +726,10 @@ namespace LeagueSandbox.GameServer.Content.Navigation
                             int v22 = sampledHeight2IndexX + v20;
                             if (v22 < sampledHeightsCount)
                             {
-                                float height = ((1.0f - v13) * this.SampledHeights[x0y0])
-                                          + (v13 * this.SampledHeights[v19])
-                                          + (((this.SampledHeights[v21] * (1.0f - v13))
-                                          + (this.SampledHeights[v22] * v13)) * v15);
+                                float height = ((1.0f - v13) * SampledHeights[x0y0])
+                                          + (v13 * SampledHeights[v19])
+                                          + (((SampledHeights[v21] * (1.0f - v13))
+                                          + (SampledHeights[v22] * v13)) * v15);
 
                                 return (1.0f - v15) * height;
                             }

--- a/GameServerLib/Content/Navigation/NavigationGrid.cs
+++ b/GameServerLib/Content/Navigation/NavigationGrid.cs
@@ -181,12 +181,10 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         /// <returns>List of points forming a path in order: from -> to</returns>
         public List<Vector2> GetPath(Vector2 from, Vector2 to, float distanceThreshold = 0)
         {
-            Vector2 vectorFrom = TranslateToNavGrid(from);
-            NavigationGridCell cellFrom = GetCell((short)vectorFrom.X, (short)vectorFrom.Y);
+            NavigationGridCell cellFrom = GetCell(from, true);
 
             to = GetClosestTerrainExit(to, distanceThreshold);
-            Vector2 vectorTo = TranslateToNavGrid(to);
-            NavigationGridCell goal = GetCell((short)vectorTo.X, (short)vectorTo.Y);
+            NavigationGridCell goal = GetCell(to, true);
 
             if (cellFrom == null || goal == null || cellFrom == goal)
             {
@@ -377,6 +375,15 @@ namespace LeagueSandbox.GameServer.Content.Navigation
             }
 
             return (int)index;
+        }
+
+        public NavigationGridCell GetCell(Vector2 coords, bool translate = true)
+        {
+            if(translate)
+            {
+                coords = TranslateToNavGrid(coords);
+            }
+            return GetCell((short)coords.X, (short)coords.Y);
         }
 
         /// <summary>
@@ -587,11 +594,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         {
             if (checkRadius == 0)
             {
-                if (translate)
-                {
-                    coords = TranslateToNavGrid(coords);
-                }
-                NavigationGridCell cell = GetCell((short)coords.X, (short)coords.Y);
+                NavigationGridCell cell = GetCell(coords, translate);
                 return IsWalkable(cell);
             }
 
@@ -632,11 +635,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         /// <returns>True/False.</returns>
         public bool IsVisible(Vector2 coords, bool translate = true)
         {
-            if (translate)
-            {
-                coords = TranslateToNavGrid(coords);
-            }
-            NavigationGridCell cell = GetCell((short)coords.X, (short)coords.Y);
+            NavigationGridCell cell = GetCell(coords, translate);
             return IsVisible(cell); //TODO: implement bush logic here
         }
 
@@ -656,11 +655,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         /// <returns>True/False.</returns>
         public bool HasFlag(Vector2 coords, NavigationGridCellFlags flag, bool translate = true)
         {
-            if (translate)
-            {
-                coords = TranslateToNavGrid(coords);
-            }
-            NavigationGridCell cell = GetCell((short)coords.X, (short)coords.Y);
+            NavigationGridCell cell = GetCell(coords, translate);
             return cell != null && cell.HasFlag(flag);
         }
 
@@ -799,7 +794,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
 
                 if (checkVisible)
                 {
-                    var cell = GetCell((short)origin.X, (short)origin.Y);
+                    var cell = GetCell(origin, false);
 
                     if (!IsVisible(cell))
                     {

--- a/GameServerLib/Content/Navigation/NavigationGrid.cs
+++ b/GameServerLib/Content/Navigation/NavigationGrid.cs
@@ -273,7 +273,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
             var returnList = new List<Vector2>(path.Count + 1){ from };
             foreach (NavigationGridCell navGridCell in path)
             {
-                returnList.Add(TranslateFrmNavigationGrid(navGridCell.Locator));
+                returnList.Add(TranslateFromNavGrid(navGridCell.Locator));
             }
 
             return returnList;
@@ -329,12 +329,13 @@ namespace LeagueSandbox.GameServer.Content.Navigation
 
         /// <summary>
         /// Translates the given cell locator position back into normal coordinate space as a Vector2.
+        /// *NOTE*: Returns the coordinates of the center of the cell.
         /// </summary>
         /// <param name="locator">Cell locator.</param>
         /// <returns>Normal coordinate space Vector2.</returns>
-        public Vector2 TranslateFrmNavigationGrid(NavigationGridLocator locator)
+        public Vector2 TranslateFromNavGrid(NavigationGridLocator locator)
         {
-            return TranslateFrmNavigationGrid(new Vector2(locator.X, locator.Y));
+            return TranslateFrmNavigationGrid(new Vector2(locator.X, locator.Y)) + Vector2.One * 0.5f * CellSize;
         }
 
         /// <summary>
@@ -432,7 +433,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         /// <summary>
         /// Gets a list of cells within the specified range of a specified point.
         /// </summary>
-        /// <param name="origin">Vector2 with normal coordinates to start the check. *NOTE*: Must be untranslated (normal coordinates).</param>
+        /// <param name="origin">Vector2 with normal coordinates to start the check.</param>
         /// <param name="radius">Range to check around the origin.</param>
         /// <returns>List of all cells in range. Null if range extends outside of NavigationGrid boundaries.</returns>
         private List<NavigationGridCell> GetAllCellsInRange(Vector2 origin, float radius, bool translate = true)

--- a/GameServerLib/Content/Navigation/NavigationGrid.cs
+++ b/GameServerLib/Content/Navigation/NavigationGrid.cs
@@ -823,31 +823,20 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         /// <returns>Vector2 position which can be pathed on.</returns>
         public Vector2 GetClosestTerrainExit(Vector2 location, float distanceThreshold = 0)
         {
-            if (IsWalkable(location, distanceThreshold))
-            {
-                return location;
-            }
-
-            double trueX = location.X;
-            double trueY = location.Y;
             double angle = Math.PI / 4;
-            // What is the point of rr?
-            double rr = (location.X - trueX) * (location.X - trueX) + (location.Y - trueY) * (location.Y - trueY);
-            double r = Math.Sqrt(rr);
 
             // x = r * cos(angle)
             // y = r * sin(angle)
             // r = distance from center
             // Draws spirals until it finds a walkable spot
-            while (!IsWalkable((float)trueX, (float)trueY, distanceThreshold))
+            for (int r = 1; !IsWalkable(location, distanceThreshold); r++)
             {
-                trueX = location.X + r * Math.Cos(angle);
-                trueY = location.Y + r * Math.Sin(angle);
+                location.X += r * (float)Math.Cos(angle);
+                location.Y += r * (float)Math.Sin(angle);
                 angle += Math.PI / 4;
-                r += 1;
             }
 
-            return new Vector2((float)trueX, (float)trueY);
+            return location;
         }
     }
 }

--- a/GameServerLib/GameObjects/GameObject.cs
+++ b/GameServerLib/GameObjects/GameObject.cs
@@ -164,7 +164,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         /// </summary>
         public virtual float GetHeight()
         {
-            return _game.Map.NavigationGrid.GetHeightAtLocation(Position.X, Position.Y);
+            return _game.Map.NavigationGrid.GetHeightAtLocation(Position);
         }
 
         /// <summary>

--- a/GameServerLib/GameObjects/Spell/Missile/SpellCircleMissile.cs
+++ b/GameServerLib/GameObjects/Spell/Missile/SpellCircleMissile.cs
@@ -112,7 +112,8 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS.Missile
 
             var next = Destination;
 
-            var goingTo = new Vector3(next.X, _game.Map.NavigationGrid.GetHeightAtLocation(next.X, next.Y), next.Y) - new Vector3(cur.X, _game.Map.NavigationGrid.GetHeightAtLocation(cur.X, cur.Y), cur.Y);
+            var goingTo = new Vector3(next.X, _game.Map.NavigationGrid.GetHeightAtLocation(next), next.Y)
+                        - new Vector3(cur.X, _game.Map.NavigationGrid.GetHeightAtLocation(cur), cur.Y);
             var dirTemp = Vector3.Normalize(goingTo);
 
             // usually doesn't happen

--- a/GameServerLib/GameObjects/Spell/Missile/SpellLineMissile.cs
+++ b/GameServerLib/GameObjects/Spell/Missile/SpellLineMissile.cs
@@ -71,7 +71,8 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS.Missile
 
             var next = Destination;
 
-            var goingTo = new Vector3(next.X, _game.Map.NavigationGrid.GetHeightAtLocation(next.X, next.Y), next.Y) - new Vector3(cur.X, _game.Map.NavigationGrid.GetHeightAtLocation(cur.X, cur.Y), cur.Y);
+            var goingTo = new Vector3(next.X, _game.Map.NavigationGrid.GetHeightAtLocation(next), next.Y)
+                        - new Vector3(cur.X, _game.Map.NavigationGrid.GetHeightAtLocation(cur), cur.Y);
             var dirTemp = Vector3.Normalize(goingTo);
 
             // usually doesn't happen

--- a/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
+++ b/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
@@ -127,7 +127,8 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS.Missile
 
             var next = GetTargetPosition();
 
-            var goingTo = new Vector3(next.X, _game.Map.NavigationGrid.GetHeightAtLocation(next.X, next.Y), next.Y) - new Vector3(cur.X, _game.Map.NavigationGrid.GetHeightAtLocation(cur.X, cur.Y), cur.Y);
+            var goingTo = new Vector3(next.X, _game.Map.NavigationGrid.GetHeightAtLocation(next), next.Y)
+                        - new Vector3(cur.X, _game.Map.NavigationGrid.GetHeightAtLocation(cur), cur.Y);
             var dirTemp = Vector3.Normalize(goingTo);
 
             // usually doesn't happen

--- a/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/GameServerLib/GameObjects/Spell/Spell.cs
@@ -311,8 +311,8 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS
 
             CastInfo.MissileNetID = _networkIdManager.GetNewNetId();
 
-            CastInfo.TargetPosition = new Vector3(start.X, _game.Map.NavigationGrid.GetHeightAtLocation(start.X, start.Y), start.Y);
-            CastInfo.TargetPositionEnd = new Vector3(end.X, _game.Map.NavigationGrid.GetHeightAtLocation(end.X, end.Y), end.Y);
+            CastInfo.TargetPosition = new Vector3(start.X, _game.Map.NavigationGrid.GetHeightAtLocation(start), start.Y);
+            CastInfo.TargetPositionEnd = new Vector3(end.X, _game.Map.NavigationGrid.GetHeightAtLocation(end), end.Y);
 
             CastInfo.Targets.Clear();
 
@@ -478,7 +478,7 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS
             if (Script.ScriptMetadata.MissileParameters != null && Script.ScriptMetadata.MissileParameters.Type == MissileType.Circle)
             {
                 var targetPos = ApiFunctionManager.GetPointFromUnit(CastInfo.Owner, GetCurrentCastRange());
-                CastInfo.TargetPosition = new Vector3(targetPos.X, _game.Map.NavigationGrid.GetHeightAtLocation(targetPos.X, targetPos.Y), targetPos.Y);
+                CastInfo.TargetPosition = new Vector3(targetPos.X, _game.Map.NavigationGrid.GetHeightAtLocation(targetPos), targetPos.Y);
                 // TODO: Verify if we should also override TargetPositionEnd (probably not due to things like Viktor E).
             }
 

--- a/GameServerLib/Packets/PacketNotifier.cs
+++ b/GameServerLib/Packets/PacketNotifier.cs
@@ -261,7 +261,7 @@ namespace PacketDefinitions420
                 targetPos = particle.EndPosition;
             }
 
-            var targetHeight = _navGrid.GetHeightAtLocation(particle.StartPosition.X, particle.StartPosition.Y);
+            var targetHeight = _navGrid.GetHeightAtLocation(particle.StartPosition);
             var higherValue = Math.Max(targetHeight, particle.GetHeight());
 
             // TODO: implement option for multiple particles instead of hardcoding one
@@ -792,7 +792,7 @@ namespace PacketDefinitions420
                 ExtraTime = attacker.AutoAttackSpell.CastInfo.ExtraCastTime, // TODO: Verify, maybe related to CastInfo.ExtraCastTime?
                 MissileNextID = futureProjNetId,
                 AttackSlot = attacker.AutoAttackSpell.CastInfo.SpellSlot,
-                TargetPosition = new Vector3(targetPos.X, _navGrid.GetHeightAtLocation(targetPos.X, targetPos.Y), targetPos.Y)
+                TargetPosition = new Vector3(targetPos.X, _navGrid.GetHeightAtLocation(targetPos), targetPos.Y)
             };
 
             // Based on DesignerCastTime. Always negative. Value range from replays: [-0.14, 0].
@@ -1739,7 +1739,7 @@ namespace PacketDefinitions420
             }
 
             var current = unit.GetPosition3D();
-            var to = Vector3.Normalize(new Vector3(targetPos.X, _navGrid.GetHeightAtLocation(targetPos.X, targetPos.Y), targetPos.Y) - current);
+            var to = Vector3.Normalize(new Vector3(targetPos.X, _navGrid.GetHeightAtLocation(targetPos), targetPos.Y) - current);
 
             var hd = new MovementDriverHomingData
             {


### PR DESCRIPTION
- `TranslationMaxGridPosition` is now supposed to be replaced by `CellSize`
- Unnecessary `this.` and `Vector2` copying removed
- `GetCell(Vector2 coords, bool translate = true)` added
- `GetCellIndex` removed. Why get the cell index when you can get the cell?
- `GetClosestValidCellIndex` renamed to `GetClosestValidCell` and rewritten to be simpler
- All functions that took `x` and `y` as arguments and passed them as `Vector2` to the function of the same name were removed
- `GetAllCellsInRange` rewritten to be simpler
- `GetClosestTerrainExit` simplified
- `TranslateFrmNavigationGrid` renamed to `TranslateFromNavGrid` to match `TranslateToNavGrid`
- `TranslateFromNavGrid(NavigationGridLocator locator)` now returns the coordinates of the center of the cell pointed to by the `locator`