### PR TITLE
Ray casting and circle casting fixes

### DIFF
--- a/GameMaths/MathExtension.cs
+++ b/GameMaths/MathExtension.cs
@@ -63,19 +63,17 @@ namespace GameMaths
         {
             return Math.Abs(a) < 1e-6f;
         }
-        public static void Normalize(this Vector2 vector2)
+        public static Vector2 Normalized(this Vector2 vector2)
         {
-            float length = vector2.Length();
-            if (!length.IsZero())
+            if(vector2 != Vector2.Zero)
             {
+                float length = vector2.Length();
                 float inv = 1.0f / length;
+                
+                // Operates on a copy of the vector.
                 vector2.X *= inv;
                 vector2.Y *= inv;
             }
-        }
-        public static Vector2 Normalized(this Vector2 vector2)
-        {
-            vector2.Normalize();
             return vector2;
         }
         public static Vector2 Perpendicular(this Vector2 vector2, int offset = 0)

--- a/GameServerLib/Content/Navigation/NavigationGrid.cs
+++ b/GameServerLib/Content/Navigation/NavigationGrid.cs
@@ -663,7 +663,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
                 destination = TranslateToNavGrid(destination);
             }
 
-            var cells = RayCast(origin, destination).GetEnumerator();
+            var cells = GetAllCellsInLine(origin, destination).GetEnumerator();
 
             bool prevPosHadBush = HasFlag(origin, NavigationGridCellFlags.HAS_GRASS, false);
             bool destinationHasGrass = HasFlag(destination, NavigationGridCellFlags.HAS_GRASS, false);
@@ -709,7 +709,7 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         }
 
         // https://playtechs.blogspot.com/2007/03/raytracing-on-grid.html
-        private IEnumerable<NavigationGridCell> RayCast(Vector2 v0, Vector2 v1)
+        private IEnumerable<NavigationGridCell> GetAllCellsInLine(Vector2 v0, Vector2 v1)
         {
             double dx = Math.Abs(v1.X - v0.X);
             double dy = Math.Abs(v1.Y - v0.Y);
@@ -797,8 +797,8 @@ namespace LeagueSandbox.GameServer.Content.Navigation
 
             var cells = GetAllCellsInRange(orig, radius, false)
             .Concat(GetAllCellsInRange(dest, radius, false))
-            .Concat(RayCast(orig + p, dest + p))
-            .Concat(RayCast(orig - p, dest - p));
+            .Concat(GetAllCellsInLine(orig + p, dest + p))
+            .Concat(GetAllCellsInLine(orig - p, dest - p));
 
             int minY = (int)(Math.Min(orig.Y, dest.Y) - tradius) - 1;
             int maxY = (int)(Math.Max(orig.Y, dest.Y) + tradius) + 1;
@@ -854,18 +854,6 @@ namespace LeagueSandbox.GameServer.Content.Navigation
         }
 
         /// <summary>
-        /// Whether or not there is anything blocking pathing or vision from the starting position to the ending position. (depending on checkVision).
-        /// </summary>
-        /// <param name="startPos">Position to start the check from.</param>
-        /// <param name="endPos">Position to end the check at.</param>
-        /// <param name="checkVision">True = Check if vision is blocked. False = Check if pathing is blocked.</param>
-        /// <returns>True/False.</returns>
-        public bool IsAnythingBetween(Vector2 startPos, Vector2 endPos, bool checkVision = false)
-        {
-            return CastRay(startPos, endPos, !checkVision, checkVision);
-        }
-
-        /// <summary>
         /// Whether or not there is anything blocking the two given GameObjects from either seeing eachother or pathing straight towards eachother (depending on checkVision).
         /// </summary>
         /// <param name="a">GameObject to start the check from.</param>
@@ -880,34 +868,6 @@ namespace LeagueSandbox.GameServer.Content.Navigation
             Vector2 destination = b.Position - d * b.PathfindingRadius;
 
             return CastRay(origin, destination, !checkVision, checkVision);
-        }
-
-        /// <summary>
-        /// Whether or not there is anything blocking pathing from the first given cell to the next.
-        /// </summary>
-        /// <param name="origin">Cell to start the check from.</param>
-        /// <param name="destination">Cell to end the check at.</param>
-        /// <param name="ignoreTerrain">Whether or not to ignore terrain when checking for pathability between cells.</param>
-        /// <returns>True/False.</returns>
-        public bool IsAnythingBetween(NavigationGridCell origin, NavigationGridCell destination, float checkDistance = 0f)
-        {
-            Vector2 v1 = origin.GetCenter();
-            Vector2 v2 = destination.GetCenter();
-
-            Vector2 dist = v2 - v1;
-            float greatestdist = Math.Max(Math.Abs(dist.X), Math.Abs(dist.Y)) * 2;
-
-            Vector2 d = dist / greatestdist;
-            for (int i = 0; i <= (int)greatestdist; i++)
-            {
-                if (!IsWalkable(new Vector2(v1.X, v1.Y), checkDistance, false))
-                {
-                    return true;
-                }
-                v1 += d;
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/GameServerLib/Packets/PacketHandlers/HandleMove.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleMove.cs
@@ -46,30 +46,28 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                         {
                             return false;
                         }
-                        waypoints = nav.GetPath(champion.Position, req.Position, champion.PathfindingRadius);
-                        if(waypoints == null)
-                        {
-                            System.Console.WriteLine($"NO PATH FROM {champion.Position} TO {req.Position} WITH RADIUS {champion.PathfindingRadius}");
-                            waypoints = nav.GetPath(champion.Position, req.Position, champion.PathfindingRadius, true);
-                            return false;
-                        }
-                        /*
                         waypoints = req.Waypoints.ConvertAll(TranslateFromCenteredCoordinates);
                         //TODO: Find the nearest point on the path and discard everything before it
                         waypoints[0] = champion.Position;
                         for(int i = 0; i < waypoints.Count - 1; i++)
                         {
-                            if(IsAnythingBetween(waypoints[i], waypoints[i + 1], champion.PathfindingRadius))
+                            if(nav.CastCircle(waypoints[i], waypoints[i + 1], champion.PathfindingRadius, true))
                             {
                                 var ithWaypoint = waypoints[i];
                                 var lastWaypoint = waypoints[waypoints.Count - 1];
                                 var path = nav.GetPath(ithWaypoint, lastWaypoint, champion.PathfindingRadius);
-                                waypoints = waypoints.GetRange(0, i);
-                                waypoints.AddRange(path);
+                                waypoints.RemoveRange(i, waypoints.Count - i);
+                                if(path != null)
+                                {
+                                    waypoints.AddRange(path);
+                                }
+                                else
+                                {
+                                    waypoints.Add(ithWaypoint);
+                                }
                                 break;
                             }
                         }
-                        */
                         champion.UpdateMoveOrder(req.OrderType, true);
                         champion.SetWaypoints(waypoints);
                         champion.SetTargetUnit(u);
@@ -111,12 +109,6 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
             }
 
             return true;
-        }
-
-        private bool IsAnythingBetween(Vector2 a, Vector2 b, float checkDistance)
-        {
-            var nav = _game.Map.NavigationGrid;
-            return nav.IsAnythingBetween(nav.GetCell(a, true), nav.GetCell(b, true), checkDistance);
         }
 
         private Vector2 TranslateFromCenteredCoordinates(Vector2 vector)

--- a/GameServerLib/Packets/PacketHandlers/HandleMove.cs
+++ b/GameServerLib/Packets/PacketHandlers/HandleMove.cs
@@ -46,6 +46,14 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                         {
                             return false;
                         }
+                        waypoints = nav.GetPath(champion.Position, req.Position, champion.PathfindingRadius);
+                        if(waypoints == null)
+                        {
+                            System.Console.WriteLine($"NO PATH FROM {champion.Position} TO {req.Position} WITH RADIUS {champion.PathfindingRadius}");
+                            waypoints = nav.GetPath(champion.Position, req.Position, champion.PathfindingRadius, true);
+                            return false;
+                        }
+                        /*
                         waypoints = req.Waypoints.ConvertAll(TranslateFromCenteredCoordinates);
                         //TODO: Find the nearest point on the path and discard everything before it
                         waypoints[0] = champion.Position;
@@ -61,6 +69,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
                                 break;
                             }
                         }
+                        */
                         champion.UpdateMoveOrder(req.OrderType, true);
                         champion.SetWaypoints(waypoints);
                         champion.SetTargetUnit(u);


### PR DESCRIPTION
- `GetAllCellsInLine` function was introduced.
- `CastRay` now returns `true` if it hits something and doesn't return the hit position because it's not used anywhere. Thanks to the use of the `GetAllCellsInLine`, it can no longer skip cells, which previously caused units to flicker in the bushes.
---
- `CastCircle` function was introduced
> A *CircleCast* is conceptually like dragging a circle through the Scene in a particular direction. Any object making contact with the circle can be detected and reported
-- Unity Documentation about `Physics2D.CircleCast`

- But instead of an objects, `CastCircle` reports contact with walls.
---
- `GetPath` now uses `CastCircle`.
- `SmoothPath` now uses `CastCircle` and it does not skip some cells, as a result, the unit no longer gets stuck on the corners.
- `GameMaths.MathExtension.Normalize` is merged into `Normalized` (It works now).
- `bool IsAnythingBetween(Vector2 startPos, Vector2 endPos, bool checkVision = false)`
and 
`bool IsAnythingBetween(NavigationGridCell origin, NavigationGridCell destination, float checkDistance = 0f)`
removed. Instead, it is now proposed to use `CastRay` and `CastCircle`.
- `IsAnythingBetween(GameObject a, GameObject b, bool checkVision = false)` remained and now simply ignores unwalkable cells that are inside the `PathfindingRadius` of units, regardless of type.